### PR TITLE
Only use the sonar-python complexity check

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -9,9 +9,6 @@ checks:
   file-lines:
     config:
       threshold: 500
-  method-complexity:
-    config:
-      threshold: 7
   method-count:
     config:
       threshold: 25

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -9,6 +9,8 @@ checks:
   file-lines:
     config:
       threshold: 500
+  method-complexity:
+    enabled: false
   method-count:
     config:
       threshold: 25

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -9,6 +9,9 @@ checks:
   file-lines:
     config:
       threshold: 500
+  method-complexity:
+    config:
+      threshold: 7
   method-count:
     config:
       threshold: 25


### PR DESCRIPTION
Only use the sonar-python complexity check by removing the code climate complexity check.