### PR TITLE
Duplicate items detection

### DIFF
--- a/mlx/traceability.py
+++ b/mlx/traceability.py
@@ -120,7 +120,6 @@ class ItemDirective(Directive):
         env = self.state.document.settings.env
         app = env.app
         caption = ''
-        messages = []
 
         targetid = self.arguments[0]
         targetnode = nodes.target('', '', ids=[targetid])
@@ -137,11 +136,8 @@ class ItemDirective(Directive):
         if targetid not in env.traceability_all_items:
             env.traceability_all_items[targetid] = {}
         elif env.traceability_all_items[targetid]['placeholder'] is False:
-            if env.traceability_all_items[targetid]['docname'] != env.docname or env.traceability_all_items[targetid]['lineno'] != self.lineno:
-                # Duplicate items not allowed. Duplicate will even not be shown
-                messages = [self.state.document.reporter.error(
-                           'Traceability: duplicated item %s (or rebuilding with a change)' % targetid,
-                            line=self.lineno)]
+            # Duplicate items not allowed. Duplicate will even not be shown
+            report_warning(env, 'Traceability: duplicated item: %s' % targetid, env.docname, self.lineno)
         env.traceability_all_items[targetid]['id'] = targetid
         env.traceability_all_items[targetid]['placeholder'] = False
         env.traceability_all_items[targetid]['type'] = self.name
@@ -186,7 +182,7 @@ class ItemDirective(Directive):
             template.append('    ' + line)
         self.state_machine.insert_input(template, self.state_machine.document.attributes['source'])
 
-        return [targetnode, itemnode] + messages
+        return [targetnode, itemnode]
 
 
 class ItemListDirective(Directive):
@@ -570,6 +566,18 @@ def initialize_environment(app):
 \\makeatother'''
 
 
+def purge_items(app, env, docname):
+    """
+    Purge traceable items
+
+    This handler should be called upon env-purge-doc event: before each source file is read, the
+    extension needs to flush part of its database.
+    """
+    if hasattr(env, 'traceability_all_items'):
+        for itemid in env.traceability_all_items.keys():
+            if env.traceability_all_items[itemid]['docname'] == docname:
+                del env.traceability_all_items[itemid]
+
 
 # -----------------------------------------------------------------------------
 # Utility functions
@@ -787,6 +795,7 @@ def setup(app):
 
     app.connect('doctree-resolved', process_item_nodes)
     app.connect('builder-inited', initialize_environment)
+    app.connect('env-purge-doc', purge_items)
 
     app.add_role('item', XRefRole(nodeclass=PendingItemXref,
                                   innernodeclass=nodes.emphasis,

--- a/mlx/traceability.py
+++ b/mlx/traceability.py
@@ -167,6 +167,7 @@ class ItemDirective(Directive):
                         env.traceability_all_items[related_id] = {
                             'id': related_id,
                             'placeholder': True,
+                            'docname': None,
                         }
                         initialize_relationships(env, related_id)
                     # Also add the reverse relationship to the related item

--- a/mlx/traceability.py
+++ b/mlx/traceability.py
@@ -136,6 +136,12 @@ class ItemDirective(Directive):
         # Store item info
         if targetid not in env.traceability_all_items:
             env.traceability_all_items[targetid] = {}
+        elif env.traceability_all_items[targetid]['placeholder'] is False:
+            if env.traceability_all_items[targetid]['docname'] != env.docname or env.traceability_all_items[targetid]['lineno'] != self.lineno:
+                # Duplicate items not allowed. Duplicate will even not be shown
+                messages = [self.state.document.reporter.error(
+                           'Traceability: duplicated item %s (or rebuilding with a change)' % targetid,
+                            line=self.lineno)]
         env.traceability_all_items[targetid]['id'] = targetid
         env.traceability_all_items[targetid]['placeholder'] = False
         env.traceability_all_items[targetid]['type'] = self.name

--- a/mlx/traceability.py
+++ b/mlx/traceability.py
@@ -167,7 +167,6 @@ class ItemDirective(Directive):
                         env.traceability_all_items[related_id] = {
                             'id': related_id,
                             'placeholder': True,
-                            'docname': None,
                         }
                         initialize_relationships(env, related_id)
                     # Also add the reverse relationship to the related item
@@ -576,8 +575,9 @@ def purge_items(app, env, docname):
     """
     if hasattr(env, 'traceability_all_items'):
         for itemid in env.traceability_all_items.keys():
-            if env.traceability_all_items[itemid]['docname'] == docname:
-                del env.traceability_all_items[itemid]
+            if 'docname' in env.traceability_all_items[itemid]:
+                if env.traceability_all_items[itemid]['docname'] == docname:
+                    del env.traceability_all_items[itemid]
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Use 'env-purge-doc' event to flush all items from a certain rst-file upon rebuilding. This means no items from previous build are in our database when parsing items. So if we encounter one with the same name, and it is not a placeholder (used for automatic reverse linking), it is a duplicate one...