### PR TITLE
Sort items alphabetically when sortattributes argument is used

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -592,9 +592,9 @@ that don't have a value for a certain attribute will have an empty cell at the c
 By default the caption for every item in the table is shown. By providing the *nocaptions* flag, the
 caption can be omitted. This gives a smaller table, but also less details.
 
-By default items are sorted based on their name. With the *sort* argument it is possible to sort on one
-or more attribute values. When providing multiple attributes on which to sort, the attribute keys are
-space separated. The sorting is a natural sort. With the *reverse* argument, the sorting is reversed.
+By default items are sorted naturally based on their name. With the *sort* argument it is possible to sort on one
+or more attribute values alphabetically. When providing multiple attributes on which to sort, the attribute keys are
+space separated. With the *reverse* argument, the sorting is reversed.
 
 Optionally, the *class* attribute can be specified, to customize table output, especially useful when rendering to
 LaTeX.  Normally the *longtable* class is used when the number of rows is greater than 30 which allows long tables to

--- a/mlx/traceable_collection.py
+++ b/mlx/traceable_collection.py
@@ -250,10 +250,11 @@ class TraceableCollection(object):
         Args:
             - regex (str): Regex to match the items in this collection against
             - attributes (dict): Dictionary with attribute-regex pairs to match the items in this collection against
-            - sortattributes (list): List of attributes on which to sort the items
+            - sortattributes (list): List of attributes on which to alphabetically sort the items
             - reverse (bool): True for reverse sorting
         Returns:
-            A naturally sorted list of item-id's matching the given regex
+            A sorted list of item-id's matching the given regex. Sorting is done naturally when sortattributes is
+            unused.
         '''
         matches = []
         for itemid in self.items:
@@ -262,8 +263,8 @@ class TraceableCollection(object):
             if self.items[itemid].is_match(regex) and self.items[itemid].attributes_match(attributes):
                 matches.append(itemid)
         if sortattributes:
-            matches = natsorted(matches, key=lambda itemid: self.get_item(itemid).get_attributes(sortattributes),
-                                reverse=reverse)
+            matches = sorted(matches, key=lambda itemid: self.get_item(itemid).get_attributes(sortattributes),
+                             reverse=reverse)
         else:
             matches = natsorted(matches, reverse=reverse)
         return matches

--- a/tests/test_traceable_collection.py
+++ b/tests/test_traceable_collection.py
@@ -312,6 +312,26 @@ class TestTraceableCollection(TestCase):
         self.assertEqual(1, len(coll.get_items('', {self.attribute_key: self.attribute_value_src})))
         self.assertEqual(1, len(coll.get_items('', {self.attribute_key: self.attribute_value_tgt})))
 
+    def test_get_items_sortattributes(self):
+        name1 = 'z11'
+        name2 = 'z2'
+        coll = dut.TraceableCollection()
+        item1 = item.TraceableItem(name1)
+        coll.add_item(item1)
+        item2 = item.TraceableItem(name2)
+        coll.add_item(item2)
+        attribute_regex = '0x[0-9A-Z]+'
+        attr = attribute.TraceableAttribute(self.attribute_key, attribute_regex)
+        dut.TraceableItem.define_attribute(attr)
+        item1.add_attribute(self.attribute_key, '0x0029')
+        item2.add_attribute(self.attribute_key, '0x003A')
+        # Alphabetical sorting: 0x0029 before 0x003A
+        self.assertEqual(item1.get_id(), coll.get_items('', sortattributes=[self.attribute_key])[0])
+        self.assertEqual(item2.get_id(), coll.get_items('', sortattributes=[self.attribute_key])[1])
+        # Natural sorting: z2 before z11
+        self.assertEqual(item2.get_id(), coll.get_items('')[0])
+        self.assertEqual(item1.get_id(), coll.get_items('')[1])
+
     def test_related(self):
         coll = dut.TraceableCollection()
         coll.add_relation_pair(self.fwd_relation, self.rev_relation)


### PR DESCRIPTION
Change the sorting behaviour of the `:sort:` option in `.. item-attributes-matrix::` from naturally to alphabetically.

Fixes issue #84