### PR TITLE
Consistency check

### DIFF
--- a/mlx/traceability.py
+++ b/mlx/traceability.py
@@ -16,7 +16,7 @@ from sphinx.environment import NoUri
 from docutils import nodes
 from docutils.parsers.rst import directives
 from docutils.utils import get_source_line
-from mlx.traceable_item import TraceableCollection, TraceableItem, TraceabilityException
+from mlx.traceable_item import TraceableCollection, TraceableItem, TraceabilityException, MultipleTraceabilityExceptions
 from sphinx import __version__ as sphinx_version
 if sphinx_version >= '1.6.0':
     from sphinx.util.logging import getLogger
@@ -347,6 +347,10 @@ def perform_consistency_check(app, doctree):
         env.traceability_collection.self_test()
     except TraceabilityException as err:
         report_warning(env, err, err.get_document())
+    except MultipleTraceabilityExceptions as errs:
+        for err in errs.iter():
+            report_warning(env, err, err.get_document())
+
 
 def process_item_nodes(app, doctree, fromdocname):
     """
@@ -363,6 +367,9 @@ def process_item_nodes(app, doctree, fromdocname):
             env.traceability_collection.self_test(fromdocname)
         except TraceabilityException as err:
             report_warning(env, err, fromdocname)
+        except MultipleTraceabilityExceptions as errs:
+            for err in errs.iter():
+                report_warning(env, err, err.get_document())
 
     all_item_ids = env.traceability_collection.iter_items()
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 project_url = 'https://github.com/melexis/sphinx-traceability-extension'
-version = '2.0.0'
+version = '2.1.0'
 
 requires = ['Sphinx>=0.6', 'docutils']
 

--- a/tests/test_traceable_collection.py
+++ b/tests/test_traceable_collection.py
@@ -172,7 +172,7 @@ class TestTraceableCollection(TestCase):
         relations = item2.iter_targets(self.fwd_relation, explicit=True, implicit=False)
         self.assertEqual(0, len(relations))
         # Self test should fail, as we have a placeholder item
-        with self.assertRaises(dut.TraceabilityException):
+        with self.assertRaises(dut.MultipleTraceabilityExceptions):
             coll.self_test()
 
     def test_add_relation_happy(self):
@@ -261,7 +261,7 @@ class TestTraceableCollection(TestCase):
         # Add item to collection
         coll.add_item(item1)
         # Self test should fail as target item is not in collection
-        with self.assertRaises(dut.TraceabilityException):
+        with self.assertRaises(dut.MultipleTraceabilityExceptions):
             coll.self_test()
         # Self test one limited scope (no matching document), should pass
         coll.self_test('document-does-not-exist.rst')
@@ -269,7 +269,7 @@ class TestTraceableCollection(TestCase):
         item2 = dut.TraceableItem(self.identification_tgt)
         item2.set_document(self.docname)
         coll.add_item(item2)
-        with self.assertRaises(dut.TraceabilityException):
+        with self.assertRaises(dut.MultipleTraceabilityExceptions):
             coll.self_test()
         # Mimicing the automatic reverse relation, self test should pass
         item2.add_target(self.rev_relation, self.identification_src)

--- a/tests/test_traceable_item.py
+++ b/tests/test_traceable_item.py
@@ -25,8 +25,9 @@ class TestTraceableItem(TestCase):
     def test_init_placeholder(self):
         item = dut.TraceableItem(self.identification, placeholder=True)
         item.set_document(self.docname)
-        with self.assertRaises(dut.TraceabilityException):
+        with self.assertRaises(dut.TraceabilityException) as err:
             item.self_test()
+        self.assertEqual(err.exception.get_document(), self.docname)
         self.assertEqual(self.identification, item.get_id())
         self.assertTrue(item.is_placeholder())
 

--- a/tox.ini
+++ b/tox.ini
@@ -56,9 +56,10 @@ whitelist_externals =
     tee
     mlx-warnings
 commands=
-    bash -c \'make -C example clean html 2>&1 | tee .tox/doc.log \'
-    mlx-warnings --version
-    mlx-warnings --sphinx --maxwarnings 8 --minwarnings 8 .tox/doc.log
+    bash -c \'make -C example html 2>&1 | tee .tox/doc_html.log \'
+    mlx-warnings --sphinx --maxwarnings 8 --minwarnings 6 .tox/doc_html.log
+    bash -c \'make -C example latexpdf 2>&1 | tee .tox/doc_pdf.log \'
+    mlx-warnings --sphinx --maxwarnings 8 --minwarnings 6 .tox/doc_pdf.log
 
 [testenv:sphinx1.4]
 deps=
@@ -70,9 +71,10 @@ whitelist_externals =
     tee
     mlx-warnings
 commands=
-    bash -c \'make -C example clean html 2>&1 | tee .tox/doc.log \'
-    mlx-warnings --version
-    mlx-warnings --sphinx --maxwarnings 8 --minwarnings 8 .tox/doc.log
+    bash -c \'make -C example html 2>&1 | tee .tox/doc_html.log \'
+    mlx-warnings --sphinx --maxwarnings 8 --minwarnings 6 .tox/doc_html.log
+    bash -c \'make -C example latexpdf 2>&1 | tee .tox/doc_pdf.log \'
+    mlx-warnings --sphinx --maxwarnings 8 --minwarnings 6 .tox/doc_pdf.log
 
 [testenv:sphinx1.5]
 deps=
@@ -84,9 +86,10 @@ whitelist_externals =
     tee
     mlx-warnings
 commands=
-    bash -c \'make -C example clean html 2>&1 | tee .tox/doc.log \'
-    mlx-warnings --version
-    mlx-warnings --sphinx --maxwarnings 8 --minwarnings 8 .tox/doc.log
+    bash -c \'make -C example html 2>&1 | tee .tox/doc_html.log \'
+    mlx-warnings --sphinx --maxwarnings 8 --minwarnings 6 .tox/doc_html.log
+    bash -c \'make -C example latexpdf 2>&1 | tee .tox/doc_pdf.log \'
+    mlx-warnings --sphinx --maxwarnings 8 --minwarnings 6 .tox/doc_pdf.log
 
 [testenv:sphinx1.6]
 deps=
@@ -98,9 +101,10 @@ whitelist_externals =
     tee
     mlx-warnings
 commands=
-    bash -c \'make -C example clean html 2>&1 | tee .tox/doc.log \'
-    mlx-warnings --version
-    mlx-warnings --sphinx --maxwarnings 8 --minwarnings 8 .tox/doc.log
+    bash -c \'make -C example html 2>&1 | tee .tox/doc_html.log \'
+    mlx-warnings --sphinx --maxwarnings 6 --minwarnings 5 .tox/doc_html.log
+    bash -c \'make -C example latexpdf 2>&1 | tee .tox/doc_pdf.log \'
+    mlx-warnings --sphinx --maxwarnings 6 --minwarnings 5 .tox/doc_pdf.log
 
 [testenv:sphinx-latest]
 deps=
@@ -112,9 +116,10 @@ whitelist_externals =
     tee
     mlx-warnings
 commands=
-    bash -c \'make -C example clean html 2>&1 | tee .tox/doc.log \'
-    mlx-warnings --version
-    mlx-warnings --sphinx --maxwarnings 8 --minwarnings 8 .tox/doc.log
+    bash -c \'make -C example html 2>&1 | tee .tox/doc_html.log \'
+    mlx-warnings --sphinx --maxwarnings 6 --minwarnings 5 .tox/doc_html.log
+    bash -c \'make -C example latexpdf 2>&1 | tee .tox/doc_pdf.log \'
+    mlx-warnings --sphinx --maxwarnings 6 --minwarnings 5 .tox/doc_pdf.log
 
 [testenv:coveralls]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -57,9 +57,9 @@ whitelist_externals =
     mlx-warnings
 commands=
     bash -c \'make -C example html 2>&1 | tee .tox/doc_html.log \'
-    mlx-warnings --sphinx --maxwarnings 8 --minwarnings 6 .tox/doc_html.log
+    mlx-warnings --sphinx --maxwarnings 5 --minwarnings 5 .tox/doc_html.log
     bash -c \'make -C example latexpdf 2>&1 | tee .tox/doc_pdf.log \'
-    mlx-warnings --sphinx --maxwarnings 8 --minwarnings 6 .tox/doc_pdf.log
+    mlx-warnings --sphinx --maxwarnings 5 --minwarnings 5 .tox/doc_pdf.log
 
 [testenv:sphinx1.4]
 deps=
@@ -72,9 +72,9 @@ whitelist_externals =
     mlx-warnings
 commands=
     bash -c \'make -C example html 2>&1 | tee .tox/doc_html.log \'
-    mlx-warnings --sphinx --maxwarnings 8 --minwarnings 6 .tox/doc_html.log
+    mlx-warnings --sphinx --maxwarnings 5 --minwarnings 5 .tox/doc_html.log
     bash -c \'make -C example latexpdf 2>&1 | tee .tox/doc_pdf.log \'
-    mlx-warnings --sphinx --maxwarnings 8 --minwarnings 6 .tox/doc_pdf.log
+    mlx-warnings --sphinx --maxwarnings 5 --minwarnings 5 .tox/doc_pdf.log
 
 [testenv:sphinx1.5]
 deps=
@@ -87,9 +87,9 @@ whitelist_externals =
     mlx-warnings
 commands=
     bash -c \'make -C example html 2>&1 | tee .tox/doc_html.log \'
-    mlx-warnings --sphinx --maxwarnings 8 --minwarnings 6 .tox/doc_html.log
+    mlx-warnings --sphinx --maxwarnings 5 --minwarnings 5 .tox/doc_html.log
     bash -c \'make -C example latexpdf 2>&1 | tee .tox/doc_pdf.log \'
-    mlx-warnings --sphinx --maxwarnings 8 --minwarnings 6 .tox/doc_pdf.log
+    mlx-warnings --sphinx --maxwarnings 5 --minwarnings 5 .tox/doc_pdf.log
 
 [testenv:sphinx1.6]
 deps=
@@ -102,9 +102,9 @@ whitelist_externals =
     mlx-warnings
 commands=
     bash -c \'make -C example html 2>&1 | tee .tox/doc_html.log \'
-    mlx-warnings --sphinx --maxwarnings 6 --minwarnings 5 .tox/doc_html.log
+    mlx-warnings --sphinx --maxwarnings 5 --minwarnings 5 .tox/doc_html.log
     bash -c \'make -C example latexpdf 2>&1 | tee .tox/doc_pdf.log \'
-    mlx-warnings --sphinx --maxwarnings 6 --minwarnings 5 .tox/doc_pdf.log
+    mlx-warnings --sphinx --maxwarnings 5 --minwarnings 5 .tox/doc_pdf.log
 
 [testenv:sphinx-latest]
 deps=
@@ -117,9 +117,9 @@ whitelist_externals =
     mlx-warnings
 commands=
     bash -c \'make -C example html 2>&1 | tee .tox/doc_html.log \'
-    mlx-warnings --sphinx --maxwarnings 6 --minwarnings 5 .tox/doc_html.log
+    mlx-warnings --sphinx --maxwarnings 5 --minwarnings 5 .tox/doc_html.log
     bash -c \'make -C example latexpdf 2>&1 | tee .tox/doc_pdf.log \'
-    mlx-warnings --sphinx --maxwarnings 6 --minwarnings 5 .tox/doc_pdf.log
+    mlx-warnings --sphinx --maxwarnings 5 --minwarnings 5 .tox/doc_pdf.log
 
 [testenv:coveralls]
 deps =


### PR DESCRIPTION
sphinx >= 1.6 allows for a callback for consistency check after parsing all input files. Use this callback to perform a self-test on the collection of items.