### PR TITLE
More refactoring

### DIFF
--- a/mlx/directives/item_2d_matrix_directive.py
+++ b/mlx/directives/item_2d_matrix_directive.py
@@ -8,7 +8,7 @@ from mlx.traceable_item import TraceableItem
 class Item2DMatrix(ItemElement):
     '''Matrix for cross referencing documentation items in 2 dimensions'''
 
-    def perform_traceability_replacement(self, app, collection):
+    def perform_replacement(self, app, collection):
         """
         Creates table with related items, printing their target references. Only source and target items matching
         respective regexp shall be included.

--- a/mlx/directives/item_attribute_directive.py
+++ b/mlx/directives/item_attribute_directive.py
@@ -10,7 +10,7 @@ from mlx.traceable_item import TraceableItem
 class ItemAttribute(ItemElement):
     '''Attribute to documentation item'''
 
-    def perform_traceability_replacement(self, app, collection):
+    def perform_replacement(self, app, collection):
         """
         Perform the node replacement
         Args:

--- a/mlx/directives/item_attributes_matrix_directive.py
+++ b/mlx/directives/item_attributes_matrix_directive.py
@@ -8,7 +8,7 @@ from mlx.traceable_item import TraceableItem
 class ItemAttributesMatrix(ItemElement):
     '''Matrix for referencing documentation items with their attributes'''
 
-    def perform_traceability_replacement(self, app, collection):
+    def perform_replacement(self, app, collection):
         """ Creates table with items, printing their attribute values.
 
         Args:

--- a/mlx/directives/item_directive.py
+++ b/mlx/directives/item_directive.py
@@ -8,7 +8,7 @@ from mlx.traceable_item import TraceableItem
 class Item(ItemElement):
     '''Documentation item'''
 
-    def perform_traceability_replacement(self, app, collection):
+    def perform_replacement(self, app, collection):
         """
         Perform the node replacement
         Args:

--- a/mlx/directives/item_link_directive.py
+++ b/mlx/directives/item_link_directive.py
@@ -7,7 +7,7 @@ from mlx.traceability_item_element import ItemElement
 class ItemLink(ItemElement):
     '''List of documentation items'''
 
-    def perform_traceability_replacement(self, app, collection):
+    def perform_replacement(self, app, collection):
         """ Processes the item-link items. The ItemLink node has no final representation, so is removed from the tree.
 
         Args:

--- a/mlx/directives/item_list_directive.py
+++ b/mlx/directives/item_list_directive.py
@@ -7,7 +7,7 @@ from mlx.traceable_item import TraceableItem
 class ItemList(ItemElement):
     '''List of documentation items'''
 
-    def perform_traceability_replacement(self, app, collection):
+    def perform_replacement(self, app, collection):
         """ Create list with target references. Only items matching list regexp shall be included.
 
         Args:

--- a/mlx/directives/item_matrix_directive.py
+++ b/mlx/directives/item_matrix_directive.py
@@ -8,7 +8,7 @@ from mlx.traceable_item import TraceableItem
 class ItemMatrix(ItemElement):
     '''Matrix for cross referencing documentation items'''
 
-    def perform_traceability_replacement(self, app, collection):
+    def perform_replacement(self, app, collection):
         """
         Creates table with related items, printing their target references. Only source and target items matching
         respective regexp shall be included.

--- a/mlx/directives/item_pie_chart_directive.py
+++ b/mlx/directives/item_pie_chart_directive.py
@@ -28,7 +28,7 @@ def pct_wrapper(sizes):
 class ItemPieChart(ItemElement):
     '''Pie chart on documentation items'''
 
-    def perform_traceability_replacement(self, app, collection):
+    def perform_replacement(self, app, collection):
         """
         Very similar to item-matrix: but instead of creating a table, the empty cells in the right column are counted.
         Generates a pie chart with coverage percentages. Only items matching regexp in ``id_set`` option shall be

--- a/mlx/directives/item_tree_directive.py
+++ b/mlx/directives/item_tree_directive.py
@@ -10,7 +10,7 @@ from mlx.traceable_item import TraceableItem
 class ItemTree(ItemElement):
     '''Tree-view on documentation items'''
 
-    def perform_traceability_replacement(self, app, collection):
+    def perform_replacement(self, app, collection):
         """ Performs the node replacement.
 
         Args:

--- a/mlx/traceability_item_element.py
+++ b/mlx/traceability_item_element.py
@@ -35,7 +35,7 @@ class ItemElement(nodes.General, nodes.Element):
         return top_node
 
     @abstractmethod
-    def perform_traceability_replacement(self, app, collection):
+    def perform_replacement(self, app, collection):
         """ Performs the traceability node replacement.
 
         Args:
@@ -54,9 +54,7 @@ class ItemElement(nodes.General, nodes.Element):
         p_node = nodes.paragraph()
 
         # Only create link when target item exists, warn otherwise (in html and terminal)
-        if item_info.is_placeholder():
-            report_warning(env, 'Traceability: cannot link to %s, item is not defined' % item_id,
-                           self['document'], self.line)
+        if self.has_warned_about_undefined(item_info, env):
             txt = nodes.Text('%s not defined, broken link' % item_id)
             p_node.append(txt)
         else:
@@ -201,3 +199,17 @@ class ItemElement(nodes.General, nodes.Element):
             if re.search(regex, item_id):
                 return tuple(colors)
         return None
+
+    def has_warned_about_undefined(self, item_info, env):
+        """
+        Reports a warning if the given node is a placeholder node. Returns True if this is the case, False otherwise.
+
+        Args:
+            item_info (TraceableItem): TraceableItem object.
+            env (sphinx.environment.BuildEnvironment): Sphinx' build environment.
+        """
+        if item_info.is_placeholder():
+            report_warning(env, 'Traceability: cannot link to %s, item is not defined' % item_info.get_id(),
+                           self['document'], self['line'])
+            return True
+        return False


### PR DESCRIPTION
- Add line number to warning about target item being undefined (closes #2)
- Make `PendingItemXref` inherit from `ItemElement` (like all other node classes do)
- Pylint fix: shorten `perform_traceability_replacement` to `perform_replacement`