### PR TITLE
Add support for manually specifying longtable

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -550,7 +550,7 @@ caption can be omitted. This gives a smaller list, but also less details.
 Matrix with attributes of documentation items
 =============================================
 
-A matrix lising the attributes of documentation items can be generated using:
+A matrix listing the attributes of documentation items can be generated using:
 
 .. code-block:: rest
 
@@ -576,6 +576,10 @@ caption can be omitted. This gives a smaller table, but also less details.
 By default items are sorted based on their name. With the *sort* argument it is possible to sort on one
 or more attribute values. When providing multiple attributes on which to sort, the attribute keys are
 space separated. The sorting is a natural sort. With the *reverse* argument, the sorting is reversed.
+
+Optionally, the *class* attribute can be specified, to customize table output, especially useful when rendering to
+LaTeX.  Normally the *longtable* class is used when the number of rows is greater than 30 which allows long tables to
+span multiple pages. By setting *class* to *longtable* manually you can force the use of this environment.
 
 .. _traceability_usage_item_matrix:
 
@@ -612,6 +616,10 @@ and the number of items having no target in the target-column (=not covered or a
 coverage/allocation percentage from these counts. If the *stats* flag is not given, this percentage is not
 displayed.
 
+Optionally, the *class* attribute can be specified, to customize table output, especially useful when rendering to
+LaTeX.  Normally the *longtable* class is used when the number of rows is greater than 30 which allows long tables to
+span multiple pages. By setting *class* to *longtable* manually you can force the use of this environment.
+
 .. _traceability_usage_2d_matrix:
 
 2D-matrix of documentation items
@@ -637,6 +645,10 @@ rows of the generated table. Where source and target items have a matching relat
 an 'x' will be placed in the cell at co-ordinates of source/target.
 
 Captions for items in the 2D table are never shown, as it would give a too heavy loaded table.
+
+Optionally, the *class* attribute can be specified, to customize table output, especially useful when rendering to
+LaTeX.  Normally the *longtable* class is used when the number of rows is greater than 30 which allows long tables to
+span multiple pages. By setting *class* to *longtable* manually you can force the use of this environment.
 
 .. _traceability_usage_item_tree:
 

--- a/mlx/traceability.py
+++ b/mlx/traceability.py
@@ -358,6 +358,9 @@ class ItemMatrixDirective(Directive):
 
         item_matrix_node = ItemMatrix('')
 
+        if self.options.get('class'):
+            item_matrix_node.get('classes').extend(self.options.get('class'))
+
         # Process title (optional argument)
         if len(self.arguments) > 0:
             item_matrix_node['title'] = self.arguments[0]
@@ -445,6 +448,9 @@ class ItemAttributesMatrixDirective(Directive):
 
         node = ItemAttributesMatrix('')
 
+        if self.options.get('class'):
+            node.get('classes').extend(self.options.get('class'))
+
         # Process title (optional argument)
         if len(self.arguments) > 0:
             node['title'] = self.arguments[0]
@@ -531,6 +537,9 @@ class Item2DMatrixDirective(Directive):
         env = self.state.document.settings.env
 
         node = Item2DMatrix('')
+
+        if self.options.get('class'):
+            node.get('classes').extend(self.options.get('class'))
 
         # Process title (optional argument)
         if len(self.arguments) > 0:
@@ -717,6 +726,8 @@ def process_item_nodes(app, doctree, fromdocname):
         target_ids = env.traceability_collection.get_items(node['target'])
         top_node = create_top_node(node['title'])
         table = nodes.table()
+        if node.get('classes'):
+            table.get('classes').extend(node.get('classes'))
         tgroup = nodes.tgroup()
         left_colspec = nodes.colspec(colwidth=5)
         right_colspec = nodes.colspec(colwidth=5)
@@ -785,6 +796,8 @@ def process_item_nodes(app, doctree, fromdocname):
                                                          reverse=node['reverse'])
         top_node = create_top_node(node['title'])
         table = nodes.table()
+        if node.get('classes'):
+            table.get('classes').extend(node.get('classes'))
         tgroup = nodes.tgroup()
         colspecs = [nodes.colspec(colwidth=5)]
         hrow = nodes.row('', nodes.entry('', nodes.paragraph('', '')))
@@ -829,6 +842,8 @@ def process_item_nodes(app, doctree, fromdocname):
         target_ids = env.traceability_collection.get_items(node['target'])
         top_node = create_top_node(node['title'])
         table = nodes.table()
+        if node.get('classes'):
+            table.get('classes').extend(node.get('classes'))
         tgroup = nodes.tgroup()
         colspecs = [nodes.colspec(colwidth=5)]
         hrow = nodes.row('', nodes.entry('', nodes.paragraph('', '')))
@@ -935,7 +950,7 @@ def process_item_nodes(app, doctree, fromdocname):
         header = currentitem.get_id()
         if currentitem.caption:
             header += ' : ' + currentitem.caption
-        top_node = create_top_node(header)    
+        top_node = create_top_node(header)
         par_node = nodes.paragraph()
         dl_node = nodes.definition_list()
         if app.config.traceability_render_attributes_per_item:


### PR DESCRIPTION
When rendering many of the tables into PDF there is a tendency for the tables to run out past the margins. The LaTeX writer normally forces the longtable environment when the number of rows is greater than 30. However, when using normal table directives in sphinx you can normally pass in the `:class: longtable` attribute to those directives to force longtable environment in LaTeX. This change just passes the `:class:` attribute down to the `Table` node where it is processed normally by the downstream transforms and writers.