### PR TITLE
Refactoring traceability.py

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -249,7 +249,7 @@ ignore-comments=yes
 ignore-docstrings=yes
 
 # Ignore imports when computing similarities.
-ignore-imports=no
+ignore-imports=yes
 
 
 [IMPORTS]

--- a/mlx/directives/item_2d_matrix_directive.py
+++ b/mlx/directives/item_2d_matrix_directive.py
@@ -17,9 +17,8 @@ class Item2DMatrix(ItemElement):
             app: Sphinx application object to use.
             collection (TraceableCollection): Collection for which to generate the nodes.
         """
-        env = app.builder.env
-        source_ids = env.traceability_collection.get_items(self['source'], self['filter-attributes'])
-        target_ids = env.traceability_collection.get_items(self['target'])
+        source_ids = collection.get_items(self['source'], self['filter-attributes'])
+        target_ids = collection.get_items(self['target'])
         top_node = self.create_top_node(self['title'])
         table = nodes.table()
         if self.get('classes'):
@@ -42,7 +41,7 @@ class Item2DMatrix(ItemElement):
             for source_id in source_ids:
                 cell = nodes.entry()
                 p_node = nodes.paragraph()
-                if env.traceability_collection.are_related(source_id, self['type'], target_id):
+                if collection.are_related(source_id, self['type'], target_id):
                     txt = self['hit']
                 else:
                     txt = self['miss']
@@ -86,7 +85,9 @@ class Item2DMatrixDirective(Directive):
     def run(self):
         env = self.state.document.settings.env
 
-        node = Item2DMatrix(env.docname, self.lineno)
+        node = Item2DMatrix('')
+        node['document'] = env.docname
+        node['line'] = self.lineno
 
         if self.options.get('class'):
             node.get('classes').extend(self.options.get('class'))

--- a/mlx/directives/item_2d_matrix_directive.py
+++ b/mlx/directives/item_2d_matrix_directive.py
@@ -1,0 +1,138 @@
+from docutils import nodes
+from docutils.parsers.rst import Directive
+from docutils.parsers.rst import directives
+from mlx.traceability import report_warning
+from mlx.traceability_item_element import ItemElement
+from mlx.traceable_item import TraceableItem
+
+class Item2DMatrix(ItemElement):
+    '''Matrix for cross referencing documentation items in 2 dimensions'''
+
+    def perform_traceability_replacement(self, app, collection):
+        """
+        Creates table with related items, printing their target references. Only source and target items matching
+        respective regexp shall be included.
+
+        Args:
+            app: Sphinx application object to use.
+            collection (TraceableCollection): Collection for which to generate the nodes.
+        """
+        env = app.builder.env
+        source_ids = env.traceability_collection.get_items(self['source'], self['filter-attributes'])
+        target_ids = env.traceability_collection.get_items(self['target'])
+        top_node = self.create_top_node(self['title'])
+        table = nodes.table()
+        if self.get('classes'):
+            table.get('classes').extend(self.get('classes'))
+        tgroup = nodes.tgroup()
+        colspecs = [nodes.colspec(colwidth=5)]
+        hrow = nodes.row('', nodes.entry('', nodes.paragraph('', '')))
+        for source_id in source_ids:
+            colspecs.append(nodes.colspec(colwidth=5))
+            src_cell = self.make_internal_item_ref(app, source_id, False)
+            hrow.append(nodes.entry('', src_cell))
+        tgroup += colspecs
+        tgroup += nodes.thead('', hrow)
+        tbody = nodes.tbody()
+        for target_id in target_ids:
+            row = nodes.row()
+            tgt_cell = nodes.entry()
+            tgt_cell += self.make_internal_item_ref(app, target_id, False)
+            row += tgt_cell
+            for source_id in source_ids:
+                cell = nodes.entry()
+                p_node = nodes.paragraph()
+                if env.traceability_collection.are_related(source_id, self['type'], target_id):
+                    txt = self['hit']
+                else:
+                    txt = self['miss']
+                p_node += nodes.Text(txt)
+                cell += p_node
+                row += cell
+            tbody += row
+        tgroup += tbody
+        table += tgroup
+        top_node += table
+        self.replace_self(top_node)
+
+
+class Item2DMatrixDirective(Directive):
+    """
+    Directive to generate a 2D-matrix of item cross-references, based on
+    a given set of relationship types.
+
+    Syntax::
+
+      .. item-2d-matrix:: title
+         :target: regexp
+         :source: regexp
+         :<<attribute>>: regexp
+         :type: <<relationship>> ...
+
+    """
+    # Optional argument: title (whitespace allowed)
+    optional_arguments = 1
+    final_argument_whitespace = True
+    # Options
+    option_spec = {'class': directives.class_option,
+                   'target': directives.unchanged,
+                   'source': directives.unchanged,
+                   'hit': directives.unchanged,
+                   'miss': directives.unchanged,
+                   'type': directives.unchanged}
+    # Content disallowed
+    has_content = False
+
+    def run(self):
+        env = self.state.document.settings.env
+
+        node = Item2DMatrix(env.docname, self.lineno)
+
+        if self.options.get('class'):
+            node.get('classes').extend(self.options.get('class'))
+
+        # Process title (optional argument)
+        if self.arguments:
+            node['title'] = self.arguments[0]
+        else:
+            node['title'] = '2D traceability matrix of items'
+
+        # Process ``target`` & ``source`` options
+        for option in ('target', 'source'):
+            if option in self.options:
+                node[option] = self.options[option]
+            else:
+                node[option] = ''
+
+        # Add found attributes to item. Attribute data is a single string.
+        node['filter-attributes'] = {}
+        for attr in TraceableItem.defined_attributes.keys():
+            if attr in self.options:
+                node['filter-attributes'][attr] = self.options[attr]
+
+        # Process ``type`` option, given as a string with relationship types
+        # separated by space. It is converted to a list.
+        if 'type' in self.options:
+            node['type'] = self.options['type'].split()
+        else:
+            node['type'] = []
+
+        # Check if given relationships are in configuration
+        for rel in node['type']:
+            if rel not in env.traceability_collection.iter_relations():
+                report_warning(env, 'Traceability: unknown relation for item-2d-matrix: %s' % rel,
+                               env.docname, self.lineno)
+
+        # Check hit string
+        if 'hit' in self.options:
+            node['hit'] = self.options['hit']
+        else:
+            node['hit'] = 'x'
+
+        # Check miss string
+        if 'miss' in self.options:
+            node['miss'] = self.options['miss']
+        else:
+            node['miss'] = ''
+
+        return [node]

--- a/mlx/directives/item_attribute_directive.py
+++ b/mlx/directives/item_attribute_directive.py
@@ -55,9 +55,11 @@ class ItemAttributeDirective(Directive):
         env = self.state.document.settings.env
 
         # Convert to lower-case as sphinx only allows lowercase arguments (attribute to item directive)
-        attrid = self.arguments[0]
-        targetnode = nodes.target('', '', ids=[attrid])
-        attrnode = ItemAttribute(env.docname, self.lineno)
+        attribute_id = self.arguments[0]
+        target_node = nodes.target('', '', ids=[attribute_id])
+        attribute_node = ItemAttribute('')
+        attribute_node['document'] = env.docname
+        attribute_node['line'] = self.lineno
 
         # Item caption is the text following the mandatory id argument.
         # Caption should be considered a line of text. Remove line breaks.
@@ -65,18 +67,19 @@ class ItemAttributeDirective(Directive):
         if len(self.arguments) > 1:
             caption = self.arguments[1].replace('\n', ' ')
 
-        stored_id = TraceableAttribute.to_id(attrid)
+        stored_id = TraceableAttribute.to_id(attribute_id)
         if stored_id not in TraceableItem.defined_attributes.keys():
             report_warning(env,
-                           'Found attribute description which is not defined in configuration ({})'.format(attrid),
+                           'Found attribute description which is not defined in configuration ({})'
+                           .format(attribute_id),
                            env.docname,
                            self.lineno)
-            attrnode['id'] = stored_id
+            attribute_node['id'] = stored_id
         else:
             attr = TraceableItem.defined_attributes[stored_id]
             attr.set_caption(caption)
             attr.set_document(env.docname, self.lineno)
-            attrnode['id'] = attr.get_id()
+            attribute_node['id'] = attr.get_id()
 
         # Output content of attribute to document
         template = []
@@ -85,4 +88,4 @@ class ItemAttributeDirective(Directive):
         self.state_machine.insert_input(template, self.state_machine.document.attributes['source'])
 
 
-        return [targetnode, attrnode]
+        return [target_node, attribute_node]

--- a/mlx/directives/item_attribute_directive.py
+++ b/mlx/directives/item_attribute_directive.py
@@ -1,0 +1,88 @@
+from docutils import nodes
+from docutils.parsers.rst import Directive
+
+from mlx.traceability import report_warning
+from mlx.traceability_item_element import ItemElement
+from mlx.traceable_attribute import TraceableAttribute
+from mlx.traceable_item import TraceableItem
+
+
+class ItemAttribute(ItemElement):
+    '''Attribute to documentation item'''
+
+    def perform_traceability_replacement(self, app, collection):
+        """
+        Perform the node replacement
+        Args:
+            app: Sphinx application object to use.
+            collection (TraceableCollection): Collection for which to generate the nodes.
+        """
+        if self['id'] in TraceableItem.defined_attributes.keys():
+            attr = TraceableItem.defined_attributes[self['id']]
+            header = attr.get_name()
+            if attr.get_caption():
+                header += ' : ' + attr.get_caption()
+        else:
+            header = self['id']
+        top_node = self.create_top_node(header)
+        par_node = nodes.paragraph()
+        dl_node = nodes.definition_list()
+        par_node.append(dl_node)
+        top_node.append(par_node)
+        self.replace_self(top_node)
+
+
+class ItemAttributeDirective(Directive):
+    """
+    Directive to declare attribute for items
+
+    Syntax::
+
+      .. item-attribute:: attribute_id [attribute_caption]
+
+         [attribute_content]
+
+    """
+    # Required argument: id
+    required_arguments = 1
+    # Optional argument: caption (whitespace allowed)
+    optional_arguments = 1
+    final_argument_whitespace = True
+    # Content allowed
+    has_content = True
+
+    def run(self):
+        env = self.state.document.settings.env
+
+        # Convert to lower-case as sphinx only allows lowercase arguments (attribute to item directive)
+        attrid = self.arguments[0]
+        targetnode = nodes.target('', '', ids=[attrid])
+        attrnode = ItemAttribute(env.docname, self.lineno)
+
+        # Item caption is the text following the mandatory id argument.
+        # Caption should be considered a line of text. Remove line breaks.
+        caption = ''
+        if len(self.arguments) > 1:
+            caption = self.arguments[1].replace('\n', ' ')
+
+        stored_id = TraceableAttribute.to_id(attrid)
+        if stored_id not in TraceableItem.defined_attributes.keys():
+            report_warning(env,
+                           'Found attribute description which is not defined in configuration ({})'.format(attrid),
+                           env.docname,
+                           self.lineno)
+            attrnode['id'] = stored_id
+        else:
+            attr = TraceableItem.defined_attributes[stored_id]
+            attr.set_caption(caption)
+            attr.set_document(env.docname, self.lineno)
+            attrnode['id'] = attr.get_id()
+
+        # Output content of attribute to document
+        template = []
+        for line in self.content:
+            template.append('    ' + line)
+        self.state_machine.insert_input(template, self.state_machine.document.attributes['source'])
+
+
+        return [targetnode, attrnode]

--- a/mlx/directives/item_attributes_matrix_directive.py
+++ b/mlx/directives/item_attributes_matrix_directive.py
@@ -1,0 +1,153 @@
+from docutils import nodes
+from docutils.parsers.rst import Directive
+from docutils.parsers.rst import directives
+from mlx.traceability import report_warning
+from mlx.traceability_item_element import ItemElement
+from mlx.traceable_item import TraceableItem
+
+class ItemAttributesMatrix(ItemElement):
+    '''Matrix for referencing documentation items with their attributes'''
+
+    def perform_traceability_replacement(self, app, collection):
+        """ Creates table with items, printing their attribute values.
+
+        Args:
+            app: Sphinx application object to use.
+            collection (TraceableCollection): Collection for which to generate the nodes.
+        """
+        env = app.builder.env
+        showcaptions = not self['nocaptions']
+        item_ids = env.traceability_collection.get_items(self['filter'], self['filter-attributes'],
+                                                         sortattributes=self['sort'],
+                                                         reverse=self['reverse'])
+        top_node = self.create_top_node(self['title'])
+        table = nodes.table()
+        if self.get('classes'):
+            table.get('classes').extend(self.get('classes'))
+        tgroup = nodes.tgroup()
+        colspecs = [nodes.colspec(colwidth=5)]
+        hrow = nodes.row('', nodes.entry('', nodes.paragraph('', '')))
+        for attr in self['attributes']:
+            colspecs.append(nodes.colspec(colwidth=5))
+            p_node = nodes.paragraph()
+            p_node += self.make_attribute_ref(app, attr)
+            hrow.append(nodes.entry('', p_node))
+        tgroup += colspecs
+        tgroup += nodes.thead('', hrow)
+        tbody = nodes.tbody()
+        for item_id in item_ids:
+            item = env.traceability_collection.get_item(item_id)
+            row = nodes.row()
+            cell = nodes.entry()
+            cell += self.make_internal_item_ref(app, item_id, showcaptions)
+            row += cell
+            for attr in self['attributes']:
+                cell = nodes.entry()
+                p_node = nodes.paragraph()
+                txt = item.get_attribute(attr)
+                p_node += nodes.Text(txt)
+                cell += p_node
+                row += cell
+            tbody += row
+        tgroup += tbody
+        table += tgroup
+        top_node += table
+        self.replace_self(top_node)
+
+
+class ItemAttributesMatrixDirective(Directive):
+    """
+    Directive to generate a matrix of items with their attribute values.
+
+    Syntax::
+
+      .. item-attributes-matrix:: title
+         :filter: regexp
+         :<<attribute>>: regexp
+         :attributes: <<attribute>> ...
+         :sort: <attribute>> ...
+         :reverse:
+         :nocaptions:
+    """
+    # Optional argument: title (whitespace allowed)
+    optional_arguments = 1
+    final_argument_whitespace = True
+    # Options
+    option_spec = {'class': directives.class_option,
+                   'filter': directives.unchanged,
+                   'attributes': directives.unchanged,
+                   'sort': directives.unchanged,
+                   'reverse': directives.flag,
+                   'nocaptions': directives.flag}
+    # Content disallowed
+    has_content = False
+
+    def run(self):
+        env = self.state.document.settings.env
+        app = env.app
+
+        node = ItemAttributesMatrix(env.docname, self.lineno)
+
+        if self.options.get('class'):
+            node.get('classes').extend(self.options.get('class'))
+
+        # Process title (optional argument)
+        if self.arguments:
+            node['title'] = self.arguments[0]
+        else:
+            node['title'] = 'Matrix of items and attributes'
+
+        # Process ``filter`` options
+        if 'filter' in self.options:
+            node['filter'] = self.options['filter']
+        else:
+            node['filter'] = ''
+
+        # Add found attributes to item. Attribute data is a single string.
+        node['filter-attributes'] = {}
+        for attr in TraceableItem.defined_attributes.keys():
+            if attr in self.options:
+                node['filter-attributes'][attr] = self.options[attr]
+
+        # Process ``attributes`` option, given as a string with attributes
+        # separated by space. It is converted to a list.
+        if 'attributes' in self.options and self.options['attributes']:
+            node['attributes'] = self.options['attributes'].split()
+        else:
+            node['attributes'] = list(app.config.traceability_attributes.keys())
+
+        # Check if given attributes are in configuration
+        for attr in node['attributes']:
+            if attr not in TraceableItem.defined_attributes.keys():
+                report_warning(env, 'Traceability: unknown attribute for item-attributes-matrix: %s' % attr,
+                               env.docname, self.lineno)
+                node['attributes'].remove(attr)
+
+        # Process ``sort`` option, given as a string with attributes
+        # separated by space. It is converted to a list.
+        if 'sort' in self.options and self.options['sort']:
+            node['sort'] = self.options['sort'].split()
+            # Check if given sort-attributes are in configuration
+            for attr in node['sort']:
+                if attr not in TraceableItem.defined_attributes.keys():
+                    report_warning(env, 'Traceability: unknown sorting attribute for item-attributes-matrix: %s' % attr,
+                                   env.docname, self.lineno)
+                    node['sort'].remove(attr)
+        else:
+            node['sort'] = None
+
+        # Check reverse flag
+        if 'reverse' in self.options:
+            node['reverse'] = True
+        else:
+            node['reverse'] = False
+
+        # Check nocaptions flag
+        if 'nocaptions' in self.options:
+            node['nocaptions'] = True
+        elif app.config.traceability_attributes_matrix_no_captions:
+            node['nocaptions'] = True
+        else:
+            node['nocaptions'] = False
+
+        return [node]

--- a/mlx/directives/item_attributes_matrix_directive.py
+++ b/mlx/directives/item_attributes_matrix_directive.py
@@ -15,9 +15,8 @@ class ItemAttributesMatrix(ItemElement):
             app: Sphinx application object to use.
             collection (TraceableCollection): Collection for which to generate the nodes.
         """
