### PR TITLE
Change behavior of traceability_render_relationship_per_item to not affect display of attributes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -222,6 +222,17 @@ Example configuration of enable rendering relationships per item:
 
     traceability_render_relationship_per_item = True
 
+Rendering of attributes per documentation object
+===================================================
+
+The rendering of attributes of documentation objects can be controlled through the *boolean* variable *traceability_render_attributes_per_item*: rendering of attributes is enabled by setting it to 'True' (the default) while a value of 'False' will prevent the attribute list from being rendered.
+
+Example configuration of disabling per item attribute rendering:
+
+.. code-block:: python
+
+    traceability_render_attributes_per_item = False
+
 .. _traceability_config_no_captions:
 
 No captions

--- a/README.rst
+++ b/README.rst
@@ -223,9 +223,11 @@ Example configuration of enable rendering relationships per item:
     traceability_render_relationship_per_item = True
 
 Rendering of attributes per documentation object
-===================================================
+================================================
 
-The rendering of attributes of documentation objects can be controlled through the *boolean* variable *traceability_render_attributes_per_item*: rendering of attributes is enabled by setting it to 'True' (the default) while a value of 'False' will prevent the attribute list from being rendered.
+The rendering of attributes of documentation objects can be controlled through the *boolean* variable
+*traceability_render_attributes_per_item*: rendering of attributes is enabled by setting it to 'True' (the default)
+while a value of 'False' will prevent the attribute list from being rendered.
 
 Example configuration of disabling per item attribute rendering:
 

--- a/example/conf.py
+++ b/example/conf.py
@@ -340,6 +340,7 @@ traceability_json_export_path = '_build/exported_items.json'
 # traceability_list_no_captions = True
 # traceability_matrix_no_captions = True
 # traceability_tree_no_captions = True
+# traceability_render_attributes_per_item = False
 
 def setup(app):
 

--- a/mlx/traceability.py
+++ b/mlx/traceability.py
@@ -938,26 +938,27 @@ def process_item_nodes(app, doctree, fromdocname):
         top_node = create_top_node(header)    
         par_node = nodes.paragraph()
         dl_node = nodes.definition_list()
-        if currentitem.iter_attributes():
-            li_node = nodes.definition_list_item()
-            dt_node = nodes.term()
-            txt = nodes.Text('Attributes')
-            dt_node.append(txt)
-            li_node.append(dt_node)
-            for attr in currentitem.iter_attributes():
-                dd_node = nodes.definition()
-                p_node = nodes.paragraph()
-                if attr in app.config.traceability_attribute_to_string:
-                    attrstr = app.config.traceability_attribute_to_string[attr]
-                else:
-                    report_warning(env, 'Traceability: attribute {attr} cannot be translated to string'
-                                        .format(attr=attr), docname, lineno)
-                    attrstr = attr
-                txt = nodes.Text('{attr}: {value}'.format(attr=attrstr, value=currentitem.get_attribute(attr)))
-                p_node.append(txt)
-                dd_node.append(p_node)
-                li_node.append(dd_node)
-            dl_node.append(li_node)
+        if app.config.traceability_render_attributes_per_item:
+            if currentitem.iter_attributes():
+                li_node = nodes.definition_list_item()
+                dt_node = nodes.term()
+                txt = nodes.Text('Attributes')
+                dt_node.append(txt)
+                li_node.append(dt_node)
+                for attr in currentitem.iter_attributes():
+                    dd_node = nodes.definition()
+                    p_node = nodes.paragraph()
+                    if attr in app.config.traceability_attribute_to_string:
+                        attrstr = app.config.traceability_attribute_to_string[attr]
+                    else:
+                        report_warning(env, 'Traceability: attribute {attr} cannot be translated to string'
+                                            .format(attr=attr), docname, lineno)
+                        attrstr = attr
+                    txt = nodes.Text('{attr}: {value}'.format(attr=attrstr, value=currentitem.get_attribute(attr)))
+                    p_node.append(txt)
+                    dd_node.append(p_node)
+                    li_node.append(dd_node)
+                dl_node.append(li_node)
         if app.config.traceability_render_relationship_per_item:
             for rel in env.traceability_collection.iter_relations():
                 tgts = currentitem.iter_targets(rel)
