### PR TITLE
item-matrix: use title, add title for columns

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -371,10 +371,13 @@ A traceability matrix of documentation items can be generated using:
     .. item-matrix:: Requirements to test case description traceability
         :source: SWRQT
         :target: [IU]TEST
+        :sourcetitle: Software requirements
+        :targettitle: Integration and unit test cases
         :type: validated_by
 
 where the *source* and *target* arguments can be replaced by any python regular expression. The *type* argument
-is a space-separated list of relationships that should be matched in the matrix.
+is a space-separated list of relationships that should be matched in the matrix. The *sourcetitle* and *targettitle*
+arguments are the titles of the columns in the generated matrix.
 
 Documentation items matching their ID to the given *source* regular expression end up in the left column of the
 generated table. Documentation items matching their ID to the given *target* regular expression with a matching

--- a/example/SSS.rst
+++ b/example/SSS.rst
@@ -22,5 +22,8 @@ Saying goodbye
 
    The systems will say goodbye
 
+.. item:: SYS_0003 Say nothing
+
+   The systems will say nothing
 
 Reference to item :item:`r001`

--- a/example/index.rst
+++ b/example/index.rst
@@ -85,21 +85,25 @@ Item list
 =========
 
 List all items:
+---------------
 
 .. item-list::
 
 
 List all items beginning with ``r00``
+-------------------------------------
 
 .. item-list::
    :filter: r00
 
 List system requirements (beginning with SYS)
+---------------------------------------------
 
 .. item-list::
    :filter: ^SYS
 
 List all well-formed SYS and SRS requirements
+---------------------------------------------
 
 .. item-list::
    :filter: ^S[YR]S_\d
@@ -108,34 +112,45 @@ Item matrix
 ===========
 
 All relationships
+-----------------
 
 .. item-matrix:: All
 
 Traceability from SRS to SSS
+----------------------------
 
-.. item-matrix:: SRS to SSS
+.. item-matrix:: Software requirements fulfilling system requirements
    :target: SYS
    :source: SRS
+   :targettitle: system requirement
+   :sourcetitle: software requirement
    :type:   fulfills
 
 Traceability from SSS to SRS
+----------------------------
 
-.. item-matrix:: SSS to SRS
+.. item-matrix:: System requirements fulfilled by software requirements
    :target: SRS
    :source: SYS
+   :targettitle: software requirement
+   :sourcetitle: system requirement
    :type:   fulfilled_by
 
 Another matrix that should spawn a warning as the relation in *type* does not exist
+-----------------------------------------------------------------------------------
 
-.. item-matrix:: SSS to SRS
+.. item-matrix:: System requirements traced to software requirements, using a non-existing relationship (=warning)
    :target: SRS
    :source: SYS
    :type:   non_existing_relation
+   :targettitle: system requirement
+   :sourcetitle: software requirement
 
 Item tree
 =========
 
 Succesfull SYS tree
+-------------------
 
 .. item-tree:: SYS
     :top: SYS
@@ -143,6 +158,7 @@ Succesfull SYS tree
     :type: fulfilled_by
 
 Another tree that should spawn a warning as the relation in *top_relation_filter* does not exist.
+-------------------------------------------------------------------------------------------------
 
 .. item-tree:: warning for unknown relation
     :top: SYS
@@ -150,6 +166,7 @@ Another tree that should spawn a warning as the relation in *top_relation_filter
     :type: fulfilled_by
 
 Another tree that should spawn a warning as the relation in *type* does not exist
+---------------------------------------------------------------------------------
 
 .. item-tree:: warning for unknown relation
     :top: SYS

--- a/mlx/traceability.py
+++ b/mlx/traceability.py
@@ -212,6 +212,8 @@ class ItemMatrixDirective(Directive):
       .. item-matrix:: title
          :target: regexp
          :source: regexp
+         :targettitle: Target column header
+         :sourcetitle: Source column header
          :type: <<relationship>> ...
 
     """
@@ -222,6 +224,8 @@ class ItemMatrixDirective(Directive):
     option_spec = {'class': directives.class_option,
                    'target': directives.unchanged,
                    'source': directives.unchanged,
+                   'targettitle': directives.unchanged,
+                   'sourcetitle': directives.unchanged,
                    'type': directives.unchanged}
     # Content disallowed
     has_content = False
@@ -254,6 +258,18 @@ class ItemMatrixDirective(Directive):
             if rel not in env.traceability_collection.iter_relations():
                 report_warning(env, 'Traceability: unknown relation for item-matrix: %s' % rel,
                                env.docname, self.lineno)
+
+        # Check source title
+        if 'sourcetitle' in self.options:
+            item_matrix_node['sourcetitle'] = self.options['sourcetitle']
+        else:
+            item_matrix_node['sourcetitle'] = 'Source'
+
+        # Check target title
+        if 'targettitle' in self.options:
+            item_matrix_node['targettitle'] = self.options['targettitle']
+        else:
+            item_matrix_node['targettitle'] = 'Target'
 
         return [item_matrix_node]
 
@@ -377,6 +393,9 @@ def process_item_nodes(app, doctree, fromdocname):
     # Create table with related items, printing their target references.
     # Only source and target items matching respective regexp shall be included
     for node in doctree.traverse(ItemMatrix):
+        p_node = nodes.paragraph()
+        title_node = nodes.Text(node['title'])
+        p_node += title_node
         table = nodes.table()
         tgroup = nodes.tgroup()
         left_colspec = nodes.colspec(colwidth=5)
@@ -384,8 +403,8 @@ def process_item_nodes(app, doctree, fromdocname):
         tgroup += [left_colspec, right_colspec]
         tgroup += nodes.thead('', nodes.row(
             '',
-            nodes.entry('', nodes.paragraph('', 'Source')),
-            nodes.entry('', nodes.paragraph('', 'Target'))))
+            nodes.entry('', nodes.paragraph('', node['sourcetitle'])),
+            nodes.entry('', nodes.paragraph('', node['targettitle']))))
         tbody = nodes.tbody()
         tgroup += tbody
         table += tgroup
@@ -417,7 +436,8 @@ def process_item_nodes(app, doctree, fromdocname):
                 row += right
                 tbody += row
 
-        node.replace_self(table)
+        p_node += table
+        node.replace_self(p_node)
 
     # Item list:
     # Create list with target references. Only items matching list regexp
@@ -702,7 +722,7 @@ def are_related(env, source, target, relationships):
     If the list of relationship types is empty, all available
     relationship types are to be considered.
 
-    There is not need to check the reverse relationship, as these are
+    There is no need to check the reverse relationship, as these are
     added to the dict during the parsing of the documents.
     """
     if not relationships:


### PR DESCRIPTION
Using the title of an item-matrix (was not used before).

Adding title for columns of an item-matrix.

And small updates in the example.