-        env = app.builder.env
         showcaptions = not self['nocaptions']
-        item_ids = env.traceability_collection.get_items(self['filter'], self['filter-attributes'],
+        item_ids = collection.get_items(self['filter'], self['filter-attributes'],
                                                          sortattributes=self['sort'],
                                                          reverse=self['reverse'])
         top_node = self.create_top_node(self['title'])
@@ -36,7 +35,7 @@ class ItemAttributesMatrix(ItemElement):
         tgroup += nodes.thead('', hrow)
         tbody = nodes.tbody()
         for item_id in item_ids:
-            item = env.traceability_collection.get_item(item_id)
+            item = collection.get_item(item_id)
             row = nodes.row()
             cell = nodes.entry()
             cell += self.make_internal_item_ref(app, item_id, showcaptions)
@@ -86,7 +85,9 @@ class ItemAttributesMatrixDirective(Directive):
         env = self.state.document.settings.env
         app = env.app
 
-        node = ItemAttributesMatrix(env.docname, self.lineno)
+        node = ItemAttributesMatrix('')
+        node['document'] = env.docname
+        node['line'] = self.lineno
 
         if self.options.get('class'):
             node.get('classes').extend(self.options.get('class'))

--- a/mlx/directives/item_directive.py
+++ b/mlx/directives/item_directive.py
@@ -1,0 +1,175 @@
+from docutils import nodes
+from docutils.parsers.rst import Directive
+from docutils.parsers.rst import directives
+from mlx.traceability_exception import report_warning, TraceabilityException
+from mlx.traceability_item_element import ItemElement, REGEXP_EXTERNAL_RELATIONSHIP
+from mlx.traceable_item import TraceableItem
+
+class Item(ItemElement):
+    '''Documentation item'''
+
+    def perform_traceability_replacement(self, app, collection):
+        """
+        Perform the node replacement
+        Args:
+            app: Sphinx application object to use.
+            collection (TraceableCollection): Collection for which to generate the nodes.
+        """
+        env = app.builder.env
+        currentitem = env.traceability_collection.get_item(self['id'])
+        showcaptions = not self['nocaptions']
+        header = currentitem.get_id()
+        if currentitem.caption:
+            header += ' : ' + currentitem.caption
+        top_node = self.create_top_node(header)
+        par_node = nodes.paragraph()
+        dl_node = nodes.definition_list()
+        if app.config.traceability_render_attributes_per_item:
+            if currentitem.iter_attributes():
+                li_node = nodes.definition_list_item()
+                dt_node = nodes.term()
+                txt = nodes.Text('Attributes')
+                dt_node.append(txt)
+                li_node.append(dt_node)
+                for attr in currentitem.iter_attributes():
+                    dd_node = nodes.definition()
+                    p_node = nodes.paragraph()
+                    link = self.make_attribute_ref(app, attr, currentitem.get_attribute(attr))
+                    p_node.append(link)
+                    dd_node.append(p_node)
+                    li_node.append(dd_node)
+                dl_node.append(li_node)
+        if app.config.traceability_render_relationship_per_item:
+            for rel in env.traceability_collection.iter_relations():
+                tgts = currentitem.iter_targets(rel)
+                if tgts:
+                    li_node = nodes.definition_list_item()
+                    dt_node = nodes.term()
+                    if rel in app.config.traceability_relationship_to_string:
+                        relstr = app.config.traceability_relationship_to_string[rel]
+                    else:
+                        report_warning(env,
+                                       'Traceability: relation {rel} cannot be translated to string'
+                                       .format(rel=rel),
+                                       self.docname, self.line)
+                        relstr = rel
+                    txt = nodes.Text(relstr)
+                    dt_node.append(txt)
+                    li_node.append(dt_node)
+                    for tgt in tgts:
+                        dd_node = nodes.definition()
+                        p_node = nodes.paragraph()
+                        if REGEXP_EXTERNAL_RELATIONSHIP.search(rel):
+                            link = self.make_external_item_ref(app, tgt, rel)
+                        else:
+                            link = self.make_internal_item_ref(app, tgt, showcaptions)
+                        p_node.append(link)
+                        dd_node.append(p_node)
+                        li_node.append(dd_node)
+                    dl_node.append(li_node)
+        par_node.append(dl_node)
+        top_node.append(par_node)
+        # Note: content should be displayed during read of RST file, as it contains other RST objects
+        self.replace_self(top_node)
+
+
+class ItemDirective(Directive):
+    """
+    Directive to declare items and their traceability relationships.
+
+    Syntax::
+
+      .. item:: item_id [item_caption]
+         :<<relationship>>:  other_item_id ...
+         :<<attribute>>: attribute_value
+         ...
+         :nocaptions:
+
+         [item_content]
+
+    When run, for each item, two nodes will be returned:
+
+    * A target node
+    * A custom node with id + caption, to be replaced with relationship links
+    * A node containing the content of the item
+
+    Also ``traceability_collection`` storage is filled with item information
+
+    """
+    # Required argument: id
+    required_arguments = 1
+    # Optional argument: caption (whitespace allowed)
+    optional_arguments = 1
+    final_argument_whitespace = True
+    # Options: the typical ones plus every relationship (and reverse)
+    # defined in env.config.traceability_relationships
+    option_spec = {'class': directives.class_option,
+                   'nocaptions': directives.flag}
+    # Content allowed
+    has_content = True
+
+    def run(self):
+        env = self.state.document.settings.env
+        app = env.app
+        caption = ''
+
+        targetid = self.arguments[0]
+        targetnode = nodes.target('', '', ids=[targetid])
+
+        itemnode = Item(env.docname, self.lineno)
+        itemnode['id'] = targetid
+
+        # Item caption is the text following the mandatory id argument.
+        # Caption should be considered a line of text. Remove line breaks.
+        if len(self.arguments) > 1:
+            caption = self.arguments[1].replace('\n', ' ')
+
+        # Store item info
+        item = TraceableItem(targetid)
+        item.set_document(env.docname, self.lineno)
+        item.bind_node(targetnode)
+        item.set_caption(caption)
+        item.set_content('\n'.join(self.content))
+        try:
+            env.traceability_collection.add_item(item)
+        except TraceabilityException as err:
+            report_warning(env, err, env.docname, self.lineno)
+
+        # Add found attributes to item. Attribute data is a single string.
+        for attribute in TraceableItem.defined_attributes.keys():
+            if attribute in self.options:
+                try:
+                    item.add_attribute(attribute, self.options[attribute])
+                except TraceabilityException as err:
+                    report_warning(env, err, env.docname, self.lineno)
+
+        # Add found relationships to item. All relationship data is a string of
+        # item ids separated by space. It is splitted in a list of item ids
+        for rel in env.traceability_collection.iter_relations():
+            if rel in self.options:
+                related_ids = self.options[rel].split()
+                for related_id in related_ids:
+                    try:
+                        env.traceability_collection.add_relation(targetid, rel, related_id)
+                    except TraceabilityException as err:
+                        report_warning(env, err, env.docname, self.lineno)
+
+        # Custom callback for modifying items
+        if app.config.traceability_callback_per_item:
+            app.config.traceability_callback_per_item(targetid, env.traceability_collection)
+
+        # Output content of item to document
+        template = []
+        for line in self.content:
+            template.append('    ' + line)
+        self.state_machine.insert_input(template, self.state_machine.document.attributes['source'])
+
+        # Check nocaptions flag
+        if 'nocaptions' in self.options:
+            itemnode['nocaptions'] = True
+        elif app.config.traceability_item_no_captions:
+            itemnode['nocaptions'] = True
+        else:
+            itemnode['nocaptions'] = False
+
+        return [targetnode, itemnode]

--- a/mlx/directives/item_link_directive.py
+++ b/mlx/directives/item_link_directive.py
@@ -1,5 +1,4 @@
 from docutils.parsers.rst import Directive
-from docutils.utils import get_source_line
 from docutils.parsers.rst import directives
 from mlx.traceability import report_warning
 from mlx.traceability_exception import TraceabilityException
@@ -41,7 +40,9 @@ class ItemLinkDirective(Directive):
     def run(self):
         env = self.state.document.settings.env
 
-        node = ItemLink(env.docname, self.lineno)
+        node = ItemLink('')
+        node['document'] = env.docname
+        node['line'] = self.lineno
         node['sources'] = []
         node['targets'] = []
         node['type'] = None

--- a/mlx/directives/item_link_directive.py
+++ b/mlx/directives/item_link_directive.py
@@ -1,0 +1,75 @@
+from docutils.parsers.rst import Directive
+from docutils.utils import get_source_line
+from docutils.parsers.rst import directives
+from mlx.traceability import report_warning
+from mlx.traceability_exception import TraceabilityException
+from mlx.traceability_item_element import ItemElement
+
+class ItemLink(ItemElement):
+    '''List of documentation items'''
+
+    def perform_traceability_replacement(self, app, collection):
+        """ Processes the item-link items. The ItemLink node has no final representation, so is removed from the tree.
+
+        Args:
+            app: Sphinx application object to use.
+            collection (TraceableCollection): Collection for which to generate the nodes.
+        """
+        self.replace_self([])
+
+
+class ItemLinkDirective(Directive):
+    """
+    Directive to add additional relations between lists of items.
+
+    Syntax::
+
+      .. item-link::
+         :sources: list_of_items
+         :targets: list_of_items
+         :type: relationship_type
+
+    """
+    final_argument_whitespace = True
+    # Options
+    option_spec = {'sources': directives.unchanged,
+                   'targets': directives.unchanged,
+                   'type': directives.unchanged}
+    # Content disallowed
+    has_content = False
+
+    def run(self):
+        env = self.state.document.settings.env
+
+        node = ItemLink(env.docname, self.lineno)
+        node['sources'] = []
+        node['targets'] = []
+        node['type'] = None
+
+        if 'sources' in self.options:
+            node['sources'] = self.options['sources'].split()
+        else:
+            report_warning(env, 'sources argument required for item-link directive', env.docname, self.lineno)
+            return []
+        if 'targets' in self.options:
+            node['targets'] = self.options['targets'].split()
+        else:
+            report_warning(env, 'targets argument required for item-link directive', env.docname, self.lineno)
+            return []
+        if 'type' in self.options:
+            node['type'] = self.options['type']
+        else:
+            report_warning(env, 'type argument required for item-link directive', env.docname, self.lineno)
+            return []
+
+        # Processing of the item-link items. They get added as additional relationships
+        # to the existing items. Should be done before converting anything to docutils.
+        for source in node['sources']:
+            for target in node['targets']:
+                try:
+                    env.traceability_collection.add_relation(source, node['type'], target)
+                except TraceabilityException as err:
+                    report_warning(env, err, env.docname, self.lineno)
+
+        # The ItemLink node has no final representation, so is removed from the tree
+        return [node]

--- a/mlx/directives/item_list_directive.py
+++ b/mlx/directives/item_list_directive.py
@@ -14,8 +14,7 @@ class ItemList(ItemElement):
             app: Sphinx application object to use.
             collection (TraceableCollection): Collection for which to generate the nodes.
         """
-        env = app.builder.env
-        item_ids = env.traceability_collection.get_items(self['filter'], self['filter-attributes'])
+        item_ids = collection.get_items(self['filter'], self['filter-attributes'])
         showcaptions = not self['nocaptions']
         top_node = self.create_top_node(self['title'])
         ul_node = nodes.bullet_list()
@@ -55,7 +54,9 @@ class ItemListDirective(Directive):
         env = self.state.document.settings.env
         app = env.app
 
-        item_list_node = ItemList(env.docname, self.lineno)
+        item_list_node = ItemList('')
+        item_list_node['document'] = env.docname
+        item_list_node['line'] = self.lineno
 
         # Process title (optional argument)
         if self.arguments:

--- a/mlx/directives/item_list_directive.py
+++ b/mlx/directives/item_list_directive.py
@@ -1,0 +1,86 @@
+from docutils import nodes
+from docutils.parsers.rst import Directive
+from docutils.parsers.rst import directives
+from mlx.traceability_item_element import ItemElement
+from mlx.traceable_item import TraceableItem
+
+class ItemList(ItemElement):
+    '''List of documentation items'''
+
+    def perform_traceability_replacement(self, app, collection):
+        """ Create list with target references. Only items matching list regexp shall be included.
+
+        Args:
+            app: Sphinx application object to use.
+            collection (TraceableCollection): Collection for which to generate the nodes.
+        """
+        env = app.builder.env
+        item_ids = env.traceability_collection.get_items(self['filter'], self['filter-attributes'])
+        showcaptions = not self['nocaptions']
+        top_node = self.create_top_node(self['title'])
+        ul_node = nodes.bullet_list()
+        for i in item_ids:
+            bullet_list_item = nodes.list_item()
+            p_node = nodes.paragraph()
+            p_node.append(self.make_internal_item_ref(app, i, showcaptions))
+            bullet_list_item.append(p_node)
+            ul_node.append(bullet_list_item)
+        top_node += ul_node
+        self.replace_self(top_node)
+
+
+class ItemListDirective(Directive):
+    """
+    Directive to generate a list of items.
+
+    Syntax::
+
+      .. item-list:: title
+         :filter: regexp
+         :<<attribute>>: regexp
+         :nocaptions:
+
+    """
+    # Optional argument: title (whitespace allowed)
+    optional_arguments = 1
+    final_argument_whitespace = True
+    # Options
+    option_spec = {'class': directives.class_option,
+                   'filter': directives.unchanged,
+                   'nocaptions': directives.flag}
+    # Content disallowed
+    has_content = False
+
+    def run(self):
+        env = self.state.document.settings.env
+        app = env.app
+
+        item_list_node = ItemList(env.docname, self.lineno)
+
+        # Process title (optional argument)
+        if self.arguments:
+            item_list_node['title'] = self.arguments[0]
+        else:
+            item_list_node['title'] = 'List of items'
+
+        # Process ``filter`` option
+        if 'filter' in self.options:
+            item_list_node['filter'] = self.options['filter']
+        else:
+            item_list_node['filter'] = ''
+
+        # Add found attributes to item. Attribute data is a single string.
+        item_list_node['filter-attributes'] = {}
+        for attr in TraceableItem.defined_attributes.keys():
+            if attr in self.options:
+                item_list_node['filter-attributes'][attr] = self.options[attr]
+
+        # Check nocaptions flag
+        if 'nocaptions' in self.options:
+            item_list_node['nocaptions'] = True
+        elif app.config.traceability_list_no_captions:
+            item_list_node['nocaptions'] = True
+        else:
+            item_list_node['nocaptions'] = False
+
+        return [item_list_node]

--- a/mlx/directives/item_matrix_directive.py
+++ b/mlx/directives/item_matrix_directive.py
@@ -19,8 +19,8 @@ class ItemMatrix(ItemElement):
         """
         env = app.builder.env
         showcaptions = not self['nocaptions']
-        source_ids = env.traceability_collection.get_items(self['source'], self['filter-attributes'])
-        target_ids = env.traceability_collection.get_items(self['target'])
+        source_ids = collection.get_items(self['source'], self['filter-attributes'])
+        target_ids = collection.get_items(self['target'])
         top_node = self.create_top_node(self['title'])
         table = nodes.table()
         if self.get('classes'):
@@ -39,13 +39,13 @@ class ItemMatrix(ItemElement):
 
         relationships = self['type']
         if not relationships:
-            relationships = env.traceability_collection.iter_relations()
+            relationships = collection.iter_relations()
 
         count_total = 0
         count_covered = 0
 
         for source_id in source_ids:
-            source_item = env.traceability_collection.get_item(source_id)
+            source_item = collection.get_item(source_id)
             count_total += 1
             covered = False
             row = nodes.row()
@@ -58,7 +58,7 @@ class ItemMatrix(ItemElement):
                         right += self.make_external_item_ref(app, target_id, relationship)
                         covered = True
             for target_id in target_ids:
-                if env.traceability_collection.are_related(source_id, relationships, target_id):
+                if collection.are_related(source_id, relationships, target_id):
                     right += self.make_internal_item_ref(app, target_id, showcaptions)
                     covered = True
             if covered:
@@ -120,7 +120,9 @@ class ItemMatrixDirective(Directive):
         env = self.state.document.settings.env
         app = env.app
 
-        item_matrix_node = ItemMatrix(env.docname, self.lineno)
+        item_matrix_node = ItemMatrix('')
+        item_matrix_node['document'] = env.docname
+        item_matrix_node['line'] = self.lineno
 
         if self.options.get('class'):
             item_matrix_node.get('classes').extend(self.options.get('class'))

--- a/mlx/directives/item_matrix_directive.py
+++ b/mlx/directives/item_matrix_directive.py
@@ -1,0 +1,186 @@
+from docutils import nodes
+from docutils.parsers.rst import Directive
+from docutils.parsers.rst import directives
+from mlx.traceability import report_warning
+from mlx.traceability_item_element import ItemElement, REGEXP_EXTERNAL_RELATIONSHIP
+from mlx.traceable_item import TraceableItem
+
+class ItemMatrix(ItemElement):
+    '''Matrix for cross referencing documentation items'''
+
+    def perform_traceability_replacement(self, app, collection):
+        """
+        Creates table with related items, printing their target references. Only source and target items matching
+        respective regexp shall be included.
+
+        Args:
+            app: Sphinx application object to use.
+            collection (TraceableCollection): Collection for which to generate the nodes.
+        """
+        env = app.builder.env
+        showcaptions = not self['nocaptions']
+        source_ids = env.traceability_collection.get_items(self['source'], self['filter-attributes'])
+        target_ids = env.traceability_collection.get_items(self['target'])
+        top_node = self.create_top_node(self['title'])
+        table = nodes.table()
+        if self.get('classes'):
+            table.get('classes').extend(self.get('classes'))
+        tgroup = nodes.tgroup()
+        left_colspec = nodes.colspec(colwidth=5)
+        right_colspec = nodes.colspec(colwidth=5)
+        tgroup += [left_colspec, right_colspec]
+        tgroup += nodes.thead('', nodes.row(
+            '',
+            nodes.entry('', nodes.paragraph('', self['sourcetitle'])),
+            nodes.entry('', nodes.paragraph('', self['targettitle']))))
+        tbody = nodes.tbody()
+        tgroup += tbody
+        table += tgroup
+
+        relationships = self['type']
+        if not relationships:
+            relationships = env.traceability_collection.iter_relations()
+
+        count_total = 0
+        count_covered = 0
+
+        for source_id in source_ids:
+            source_item = env.traceability_collection.get_item(source_id)
+            count_total += 1
+            covered = False
+            row = nodes.row()
+            left = nodes.entry()
+            left += self.make_internal_item_ref(app, source_id, showcaptions)
+            right = nodes.entry()
+            for relationship in relationships:
+                if REGEXP_EXTERNAL_RELATIONSHIP.search(relationship):
+                    for target_id in source_item.iter_targets(relationship):
+                        right += self.make_external_item_ref(app, target_id, relationship)
+                        covered = True
+            for target_id in target_ids:
+                if env.traceability_collection.are_related(source_id, relationships, target_id):
+                    right += self.make_internal_item_ref(app, target_id, showcaptions)
+                    covered = True
+            if covered:
+                count_covered += 1
+            row += left
+            row += right
+            tbody += row
+
+        try:
+            percentage = int(100 * count_covered / count_total)
+        except ZeroDivisionError:
+            percentage = 0
+        disp = 'Statistics: {cover} out of {total} covered: {pct}%'.format(cover=count_covered,
+                                                                           total=count_total,
+                                                                           pct=percentage)
+        if self['stats']:
+            p_node = nodes.paragraph()
+            txt = nodes.Text(disp)
+            p_node += txt
+            top_node += p_node
+
+        top_node += table
+        self.replace_self(top_node)
+
+
+class ItemMatrixDirective(Directive):
+    """
+    Directive to generate a matrix of item cross-references, based on
+    a given set of relationship types.
+
+    Syntax::
+
+      .. item-matrix:: title
+         :target: regexp
+         :source: regexp
+         :<<attribute>>: regexp
+         :targettitle: Target column header
+         :sourcetitle: Source column header
+         :type: <<relationship>> ...
+         :stats:
+         :nocaptions:
+    """
+    # Optional argument: title (whitespace allowed)
+    optional_arguments = 1
+    final_argument_whitespace = True
+    # Options
+    option_spec = {'class': directives.class_option,
+                   'target': directives.unchanged,
+                   'source': directives.unchanged,
+                   'targettitle': directives.unchanged,
+                   'sourcetitle': directives.unchanged,
+                   'type': directives.unchanged,
+                   'stats': directives.flag,
+                   'nocaptions': directives.flag}
+    # Content disallowed
+    has_content = False
+
+    def run(self):
+        env = self.state.document.settings.env
+        app = env.app
+
+        item_matrix_node = ItemMatrix(env.docname, self.lineno)
+
+        if self.options.get('class'):
+            item_matrix_node.get('classes').extend(self.options.get('class'))
+
+        # Process title (optional argument)
+        if self.arguments:
+            item_matrix_node['title'] = self.arguments[0]
+        else:
+            item_matrix_node['title'] = 'Traceability matrix of items'
+
+        # Add found attributes to item. Attribute data is a single string.
+        item_matrix_node['filter-attributes'] = {}
+        for attr in TraceableItem.defined_attributes.keys():
+            if attr in self.options:
+                item_matrix_node['filter-attributes'][attr] = self.options[attr]
+
+        # Process ``target`` & ``source`` options
+        for option in ('target', 'source'):
+            if option in self.options:
+                item_matrix_node[option] = self.options[option]
+            else:
+                item_matrix_node[option] = ''
+
+        # Process ``type`` option, given as a string with relationship types
+        # separated by space. It is converted to a list.
+        if 'type' in self.options:
+            item_matrix_node['type'] = self.options['type'].split()
+        else:
+            item_matrix_node['type'] = []
+
+        # Check if given relationships are in configuration
+        for rel in item_matrix_node['type']:
+            if rel not in env.traceability_collection.iter_relations():
+                report_warning(env, 'Traceability: unknown relation for item-matrix: %s' % rel,
+                               env.docname, self.lineno)
+
+        # Check statistics flag
+        if 'stats' in self.options:
+            item_matrix_node['stats'] = True
+        else:
+            item_matrix_node['stats'] = False
+
+        # Check nocaptions flag
+        if 'nocaptions' in self.options:
+            item_matrix_node['nocaptions'] = True
+        elif app.config.traceability_matrix_no_captions:
+            item_matrix_node['nocaptions'] = True
+        else:
+            item_matrix_node['nocaptions'] = False
+
+        # Check source title
+        if 'sourcetitle' in self.options:
+            item_matrix_node['sourcetitle'] = self.options['sourcetitle']
+        else:
+            item_matrix_node['sourcetitle'] = 'Source'
+
+        # Check target title
+        if 'targettitle' in self.options:
+            item_matrix_node['targettitle'] = self.options['targettitle']
+        else:
+            item_matrix_node['targettitle'] = 'Target'
+
+        return [item_matrix_node]

--- a/mlx/directives/item_pie_chart_directive.py
+++ b/mlx/directives/item_pie_chart_directive.py
@@ -1,0 +1,233 @@
+import re
+from hashlib import sha256
+from os import environ, mkdir, path
+
+from docutils import nodes
+from docutils.parsers.rst import Directive, directives
+import matplotlib as mpl
+if not environ.get('DISPLAY'):
+    mpl.use('Agg')
+import matplotlib.pyplot as plt
+
+from mlx.traceability import report_warning
+from mlx.traceability_item_element import ItemElement
+from mlx.traceable_item import TraceableItem
+
+def pct_wrapper(sizes):
+    """ Helper function for matplotlib which returns the percentage and the absolute size of the slice.
+
+    Args:
+        sizes (list): List containing the amount of elements per slice.
+    """
+    def make_pct(pct):
+        absolute = int(round(pct / 100 * sum(sizes)))
+        return "{:.0f}%\n({:d})".format(pct, absolute)
+    return make_pct
+
+
+class ItemPieChart(ItemElement):
+    '''Pie chart on documentation items'''
+
+    def perform_traceability_replacement(self, app, collection):
+        """
+        Very similar to item-matrix: but instead of creating a table, the empty cells in the right column are counted.
+        Generates a pie chart with coverage percentages. Only items matching regexp in ``id_set`` option shall be
+        included.
+
+        Args:
+            app: Sphinx application object to use.
+            collection (TraceableCollection): Collection for which to generate the nodes.
+        """
+        env = app.builder.env
+        top_node = self.create_top_node(self['title'])
+        relationships = env.traceability_collection.iter_relations()
+        all_item_ids = env.traceability_collection.get_items('')
+
+        # default priority order is 'uncovered', 'covered', 'executed', 'pass', 'fail', 'error'
+        priorities = {}
+        for idx, label in enumerate(self['label_set']):
+            priorities[label] = idx
+        # store :<<attribute>>: arguments in reverse order in lowercase for case-insensitivity
+        if self['priorities']:
+            for idx, attr in enumerate([value.lower() for value in self['priorities'][::-1]],
+                                       start=len(self['label_set'])):
+                priorities[attr] = idx
+
+        attribute_id = ''
+        if len(self['id_set']) > 2:
+            attribute_id = self['id_set'][2]
+
+        linked_attributes = {}  # source_id (str): attr_value (str)
+        covered_items = {}  # source_id (str): test_items (list)
+
+        for source_id in all_item_ids:
+            source_item = env.traceability_collection.get_item(source_id)
+            # placeholders don't end up in any item-piechart (less duplicate warnings for missing items)
+            if source_item.is_placeholder():
+                continue
+            if re.match(self['id_set'][0], source_id):
+                covered = False
+                test_items = []
+                linked_attributes[source_id] = list(priorities.keys())[0]  # default is "uncovered"
+                for relationship in relationships:
+                    tgts = source_item.iter_targets(relationship, True, True)
+                    for target_id in tgts:
+                        target_item = env.traceability_collection.get_item(target_id)
+                        # placeholders don't end up in any item-matrix (less duplicate warnings for missing items)
+                        if not target_item or target_item.is_placeholder():
+                            continue
+                        if re.match(self['id_set'][1], target_id):
+                            test_items.append(target_item)
+                            linked_attributes[source_id] = list(priorities.keys())[1]  # default is "covered"
+                            covered = True
+                if covered and attribute_id:
+                    covered_items[source_id] = test_items
+
+        # link highest priority attribute value of nested relations to source id
+        for source_id, test_items in covered_items.items():
+            for covering_item in test_items:
+                for relationship in relationships:
+                    tgts = covering_item.iter_targets(relationship, True, True)
+                    for target_id in tgts:
+                        target_item = env.traceability_collection.get_item(target_id)
+                        # placeholders don't end up in any item-matrix (less duplicate warnings for missing items)
+                        if not target_item or target_item.is_placeholder():
+                            continue
+                        if re.match(attribute_id, target_id):
+                            # case-insensitivity
+                            attribute_value = target_item.get_attribute(self['attribute']).lower()
+                            if attribute_value not in priorities.keys():
+                                attribute_value = list(priorities.keys())[2]  # default is "executed"
+
+                            if source_id not in linked_attributes.keys():
+                                linked_attributes[source_id] = attribute_value
+                            else:
+                                # store newly encountered attribute value if it has a higher priority
+                                stored_attribute_priority = priorities[linked_attributes[source_id]]
+                                latest_attribute_priority = priorities[attribute_value]
+                                if latest_attribute_priority > stored_attribute_priority:
+                                    linked_attributes[source_id] = attribute_value
+
+        # initialize dictionary and increment counters for each possible value
+        all_states = {}
+        for priority in priorities.keys():
+            all_states[priority] = 0
+        for attribute in linked_attributes.values():
+            all_states[attribute] += 1
+
+        count_total = len(linked_attributes)
+        count_uncovered = all_states[self['label_set'][0]]
+        count_covered = count_total - count_uncovered
+        try:
+            percentage = int(100 * count_covered / count_total)
+        except ZeroDivisionError:
+            percentage = 0
+        disp = 'Statistics: {cover} out of {total} covered: {pct}%'.format(cover=count_covered,
+                                                                           total=count_total,
+                                                                           pct=percentage,)
+
+        # remove items with count value equal to 0
+        all_states = {k: v for k, v in all_states.items() if v}
+        # keep case-sensitivity of :<<attribute>>: arguments in labels of pie chart
+        case_sensitive_priorities = self['priorities']
+        for priority in case_sensitive_priorities:
+            if priority.lower() in all_states.keys():
+                value = all_states.pop(priority.lower())
+                all_states[priority] = value
+        labels = list(all_states.keys())
+
+        sizes = all_states.values()
+        explode = [0.05]  # slightly detaches slice of first state, default is "uncovered"
+        explode.extend([0] * (len(all_states.values()) - 1))
+
+        fig, axes = plt.subplots()
+        axes.pie(sizes, explode=explode, labels=labels, autopct=pct_wrapper(sizes), startangle=90)
+        axes.axis('equal')
+        folder_name = path.join(env.app.srcdir, '_images')
+        if not path.exists(folder_name):
+            mkdir(folder_name)
+        hash_string = ''
+        for pie_slice in axes.__dict__['texts']:
+            hash_string += str(pie_slice)
+        hash_value = sha256(hash_string.encode()).hexdigest()  # create hash value based on chart parameters
+        rel_file_path = path.join('_images', 'piechart-{}.png'.format(hash_value))
+        if rel_file_path not in env.images.keys():
+            fig.savefig(path.join(env.app.srcdir, rel_file_path), format='png')
+            env.images[rel_file_path] = ['_images', path.split(rel_file_path)[-1]]  # store file name in build env
+
+        p_node = nodes.paragraph()
+        p_node += nodes.Text(disp)
+        image_node = nodes.image()
+        image_node['uri'] = rel_file_path
+        image_node['candidates'] = '*'  # look at uri value for source path, relative to the srcdir folder
+        p_node += image_node
+        top_node += p_node
+        self.replace_self(top_node)
+
+
+class ItemPieChartDirective(Directive):
+    """
+    Directive to generate a pie chart for coverage of item cross-references.
+
+    Syntax::
+
+      .. item-piechart:: title
+         :id_set: source_regexp target_regexp (nested_target_regexp)
+         :label_set: uncovered, covered(, executed)
+         :<<attribute>>: error, fail, pass ...
+
+    """
+    # Optional argument: title (whitespace allowed)
+    optional_arguments = 1
+    final_argument_whitespace = True
+    # Options
+    option_spec = {'class': directives.class_option,
+                   'id_set': directives.unchanged,
+                   'label_set': directives.unchanged}
+    # Content disallowed
+    has_content = False
+
+    def run(self):
+        env = self.state.document.settings.env
+
+        item_piechart_node = ItemPieChart(env.docname, self.lineno)
+
+        # Process title (optional argument)
+        if self.arguments:
+            item_piechart_node['title'] = self.arguments[0]
+
+        # Process ``id_set`` option
+        if 'id_set' in self.options and len(self.options['id_set']) >= 2:
+            item_piechart_node['id_set'] = self.options['id_set'].split()
+        else:
+            item_piechart_node['id_set'] = []
+            report_warning(env, 'Traceability: Expected at least two arguments in id_set.', env.docname, self.lineno)
+
+        # Process ``label_set`` option
+        default_labels = ['uncovered', 'covered', 'executed']
+        if 'label_set' in self.options:
+            item_piechart_node['label_set'] = [x.strip(' ') for x in self.options['label_set'].split(',')]
+            if len(item_piechart_node['label_set']) != len(item_piechart_node['id_set']):
+                item_piechart_node['label_set'].extend(
+                    default_labels[len(item_piechart_node['label_set']):len(item_piechart_node['id_set'])])
+        else:
+            id_amount = len(item_piechart_node['id_set'])
+            item_piechart_node['label_set'] = default_labels[:id_amount]  # default labels
+
+        # Add found attribute to item. Attribute data is a comma-separated list of strings
+        item_piechart_node['attribute'] = ''
+        item_piechart_node['priorities'] = []
+        for attr in TraceableItem.defined_attributes.keys():
+            if attr in self.options:
+                if len(item_piechart_node['id_set']) == 3:
+                    item_piechart_node['attribute'] = attr
+                    item_piechart_node['priorities'] = [x.strip(' ') for x in self.options[attr].split(',')]
+                else:
+                    report_warning(env,
+                                   'Traceability: The <<attribute>> option is only viable with an id_set with 3 '
+                                   'arguments.',
+                                   env.docname,
+                                   self.lineno,)
+                break
+
+        return [item_piechart_node]

--- a/mlx/directives/item_tree_directive.py
+++ b/mlx/directives/item_tree_directive.py
@@ -1,0 +1,128 @@
+from docutils import nodes
+from docutils.parsers.rst import Directive, directives
+from sphinx.builders.latex import LaTeXBuilder
+
+from mlx.traceability import report_warning
+from mlx.traceability_item_element import ItemElement
+from mlx.traceable_item import TraceableItem
+
+
+class ItemTree(ItemElement):
+    '''Tree-view on documentation items'''
+
+    def perform_traceability_replacement(self, app, collection):
+        """ Performs the node replacement.
+
+        Args:
+            app: Sphinx application object to use.
+            collection (TraceableCollection): Collection for which to generate the nodes.
+        """
+        env = app.builder.env
+        top_item_ids = env.traceability_collection.get_items(self['top'], self['filter-attributes'])
+        showcaptions = not self['nocaptions']
+        top_node = self.create_top_node(self['title'])
+        if isinstance(app.builder, LaTeXBuilder):
+            p_node = nodes.paragraph()
+            p_node.append(nodes.Text('Item tree is not supported in latex builder'))
+            top_node.append(p_node)
+        else:
+            ul_node = nodes.bullet_list()
+            ul_node.set_class('bonsai')
+            for i in top_item_ids:
+                if self.is_item_top_level(env, i):
+                    ul_node.append(self.generate_bullet_list_tree(app, env, i, showcaptions))
+            top_node += ul_node
+        self.replace_self(top_node)
+
+
+class ItemTreeDirective(Directive):
+    """
+    Directive to generate a treeview of items, based on
+    a given set of relationship types.
+
+    Syntax::
+
+      .. item-tree:: title
+         :top: regexp
+         :top_relation_filter: <<relationship>> ...
+         :<<attribute>>: regexp
+         :type: <<relationship>> ...
+         :nocaptions:
+
+    """
+    # Optional argument: title (whitespace allowed)
+    optional_arguments = 1
+    final_argument_whitespace = True
+    # Options
+    option_spec = {'class': directives.class_option,
+                   'top': directives.unchanged,
+                   'top_relation_filter': directives.unchanged,
+                   'type': directives.unchanged,
+                   'nocaptions': directives.flag}
+    # Content disallowed
+    has_content = False
+
+    def run(self):
+        env = self.state.document.settings.env
+        app = env.app
+
+        item_tree_node = ItemTree(env.docname, self.lineno)
+
+        # Process title (optional argument)
+        if self.arguments:
+            item_tree_node['title'] = self.arguments[0]
+        else:
+            item_tree_node['title'] = 'Tree of items'
+
+        # Process ``top`` option
+        if 'top' in self.options:
+            item_tree_node['top'] = self.options['top']
+        else:
+            item_tree_node['top'] = ''
+
+        # Process ``top_relation_filter`` option, given as a string with relationship types
+        # separated by space. It is converted to a list.
+        if 'top_relation_filter' in self.options:
+            item_tree_node['top_relation_filter'] = self.options['top_relation_filter'].split()
+        else:
+            item_tree_node['top_relation_filter'] = ''
+
+        # Add found attributes to item. Attribute data is a single string.
+        item_tree_node['filter-attributes'] = {}
+        for attr in TraceableItem.defined_attributes.keys():
+            if attr in self.options:
+                item_tree_node['filter-attributes'][attr] = self.options[attr]
+
+        # Check if given relationships are in configuration
+        for rel in item_tree_node['top_relation_filter']:
+            if rel not in env.traceability_collection.iter_relations():
+                report_warning(env, 'Traceability: unknown relation for item-tree: %s' % rel, env.docname, self.lineno)
+
+        # Process ``type`` option, given as a string with relationship types
+        # separated by space. It is converted to a list.
+        if 'type' in self.options:
+            item_tree_node['type'] = self.options['type'].split()
+        else:
+            item_tree_node['type'] = []
+
+        # Check if given relationships are in configuration
+        # Combination of forward + matching reverse relationship cannot be in the same list, as it will give
+        # endless treeview (and endless recursion in python --> exception)
+        for rel in item_tree_node['type']:
+            if rel not in env.traceability_collection.iter_relations():
+                report_warning(env, 'Traceability: unknown relation for item-tree: %s' % rel, env.docname, self.lineno)
+                continue
+            if env.traceability_collection.get_reverse_relation(rel) in item_tree_node['type']:
+                report_warning(env, 'Traceability: combination of forward+reverse relations for item-tree: %s' % rel,
+                               env.docname, self.lineno)
+                raise ValueError('Traceability: combination of forward+reverse relations for item-tree: %s' % rel)
+
+        # Check nocaptions flag
+        if 'nocaptions' in self.options:
+            item_tree_node['nocaptions'] = True
+        elif app.config.traceability_tree_no_captions:
+            item_tree_node['nocaptions'] = True
+        else:
+            item_tree_node['nocaptions'] = False
+
+        return [item_tree_node]

--- a/mlx/directives/item_tree_directive.py
+++ b/mlx/directives/item_tree_directive.py
@@ -17,8 +17,7 @@ class ItemTree(ItemElement):
             app: Sphinx application object to use.
             collection (TraceableCollection): Collection for which to generate the nodes.
         """
-        env = app.builder.env
-        top_item_ids = env.traceability_collection.get_items(self['top'], self['filter-attributes'])
+        top_item_ids = collection.get_items(self['top'], self['filter-attributes'])
         showcaptions = not self['nocaptions']
         top_node = self.create_top_node(self['title'])
         if isinstance(app.builder, LaTeXBuilder):
@@ -29,8 +28,8 @@ class ItemTree(ItemElement):
             ul_node = nodes.bullet_list()
             ul_node.set_class('bonsai')
             for i in top_item_ids:
-                if self.is_item_top_level(env, i):
-                    ul_node.append(self.generate_bullet_list_tree(app, env, i, showcaptions))
+                if self.is_item_top_level(app.env, i):
+                    ul_node.append(self.generate_bullet_list_tree(app, collection, i, showcaptions))
             top_node += ul_node
         self.replace_self(top_node)
 
@@ -66,7 +65,9 @@ class ItemTreeDirective(Directive):
         env = self.state.document.settings.env
         app = env.app
 
-        item_tree_node = ItemTree(env.docname, self.lineno)
+        item_tree_node = ItemTree('')
+        item_tree_node['document'] = env.docname
+        item_tree_node['line'] = self.lineno
 
         # Process title (optional argument)
         if self.arguments:

--- a/mlx/traceability.py
+++ b/mlx/traceability.py
@@ -115,9 +115,9 @@ class PendingItemXref(nodes.Inline, nodes.Element):
                                 self['reftarget'] + '??')
         # If target exists, try to create the reference
         item_info = collection.get_item(self['reftarget'])
-        docname, lineno = get_source_line(self)
         if item_info:
             if item_info.is_placeholder():
+                docname, lineno = get_source_line(self)
                 report_warning(env, 'Traceability: cannot link to %s, item is not defined' % item_info.get_id(),
                                docname, lineno)
             else:
@@ -132,6 +132,7 @@ class PendingItemXref(nodes.Inline, nodes.Element):
                     # ignore if no URI can be determined, e.g. for LaTeX output :(
                     pass
         else:
+            docname, lineno = get_source_line(self)
             report_warning(env, 'Traceability: item %s not found' % self['reftarget'],
                            docname, lineno)
         self.replace_self(new_node)

--- a/mlx/traceability_exception.py
+++ b/mlx/traceability_exception.py
@@ -1,6 +1,28 @@
 '''
 Exception classes for traceability
 '''
+from sphinx import __version__ as sphinx_version
+if sphinx_version >= '1.6.0':
+    from sphinx.util.logging import getLogger
+
+
+def report_warning(env, msg, docname=None, lineno=None):
+    '''Convenience function for logging a warning
+
+    Args:
+        msg (any __str__): Message of the warning, gets converted to str
+        docname (str): Name of the document on which the error occured
+        lineno (int): Line number in the document on which the error occured
+    '''
+    msg = str(msg)
+    if sphinx_version >= '1.6.0':
+        logger = getLogger(__name__)
+        if lineno is not None:
+            logger.warning(msg, location=(docname, str(lineno)))
+        else:
+            logger.warning(msg, location=docname)
+    else:
+        env.warn(docname, msg, lineno=lineno)
 
 
 class MultipleTraceabilityExceptions(Exception):

--- a/mlx/traceability_item_element.py
+++ b/mlx/traceability_item_element.py
@@ -1,0 +1,214 @@
+import re
+from abc import abstractmethod
+
+from docutils import nodes
+from sphinx.environment import NoUri
+
+from mlx.traceability_exception import report_warning
+from mlx.traceable_item import TraceableItem
+
+# External relationship: starts with ext_
+# An external relationship is a relationship where the item to link to is not in the
+# traceability system, but on an external tool. Translating the link to a clickable
+# hyperlink is done through the config traceability_external_relationship_to_url.
+REGEXP_EXTERNAL_RELATIONSHIP = re.compile('^ext_.*')
+EXTERNAL_LINK_FIELDNAME = 'field'
+
+
+class ItemElement(nodes.General, nodes.Element):
+
+    def __init__(self, docname, line, *args, **kwargs):
+        """ Constructor of the ItemElement class.
+
+        Args:
+            docname (str): Name of the document where the node was found.
+            line (int): Number of the line where the node was found.
+        """
+        super(ItemElement, self).__init__(*args, **kwargs)
+        self.docname = docname
+        self.line = line
+
+    @staticmethod
+    def create_top_node(title):
+        '''
+        Create the top node for the Element node
+        An admonition object with given title is created and returns
+        Args:
+            - title (str): Title of the top node
+        Returns: Top level replacement node to which other nodes can be appended
+        '''
+        top_node = nodes.container()
+        admon_node = nodes.admonition()
+        title_node = nodes.title()
+        title_node += nodes.Text(title)
+        admon_node += title_node
+        top_node += admon_node
+        return top_node
+
+    @abstractmethod
+    def perform_traceability_replacement(self, app, collection):
+        """ Performs the node replacement.
+
+        Args:
+            app: Sphinx application object to use.
+            collection (TraceableCollection): Collection for which to generate the nodes.
+        """
+
+    def make_internal_item_ref(self, app, item_id, caption=True):
+        """
+        Creates a reference node for an item, embedded in a
+        paragraph. Reference text adds also a caption if it exists.
+        """
+        env = app.builder.env
+        item_info = env.traceability_collection.get_item(item_id)
+
+        p_node = nodes.paragraph()
+
+        # Only create link when target item exists, warn otherwise (in html and terminal)
+        if item_info.is_placeholder():
+            report_warning(env, 'Traceability: cannot link to %s, item is not defined' % item_id,
+                           self.docname, self.line)
+            txt = nodes.Text('%s not defined, broken link' % item_id)
+            p_node.append(txt)
+        else:
+            if item_info.caption != '' and caption:
+                caption = ' : {}'.format(item_info.caption)
+            else:
+                caption = ''
+
+            newnode = nodes.reference('', '')
+            innernode = nodes.emphasis(item_id + caption, item_id + caption)
+            newnode['refdocname'] = item_info.docname
+            try:
+                newnode['refuri'] = app.builder.get_relative_uri(self.docname, item_info.docname)
+                newnode['refuri'] += '#' + item_id
+            except NoUri:
+                # ignore if no URI can be determined, e.g. for LaTeX output :(
+                pass
+            # change text color if item_id matches a regex in traceability_hyperlink_colors
+            colors = self.find_colors_for_class(app.config.traceability_hyperlink_colors, item_id)
+            if colors:
+                class_name = app.config.class_names[colors]
+                newnode['classes'].append(class_name)
+            newnode.append(innernode)
+            p_node += newnode
+
+        return p_node
+
+    def generate_bullet_list_tree(self, app, env, item_id, captions=True):
+        '''
+        Generates a bullet list tree for the given item ID.
+
+        This function returns the given item ID as a bullet item node, makes a child bulleted list, and adds all
+        of the matching child items to it.
+        '''
+        # First add current item_id
+        bullet_list_item = nodes.list_item()
+        bullet_list_item['id'] = nodes.make_id(item_id)
+        p_node = nodes.paragraph()
+        p_node.set_class('thumb')
+        bullet_list_item.append(p_node)
+        bullet_list_item.append(self.make_internal_item_ref(app, item_id, captions))
+        bullet_list_item.set_class('has-children')
+        bullet_list_item.set_class('collapsed')
+        childcontent = nodes.bullet_list()
+        childcontent.set_class('bonsai')
+        # Then recurse one level, and add dependencies
+        for relation in self['type']:
+            tgts = env.traceability_collection.get_item(item_id).iter_targets(relation)
+            for target in tgts:
+                # print('%s has child %s for relation %s' % (item_id, target, relation))
+                if env.traceability_collection.get_item(target).attributes_match(self['filter-attributes']):
+                    childcontent.append(self.generate_bullet_list_tree(app, env, target, captions))
+        bullet_list_item.append(childcontent)
+        return bullet_list_item
+
+    @staticmethod
+    def make_external_item_ref(app, targettext, relationship):
+        '''Generates a reference to an external item.'''
+        if relationship not in app.config.traceability_external_relationship_to_url:
+            return
+        p_node = nodes.paragraph()
+        link = nodes.reference()
+        txt = nodes.Text(targettext)
+        tgt_strs = targettext.split(':')  # syntax = field1:field2:field3:...
+        url = app.config.traceability_external_relationship_to_url[relationship]
+        cnt = 0
+        for tgt_str in tgt_strs:
+            cnt += 1
+            url = url.replace(EXTERNAL_LINK_FIELDNAME + str(cnt), tgt_str)
+        link['refuri'] = url
+        link.append(txt)
+        targetid = nodes.make_id(targettext)
+        target = nodes.target('', '', ids=[targetid])
+        p_node += target
+        p_node += link
+        return p_node
+
+    def is_item_top_level(self, env, item_id):
+        '''
+        Checks if item with given item ID is a top level item.
+
+        True, if the item is a top level item:
+
+        - given relation does not exist for given item,
+        - or given relation exists, but targets don't match the 'top' regexp.
+
+        False, otherwise.
+        '''
+        item = env.traceability_collection.get_item(item_id)
+        for relation in self['top_relation_filter']:
+            tgts = item.iter_targets(relation)
+            for tgt in tgts:
+                if re.match(self['top'], tgt):
+                    return False
+        return True
+
+    def make_attribute_ref(self, app, attr_id, value=''):
+        """
+        Creates a reference node for an attribute, embedded in a paragraph.
+        """
+        p_node = nodes.paragraph()
+
+        if value:
+            value = ': ' + value
+
+        if attr_id in TraceableItem.defined_attributes.keys():
+            attr_info = TraceableItem.defined_attributes[attr_id]
+            attr_name = attr_info.get_name()
+            if attr_info.docname:
+                newnode = nodes.reference('', '')
+                innernode = nodes.emphasis(attr_name + value, attr_name + value)
+                newnode['refdocname'] = attr_info.docname
+                try:
+                    newnode['refuri'] = app.builder.get_relative_uri(self.docname, attr_info.docname)
+                    newnode['refuri'] += '#' + attr_info.get_name()
+                except NoUri:
+                    # ignore if no URI can be determined, e.g. for LaTeX output :(
+                    pass
+                newnode.append(innernode)
+            else:
+                newnode = nodes.Text('{attr}{value}'.format(attr=attr_info.get_name(), value=value))
+        else:
+            newnode = nodes.Text('{attr}{value}'.format(attr=attr_id, value=value))
+        p_node += newnode
+
+        return p_node
+
+    @staticmethod
+    def find_colors_for_class(hyperlink_colors, item_id):
+        """
+        Returns CSS class identifier to change a node's text color if the item ID matches a regexp in hyperlink_colors.
+        The regexp of the first item in the ordered dictionary has the highest priority.
+
+        Args:
+            hyperlink_colors (OrderedDict): Ordered dict with regex strings as keys and list/tuple of strings as values.
+            item_id (str): A traceability item ID.
+        Returns:
+            (tuple) Tuple of color strings that should be used to color the given item ID or None if no match was found.
+        """
+        for regex, colors in hyperlink_colors.items():
+            colors = tuple(colors)
+            if re.search(regex, item_id):
+                return tuple(colors)
+        return None

--- a/mlx/traceable_collection.py
+++ b/mlx/traceable_collection.py
@@ -109,36 +109,36 @@ class TraceableCollection(object):
         '''
         return itemid in self.items
 
-    def add_relation(self, sourceid, relation, targetid):
+    def add_relation(self, source_id, relation, target_id):
         '''
         Add relation between two items
 
         The function adds the forward and the automatic reverse relation.
 
         Args:
-            sourceid (str): ID of the source item
+            source_id (str): ID of the source item
             relation (str): Relation between source and target item
-            targetid (str): ID of the target item
+            target_id (str): ID of the target item
         '''
         # Add placeholder if source item is unknown
-        if sourceid not in self.items:
-            src = TraceableItem(sourceid, True)
+        if source_id not in self.items:
+            src = TraceableItem(source_id, True)
             self.add_item(src)
-        source = self.items[sourceid]
+        source = self.items[source_id]
         # Error if relation is unknown
         if relation not in self.relations:
             raise TraceabilityException('Relation {name} not known'.format(name=relation), source.get_document())
         # Add forward relation
-        source.add_target(relation, targetid)
+        source.add_target(relation, target_id)
         # When reverse relation exists, continue to create/adapt target-item
         reverse_relation = self.get_reverse_relation(relation)
         if reverse_relation:
             # Add placeholder if target item is unknown
-            if targetid not in self.items:
-                tgt = TraceableItem(targetid, True)
+            if target_id not in self.items:
+                tgt = TraceableItem(target_id, True)
                 self.add_item(tgt)
             # Add reverse relation to target-item
-            self.items[targetid].add_target(reverse_relation, sourceid, implicit=True)
+            self.items[target_id].add_target(reverse_relation, source_id, implicit=True)
 
     def export(self, fname):
         '''
@@ -214,32 +214,32 @@ class TraceableCollection(object):
             retval += str(self.items[itemid])
         return retval
 
-    def are_related(self, sourceid, relations, targetid):
+    def are_related(self, source_id, relations, target_id):
         '''
         Check if 2 items are related using a list of relationships
 
         Placeholders are excluded
 
         Args:
-            - sourceid (str): id of the source item
+            - source_id (str): id of the source item
             - relations (list): list of relations, empty list for wildcard
-            - targetid (str): id of the target item
+            - target_id (str): id of the target item
         Returns:
             (boolean) True if both items are related through the given relationships, false otherwise
         '''
-        if sourceid not in self.items:
+        if source_id not in self.items:
             return False
-        source = self.items[sourceid]
+        source = self.items[source_id]
         if not source or source.is_placeholder():
             return False
-        if targetid not in self.items:
+        if target_id not in self.items:
             return False
-        target = self.items[targetid]
+        target = self.items[target_id]
         if not target or target.is_placeholder():
             return False
         if not relations:
             relations = self.iter_relations()
-        return self.items[sourceid].is_related(relations, targetid)
+        return self.items[source_id].is_related(relations, target_id)
 
     def get_items(self, regex, attributes={}, sortattributes=None, reverse=False):
         '''


### PR DESCRIPTION
- Split off each directive with its node class into a separate file
- Created `ItemElement` parent class for custom node classes and moved utility functions inside this parent class
- Moved `report_warning()` to `traceability_exception.py`

Closes #51 