@@ -1236,6 +1237,10 @@ def setup(app):
     app.add_config_value('traceability_external_relationship_to_url',
                          {'ext_toolname': 'http://toolname.company.com/field1/workitem?field2'},
                          'env')
+
+    # Configuration for enabling the rendering of the attributes on every item
+    app.add_config_value('traceability_render_attributes_per_item',
+                         True, 'env')
 
     # Configuration for enabling the rendering of the relations on every item
     app.add_config_value('traceability_render_relationship_per_item',

--- a/mlx/traceability.py
+++ b/mlx/traceability.py
@@ -935,30 +935,30 @@ def process_item_nodes(app, doctree, fromdocname):
         header = currentitem.get_id()
         if currentitem.caption:
             header += ' : ' + currentitem.caption
-        top_node = create_top_node(header)
+        top_node = create_top_node(header)    
+        par_node = nodes.paragraph()
+        dl_node = nodes.definition_list()
+        if currentitem.iter_attributes():
+            li_node = nodes.definition_list_item()
+            dt_node = nodes.term()
+            txt = nodes.Text('Attributes')
+            dt_node.append(txt)
+            li_node.append(dt_node)
+            for attr in currentitem.iter_attributes():
+                dd_node = nodes.definition()
+                p_node = nodes.paragraph()
+                if attr in app.config.traceability_attribute_to_string:
+                    attrstr = app.config.traceability_attribute_to_string[attr]
+                else:
+                    report_warning(env, 'Traceability: attribute {attr} cannot be translated to string'
+                                        .format(attr=attr), docname, lineno)
+                    attrstr = attr
+                txt = nodes.Text('{attr}: {value}'.format(attr=attrstr, value=currentitem.get_attribute(attr)))
+                p_node.append(txt)
+                dd_node.append(p_node)
+                li_node.append(dd_node)
+            dl_node.append(li_node)
         if app.config.traceability_render_relationship_per_item:
-            par_node = nodes.paragraph()
-            dl_node = nodes.definition_list()
-            if currentitem.iter_attributes():
-                li_node = nodes.definition_list_item()
-                dt_node = nodes.term()
-                txt = nodes.Text('Attributes')
-                dt_node.append(txt)
-                li_node.append(dt_node)
-                for attr in currentitem.iter_attributes():
-                    dd_node = nodes.definition()
-                    p_node = nodes.paragraph()
-                    if attr in app.config.traceability_attribute_to_string:
-                        attrstr = app.config.traceability_attribute_to_string[attr]
-                    else:
-                        report_warning(env, 'Traceability: attribute {attr} cannot be translated to string'
-                                            .format(attr=attr), docname, lineno)
-                        attrstr = attr
-                    txt = nodes.Text('{attr}: {value}'.format(attr=attrstr, value=currentitem.get_attribute(attr)))
-                    p_node.append(txt)
-                    dd_node.append(p_node)
-                    li_node.append(dd_node)
-                dl_node.append(li_node)
             for rel in env.traceability_collection.iter_relations():
                 tgts = currentitem.iter_targets(rel)
                 if tgts:
@@ -984,8 +984,8 @@ def process_item_nodes(app, doctree, fromdocname):
                         dd_node.append(p_node)
                         li_node.append(dd_node)
                     dl_node.append(li_node)
-            par_node.append(dl_node)
-            top_node.append(par_node)
+        par_node.append(dl_node)
+        top_node.append(par_node)
         # Note: content should be displayed during read of RST file, as it contains other RST objects
         node.replace_self(top_node)
 


### PR DESCRIPTION
The traceability_render_relationship_per_item configuration parameter now only affects relationship rendering and leaves the display of attributes unchanged.