### PR TITLE
Refactor perform_replacement in ItemPieChart

### DIFF
--- a/mlx/directives/item_pie_chart_directive.py
+++ b/mlx/directives/item_pie_chart_directive.py
@@ -202,7 +202,7 @@ class ItemPieChart(ItemElement):
         sizes = list(chart_labels.values())
         explode = [0] * len(labels)
         uncoverd_index = labels.index(self['label_set'][0])
-        explode[uncoverd_index] = 0.05
+        explode[uncoverd_index] = 0.05  # slightly detaches slice of first state, default is "uncovered"
 
         fig, axes = plt.subplots()
         axes.pie(sizes, explode=explode, labels=labels, autopct=pct_wrapper(sizes), startangle=90)


### PR DESCRIPTION
Refactored `perform_replacement` in `ItemPieChart`, which used a deeply nested structure, by using `loop_relationships` recursively.
I also fixed several occurences where the order of dictionary keys was used, while a dictionary's order isn't always deterministic.