### PR TITLE
Proof issue #5 - adapt tox to build example for several sphinx versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,16 +11,16 @@ matrix:
   include:
     - python: '2.7'
       env:
-        - TOXENV=py27,sphinx1.1,sphinx1.2,sphinx1.3,sphinx1.4,sphinx1.5,sphinx1.6,sphinx-latest,example
+        - TOXENV=py27,sphinx1.3,sphinx1.4,sphinx1.5,sphinx1.6,sphinx-latest
     - python: '3.4'
       env:
-        - TOXENV=py34,sphinx1.1,sphinx1.2,sphinx1.3,sphinx1.4,sphinx1.5,sphinx1.6,sphinx-latest,example
+        - TOXENV=py34,sphinx1.3,sphinx1.4,sphinx1.5,sphinx1.6,sphinx-latest
     - python: '3.5'
       env:
-        - TOXENV=py35,sphinx1.1,sphinx1.2,sphinx1.3,sphinx1.4,sphinx1.5,sphinx1.6,sphinx-latest,example
+        - TOXENV=py35,sphinx1.3,sphinx1.4,sphinx1.5,sphinx1.6,sphinx-latest
     - python: '3.6'
       env:
-        - TOXENV=py36,sphinx1.1,sphinx1.2,sphinx1.3,sphinx1.4,sphinx1.5,sphinx1.6,sphinx-latest,example
+        - TOXENV=py36,sphinx1.3,sphinx1.4,sphinx1.5,sphinx1.6,sphinx-latest
 
 before_install:
   - python --version

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=check,py27,py32,py34,py35,py36,sphinx1.1,sphinx1.2,sphinx1.3,sphinx1.4,sphinx1.5,sphinx1.6,sphinx-latest, example
+envlist=check,py27,py32,py34,py35,py36,sphinx1.3,sphinx1.4,sphinx1.5,sphinx1.6,sphinx-latest
 
 [testenv]
 deps=
@@ -8,17 +8,12 @@ deps=
 	flake8
     reportlab
     sphinx-testing >= 0.5.2
+    sphinx_selective_exclude
+    sphinx_rtd_theme
 commands=
     nosetests
     #flake8 setup.py sphinxcontrib/ tests/
-
-[testenv:example]
-deps =
-    sphinx_selective_exclude
-    sphinx_rtd_theme
-commands =
     make -C example/ clean html
-
 
 [testenv:check]
 deps =
@@ -52,16 +47,6 @@ deps=
     sphinx-testing >= 0.5.2
     jinja2 < 2.7
     pygments <= 1.9999
-
-[testenv:sphinx1.1]
-deps=
-    {[testenv]deps}
-    sphinx <= 1.1.9999
-
-[testenv:sphinx1.2]
-deps=
-    {[testenv]deps}
-    sphinx <= 1.2.9999
 
 [testenv:sphinx1.3]
 deps=


### PR DESCRIPTION
Removed sphinx<1.3 from tox due to template not available at that time
(2014).

Proving issue #5