### PR TITLE
WIP: Adding string operator to TraceabilityException

### DIFF
--- a/mlx/traceability_exception.py
+++ b/mlx/traceability_exception.py
@@ -32,6 +32,10 @@ class TraceabilityException(Exception):
         '''
         super(TraceabilityException, self).__init__(message)
         self.docname = docname
+        self.message = message
+
+    def __str__(self):
+        return str(self.message)
 
     def get_document(self):
         '''


### PR DESCRIPTION
Reported issue where sphinx expects a string, but gets the Exception type