### PR TITLE
Initial implementation for item attributes (item and item-list)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -300,6 +300,10 @@ The plugin itself holds a default config that can be used for any traceability d
 .. code-block:: python
 
     traceability_callback_per_item = None
+    traceability_attributes = {
+        'value',
+        'status'
+    }
     traceability_relationships = {
         'fulfills': 'fulfilled_by',
         'depends_on': 'impacts_on',
@@ -343,9 +347,11 @@ per documentation object:
 
     sys.path.insert(0, os.path.abspath('<path_to_process_submodule>/config'))
 
+    from traceability_config import swcc_traceability_attributes
     from traceability_config import swcc_traceability_relationships
     from traceability_config import swcc_traceability_relationship_to_string
 
+    traceability_attributes = swcc_traceability_attributes
     traceability_relationships = swcc_traceability_relationships
     traceability_relationship_to_string = swcc_traceability_relationship_to_string
     traceability_render_relationship_per_item = False
@@ -388,12 +394,15 @@ Documentation items can be defined using the *item* directive, specifying:
 
 - the name (id) of the documenation item
 - caption or short description of the documentation item
+- attributes for the documentation item
 - internal/external relationships to other documentation items (details in next paragraph)
 - content of documentation item including any rst content including text, images, formulas, code-blocks, etc.
 
 .. code-block:: rest
 
     .. item:: SWRQT-MY_FIRST_REQUIREMENT Caption of my first requirement
+        :value: 400
+        :status: Approved
         :validated_by: ITEST-MY_FIRST_INTEGRATION_TEST
         :ext_polarion_reference: project_x:workitem_y
         :nocaptions:

--- a/README.rst
+++ b/README.rst
@@ -301,6 +301,7 @@ The plugin itself holds a default config that can be used for any traceability d
 
     traceability_callback_per_item = None
     traceability_attributes = {
+        'level',
         'value',
         'status'
     }
@@ -409,6 +410,9 @@ Documentation items can be defined using the *item* directive, specifying:
 
         According to the Polarion reference, the software **shall** implement my first requirement.
 
+Attributes can be added to the item, using the `configured attribute keys <traceability_default_config>`_
+(e.g. *value* in the above example). The content of the attribute is a free string.
+
 The relations to other documentation items can be specified as:
 
 - a space seperated list of item ID's, or
@@ -446,10 +450,14 @@ A flat list of documentation items can be generated using a python regular expre
 
     .. item-list:: All software requirements
         :filter: SWRQT
+        :status: Appr
         :nocaptions:
 
-where *SWRQT* (*filter* argument) can be replace by any python regular expression. Documentation items matching
+where *SWRQT* (*filter* argument) can be replaced by any python regular expression. Documentation items matching
 their ID to the given regular expression end up in the list.
+
+where *status* can be replaced by any configured attribute, and *Appr* can be replaced by any python regular
+expression. Documentation items where the *status* attribute matches the given regular expression end up in the list.
 
 By default the caption for every item in the list is shown. By providing the *nocaptions* flag, the
 caption can be omitted. This gives a smaller list, but also less details.

--- a/example/index.rst
+++ b/example/index.rst
@@ -16,6 +16,8 @@ Contents:
 
 .. item:: r001 First requirement
     :class: functional requirement
+    :status: Draft
+    :value: ASIL-C ASPICE-3
 
     This is one item
 
@@ -31,6 +33,7 @@ Contents:
 
 .. item:: r002
     :class: critical
+    :status: Reviewed
 
     We have to extend this section
 
@@ -40,6 +43,7 @@ This text is not part of any item
     :class: secondary
     :trace: r002
     :ext_toolname: namespace:group:document
+    :status: Approved
 
     Clean up all this.
 

--- a/example/index.rst
+++ b/example/index.rst
@@ -17,7 +17,7 @@ Contents:
 .. item:: r001 First requirement
     :class: functional requirement
     :status: Draft
-    :value: ASIL-C ASPICE-3
+    :level: ASIL-C ASPICE-3
 
     This is one item
 
@@ -43,11 +43,13 @@ This text is not part of any item
     :class: secondary
     :trace: r002
     :ext_toolname: namespace:group:document
+    :level: ASIL-A
     :status: Approved
 
     Clean up all this.
 
 .. item:: r005 Another (does not show captions on the related items)
+    :level: ASIL-C ASPICE-3
     :class: terciary
     :trace: r002 r002 r003
     :nocaptions:
@@ -64,13 +66,16 @@ This text is not part of any item
     To demonstrate that bug #2 is solved
 
 .. item:: r007 Depends on all with stereotypes
+    :level: ASIL-X
     :class: terciary
     :trace: r001
     :validates: r002
     :fulfills:  r003
         r005
 
-    To demonstrate stereotype usage in relationships
+    To demonstrate stereotype usage in relationships.
+
+    To demonstrate invalid attribute, ASIL-X is not valid attribute (should not appear in e.g. item-list).
 
 
 .. requirement:: r100 A requirement using the ``requirement`` type
@@ -79,14 +84,15 @@ This text is not part of any item
     rst semantics
 
 .. item:: r008 Requirement with invalid reference to other one
+    :level: ASIL-D
     :trace: non_existing_requirement
 
     Ai caramba, this should report a broken link to an non existing requirement.
 
-.. item:: r009 Requirement with invalid relation kind to other one
-    :non_existing_relation: r007
+.. item:: r009 Requirement with invalid relation kind or attribute
+    :non_existing_relation_or_attribute: r007
 
-    Ai caramba, this should report a warning as the relation kind does not exist.
+    Ai caramba, this should report a warning as the relation kind or attribute does not exist.
 
 Item list
 =========
@@ -121,6 +127,19 @@ List all well-formed SYS and SRS requirements
 
 .. item-list:: System and software requirements
     :filter: ^S[YR]S_\d
+
+List all items with ASIL attribute
+----------------------------------
+
+.. item-list:: All ASIL items
+    :level: ASIL-[ABCD]
+
+List all items with ASIL and Draft/Approved attribute
+-----------------------------------------------------
+
+.. item-list:: All Draft ASIL items
+    :status: (Draft|Approved)
+    :level: ASIL-[ABCD]
 
 Item matrix
 ===========

--- a/mlx/traceability.py
+++ b/mlx/traceability.py
@@ -717,14 +717,22 @@ def process_item_nodes(app, doctree, fromdocname):
             header += ' : ' + currentitem.caption
         top_node = create_top_node(header)
         if app.config.traceability_render_relationship_per_item:
-            for attr in currentitem.iter_attributes():
-                print('{attr}: {value}'.format(attr=attr, value=currentitem.get_attribute(attr)))
-                p_node = nodes.paragraph()
-                txt = nodes.Text('{attr}: {value}'.format(attr=attr, value=currentitem.get_attribute(attr)))
-                p_node.append(txt)
-                top_node.append(p_node)
             par_node = nodes.paragraph()
             dl_node = nodes.definition_list()
+            if currentitem.iter_attributes():
+                li_node = nodes.definition_list_item()
+                dt_node = nodes.term()
+                txt = nodes.Text('Attributes')
+                dt_node.append(txt)
+                li_node.append(dt_node)
+                for attr in currentitem.iter_attributes():
+                    dd_node = nodes.definition()
+                    p_node = nodes.paragraph()
+                    txt = nodes.Text('{attr}: {value}'.format(attr=attr, value=currentitem.get_attribute(attr)))
+                    p_node.append(txt)
+                    dd_node.append(p_node)
+                    li_node.append(dd_node)
+                dl_node.append(li_node)
             for rel in env.traceability_collection.iter_relations():
                 tgts = currentitem.iter_targets(rel)
                 if tgts:

--- a/mlx/traceable_collection.py
+++ b/mlx/traceable_collection.py
@@ -240,7 +240,7 @@ class TraceableCollection(object):
             relations = self.iter_relations()
         return self.items[sourceid].is_related(relations, targetid)
 
-    def get_items(self, regex):
+    def get_items(self, regex, attributes={}):
         '''
         Get all items that match a given regular expression
 
@@ -248,6 +248,7 @@ class TraceableCollection(object):
 
         Args:
             - regex (str): Regex to match the items in this collection against
+            - attributes (dict): Dictionary with attribute-regex pairs to match the items in this collection against
         Returns:
             A sorted list of item-id's matching the given regex
         '''
@@ -255,7 +256,7 @@ class TraceableCollection(object):
         for itemid in self.items:
             if self.items[itemid].is_placeholder():
                 continue
-            if self.items[itemid].is_match(regex):
+            if self.items[itemid].is_match(regex) and self.items[itemid].attributes_match(attributes):
                 matches.append(itemid)
         matches.sort()
         return matches

--- a/mlx/traceable_item.py
+++ b/mlx/traceable_item.py
@@ -287,6 +287,8 @@ class TraceableItem(object):
             value (str): Value of the attribute
             overwrite(boolean): Overwrite existing attribute value, if any
         '''
+        if not attr or not value:
+            raise TraceabilityException('item {item} has invalid attribute ({attr}={value})'.format(item=self.get_id(), attr=attr, value=value), self.get_document())
         if overwrite or attr not in self.attributes:
             self.attributes[attr] = value
 
@@ -297,6 +299,8 @@ class TraceableItem(object):
         Args:
             attr (str): Name of the attribute
         '''
+        if not attr:
+            raise TraceabilityException('item {item} cannot remove invalid attribute ({attr})'.format(item=self.get_id(), attr=attr), self.get_document())
         del self.attributes[attr]
 
     def get_attribute(self, attr):

--- a/mlx/traceable_item.py
+++ b/mlx/traceable_item.py
@@ -327,7 +327,8 @@ class TraceableItem(object):
         retval = self.STRING_TEMPLATE.format(identification=self.get_id())
         retval += '\tPlaceholder: {placeholder}\n'.format(placeholder=self.is_placeholder())
         for attribute in self.attributes:
-            retval += '\tAttribute {attribute} = {value}\n'.format(attribute=attribute, value=self.attributes[attribute])
+            retval += '\tAttribute {attribute} = {value}\n'.format(attribute=attribute,
+                                                                   value=self.attributes[attribute])
         for relation in self.explicit_relations:
             retval += '\tExplicit {relation}\n'.format(relation=relation)
             for tgtid in self.explicit_relations[relation]:

--- a/mlx/traceable_item.py
+++ b/mlx/traceable_item.py
@@ -49,7 +49,8 @@ class TraceableItem(object):
                 self.implicit_relations[relation] = []
             self.implicit_relations[relation].extend(other.implicit_relations[relation])
         # Remainder of fields: update if they improve quality of the item
-        # TODO: do something for attributes
+        for attr in other.attributes.keys():
+            self.add_attribute(attr, other.attributes[attr], False)
         if not other.placeholder:
             self.placeholder = False
         if other.docname is not None:
@@ -277,16 +278,17 @@ class TraceableItem(object):
         '''
         return sorted(list(self.explicit_relations) + list(self.implicit_relations.keys()))
 
-    def add_attribute(self, attr, value):
+    def add_attribute(self, attr, value, overwrite=True):
         '''
         Add an attribute key-value pair to the traceable item
 
         Args:
             attr (str): Name of the attribute
             value (str): Value of the attribute
+            overwrite(boolean): Overwrite existing attribute value, if any
         '''
-        # TODO: just overwrites for now, are we sure about that?
-        self.attributes[attr] = value
+        if overwrite or attr not in self.attributes:
+            self.attributes[attr] = value
 
     def remove_attribute(self, attr):
         '''

--- a/mlx/traceable_item.py
+++ b/mlx/traceable_item.py
@@ -306,9 +306,9 @@ class TraceableItem(object):
         Args:
             attr (str): Name of the attribute
         Returns:
-            Value matching the given attribute key, or None if attribute does not exist
+            Value matching the given attribute key, or '' if attribute does not exist
         '''
-        value = None
+        value = ''
         if attr in self.attributes:
             value = self.attributes[attr]
         return value
@@ -351,6 +351,20 @@ class TraceableItem(object):
             (boolean) True if the given regex matches the item identification
         '''
         return re.match(regex, self.get_id())
+
+    def attributes_match(self, attributes):
+        '''
+        Check if item matches a given set of attributes
+
+        Args:
+            - attributes (dict): Dictionary with attribute-regex pairs to match the given item against
+        Returns:
+            (boolean) True if the given attributes match the item attributes
+        '''
+        for attr in attributes.keys():
+            if not re.match(attributes[attr], self.get_attribute(attr)):
+                return False
+        return True
 
     def is_related(self, relations, targetid):
         '''

--- a/mlx/traceable_item.py
+++ b/mlx/traceable_item.py
@@ -288,7 +288,10 @@ class TraceableItem(object):
             overwrite(boolean): Overwrite existing attribute value, if any
         '''
         if not attr or not value:
-            raise TraceabilityException('item {item} has invalid attribute ({attr}={value})'.format(item=self.get_id(), attr=attr, value=value), self.get_document())
+            raise TraceabilityException('item {item} has invalid attribute ({attr}={value})'.format(item=self.get_id(),
+                                                                                                    attr=attr,
+                                                                                                    value=value),
+                                        self.get_document())
         if overwrite or attr not in self.attributes:
             self.attributes[attr] = value
 
@@ -300,7 +303,9 @@ class TraceableItem(object):
             attr (str): Name of the attribute
         '''
         if not attr:
-            raise TraceabilityException('item {item} cannot remove invalid attribute ({attr})'.format(item=self.get_id(), attr=attr), self.get_document())
+            raise TraceabilityException('item {item} cannot remove invalid attribute {attr}'.format(item=self.get_id(),
+                                                                                                    attr=attr),
+                                        self.get_document())
         del self.attributes[attr]
 
     def get_attribute(self, attr):

--- a/tests/test_traceable_collection.py
+++ b/tests/test_traceable_collection.py
@@ -16,6 +16,9 @@ class TestTraceableCollection(TestCase):
     rev_relation = 'some-random-reverse-relation'
     unidir_relation = 'some-random-unidirectional-relation'
     identification_tgt = 'another-item-to-target'
+    attribute_key = 'some-random-attribute-key'
+    attribute_value_src = 'some-random-attribute value1'
+    attribute_value_tgt = 'some-random-attribute value2'
     mock_export_file = '/tmp/my/mocked_export_file.json'
 
     def test_init(self):
@@ -268,6 +271,24 @@ class TestTraceableCollection(TestCase):
         # placeholder is replaced by actual item
         coll.add_item(item2)
         self.assertEqual(2, len(coll.get_items('\w*')))
+        # Empty filter should match all items
+        self.assertEqual(2, len(coll.get_items('')))
+
+    def test_get_items_attribute(self):
+        coll = dut.TraceableCollection()
+        item1 = item.TraceableItem(self.identification_src)
+        coll.add_item(item1)
+        item2 = item.TraceableItem(self.identification_tgt)
+        coll.add_item(item2)
+        self.assertEqual(2, len(coll.get_items('')))
+        self.assertEqual(0, len(coll.get_items('', {self.attribute_key: self.attribute_value_src})))
+        self.assertEqual(0, len(coll.get_items('', {self.attribute_key: self.attribute_value_tgt})))
+        item1.add_attribute(self.attribute_key, self.attribute_value_src)
+        self.assertEqual(1, len(coll.get_items('', {self.attribute_key: self.attribute_value_src})))
+        self.assertEqual(0, len(coll.get_items('', {self.attribute_key: self.attribute_value_tgt})))
+        item2.add_attribute(self.attribute_key, self.attribute_value_tgt)
+        self.assertEqual(1, len(coll.get_items('', {self.attribute_key: self.attribute_value_src})))
+        self.assertEqual(1, len(coll.get_items('', {self.attribute_key: self.attribute_value_tgt})))
 
     def test_related(self):
         coll = dut.TraceableCollection()


### PR DESCRIPTION
This PR contributing to #33 adds attributes to

- items: items can be attributed with a configurable set of attributes
- item-list: lists of items can be filtered for a specific attribute value (regex)

Attributes are probably useful for other directives (matrix, 2d-matrix, tree) but that is still todo for now. Ideas are welcome however in #33.