### PR TITLE
Update class diagram

### DIFF
--- a/doc/design.rst
+++ b/doc/design.rst
@@ -19,12 +19,243 @@ Design for mlx.traceability
     .. uml::
         :align: center
 
+        @startuml
+        class TraceableBaseClass {
+            + str id
+            + str name
+            + str caption
+            + str docname
+            + int lineno
+            + docutils.nodes.Node node
+            + str content
+
+            + __init__(name)
+            + update(other)
+            + to_dict()
+            + self_test()
+        }
+
+        class TraceableItem {
+            + dict explicit_relations
+            + dict implicit_relations
+            + dict attributes
+            # bool placeholder
+
+            + __init__(item_id, placeholder=False)
+            + __str__(explicit=True, implicit=True)
+            + is_placeholder()
+            + add_target(relation, target, implicit=False)
+            + remove_targets(target_id, explicit=False, implicit=True)
+            + iter_targets(relation, explicit=True, implicit=True)
+            + iter_relations()
+            + define_attribute(attr)
+            + add_attribute(attr, value, overwrite=True)
+            + remove_attribute(attr)
+            + get_attribute(attr)
+            + get_attributes(attrs)
+            + iter_attributes()
+            + is_match(regex)
+            + attributes_match(attributes)
+            + is_related(relations, target_id)
+        }
+
+        class TraceableAttribute {
+            + str value
+
+            + __init__(attr_id, value)
+            + can_accept(value)
+        }
+
+        class TraceableCollection {
+            + dict relations
+            + dict items
+
+            + __init__()
+            + __str__()
+            + add_relation_pair(forward, reverse='')
+            + get_reverse_relation(forward)
+            + iter_relations()
+            + add_item(item)
+            + get_item(item_id)
+            + iter_items()
+            + has_item(item_id)
+            + add_relation(source_id, relation, target_id)
+            + export(f_name)
+            + self_test(docname=None)
+            + are_related(source_id, relations, target_id)
+            + get_items(regex, attributes={}, sortattributes=None, reverse=False)
+        }
+
+        abstract class TraceableBaseDirective {
+            + {static} final_argument_whitespace = True
+
+            + {abstract} run()
+            + get_caption()
+            + add_found_attributes(node)
+            + remove_unknown_attributes(attributes, description, env)
+            + check_relationships(relationships, env)
+            + check_no_captions_flag(node, no_captions_config)
+            + process_options(node, options)
+        }
+
+        class Item2DMatrixDirective {
+            + {static} optional_arguments = 1
+            + {static} dict option_spec
+            + {static} has_content = False
+        }
+
+        class ItemAttributeDirective {
+            + {static} required_arguments = 1
+            + {static} optional_arguments = 1
+            + {static} has_content = True
+        }
+
+        class ItemAttributesMatrixDirective {
+            + {static} optional_arguments = 1
+            + {static} dict option_spec
+            + {static} has_content = False
+        }
+
+        class ItemDirective {
+            + {static} required_arguments = 1
+            + {static} optional_arguments = 1
+            + {static} dict option_spec
+            + {static} has_content = True
+
+            # store_item_info(target_id, env)
+            # add_relation_to_ids(relation, source_id, related_ids, env)
+            # add_attributes(item, env)
+        }
+
+        class ItemLinkDirective {
+            + {static} dict option_spec
+            + {static} has_content = False
+        }
+
+        class ItemListDirective {
+            + {static} optional_arguments = 1
+            + {static} dict option_spec
+            + {static} has_content = False
+        }
+
+        class ItemMatrixDirective {
+            + {static} optional_arguments = 1
+            + {static} dict option_spec
+            + {static} has_content = False
+        }
+
+        class ItemPieChartDirective {
+            + {static} optional_arguments = 1
+            + {static} dict option_spec
+            + {static} has_content = False
+
+            # process_id_set(node, env)
+            # process_label_set(node)
+            # process_attribute(node, env)
+        }
+
+        class ItemTreeDirective {
+            + {static} optional_arguments = 1
+            + {static} dict option_spec
+            + {static} has_content = False
+        }
+
+        abstract class TraceableBaseNode {
+            + {abstract} perform_replacement(app, collection)
+            + {static} create_top_node(title)
+            + make_internal_item_ref(app, item_id, caption=True)
+            + {static} make_external_item_ref(app, target_text, relationship)
+            + is_item_top_level(env, item_id)
+            + make_attribute_ref(app, attr_id, value='')
+            + has_warned_about_undefined(item_info, env)
+            # {static} find_colors_for_class(hyperlink_colors, item_id)
+        }
+
+        class Item2DMatrix {
+        }
+
+        class ItemAttribute {
+        }
+
+        class ItemAttributesMatrix {
+        }
+
+        class Item {
+            # {static} item = None
+
+            # process_attributes(dl_node, app)
+            # process_relationships(collection, *args)
+            # list_targets_for_relation(relation, targets, dl_node, app)
+        }
+
+        class ItemLink {
+        }
+
+        class ItemList {
+        }
+
+        class ItemMatrix {
+        }
+
+        class ItemPieChart {
+            + {static} collection = None
+            + {static} relationships = []
+            + {static} priorities = {}
+            + {static} attribute_id = ''
+            + {static} linked_attributes = {}
+
+            + loop_relationships(top_source_id, source_item, pattern, match_function)
+            + build_pie_chart(chart_labels, env)
+            # set_priorities()
+            # set_attribute_id()
+            # match_covered(top_source_id, nested_source_item)
+            # match_attribute_values(top_source_id, nested_target_item)
+            # prepare_labels_and_values(lower_labels, attributes)
+            # {static} get_statistics(count_uncovered, count_total)
+        }
+
+        class ItemTree {
+            # generate_bullet_list_tree(app, collection, item_id, captions=True)
+        }
+
+        class PendingItemXref {
+        }
+
         TraceableBaseClass <|-- TraceableItem
         TraceableBaseClass <|-- TraceableAttribute
         TraceableItem "1" *-- "N" TraceableAttribute
         TraceableCollection "1" *-- "N" TraceableItem
+        TraceableBaseDirective <|-- Item2DMatrixDirective
+        TraceableBaseDirective <|-- ItemAttributeDirective
+        TraceableBaseDirective <|-- ItemAttributesMatrixDirective
+        TraceableBaseDirective <|-- ItemDirective
+        TraceableBaseDirective <|-- ItemLinkDirective
+        TraceableBaseDirective <|-- ItemListDirective
+        TraceableBaseDirective <|-- ItemMatrixDirective
+        TraceableBaseDirective <|-- ItemPieChartDirective
+        TraceableBaseDirective <|-- ItemTreeDirective
+        TraceableBaseNode <|-- Item2DMatrix
+        TraceableBaseNode <|-- ItemAttribute
+        TraceableBaseNode <|-- ItemAttributesMatrix
+        TraceableBaseNode <|-- Item
+        TraceableBaseNode <|-- ItemLink
+        TraceableBaseNode <|-- ItemList
+        TraceableBaseNode <|-- ItemMatrix
+        TraceableBaseNode <|-- ItemPieChart
+        TraceableBaseNode <|-- ItemTree
+        TraceableBaseNode <|-- PendingItemXref
+        Item2DMatrixDirective "1" *-- "1" Item2DMatrix
+        ItemAttributeDirective "1" *-- "1" ItemAttribute
+        ItemAttributesMatrixDirective "1" *-- "1" ItemAttributesMatrix
+        ItemDirective "1" *-- "1" Item
+        ItemLinkDirective "1" *-- "1" ItemLink
+        ItemListDirective "1" *-- "1" ItemList
+        ItemMatrixDirective "1" *-- "1" ItemMatrix
+        ItemPieChartDirective "1" *-- "1" ItemPieChart
+        ItemTreeDirective "1" *-- "1" ItemTree
         Exception <|-- TraceabilityException
         Exception <|-- MultipleTraceabilityExceptions
+        @enduml
 
 .. item:: DESIGN-ITEMIZE Allow splitting the documentation in parts
     :depends_on: DESIGN-TRACEABILITY
@@ -141,4 +372,3 @@ Implementation coverage
     :targettitle: Implementation
     :nocaptions:
     :stats:
-

--- a/doc/design.rst
+++ b/doc/design.rst
@@ -223,8 +223,10 @@ Design for mlx.traceability
 
         TraceableBaseClass <|-- TraceableItem
         TraceableBaseClass <|-- TraceableAttribute
-        TraceableItem "1" *-- "N" TraceableAttribute
-        TraceableCollection "1" *-- "N" TraceableItem
+        TraceableItem "1" o-- "N" TraceableAttribute
+        TraceableCollection "1" o-- "N" TraceableItem
+        sphinx.environment.BuildEnvironment "1" o-- "1" TraceableCollection
+        docutils.parsers.rst.Directive <|-- TraceableBaseDirective
         TraceableBaseDirective <|-- Item2DMatrixDirective
         TraceableBaseDirective <|-- ItemAttributeDirective
         TraceableBaseDirective <|-- ItemAttributesMatrixDirective
@@ -234,6 +236,8 @@ Design for mlx.traceability
         TraceableBaseDirective <|-- ItemMatrixDirective
         TraceableBaseDirective <|-- ItemPieChartDirective
         TraceableBaseDirective <|-- ItemTreeDirective
+        TraceableBaseNode <|-- docutils.nodes.General
+        TraceableBaseNode <|-- docutils.nodes.Element
         TraceableBaseNode <|-- Item2DMatrix
         TraceableBaseNode <|-- ItemAttribute
         TraceableBaseNode <|-- ItemAttributesMatrix

--- a/mlx/directives/item_2d_matrix_directive.py
+++ b/mlx/directives/item_2d_matrix_directive.py
@@ -1,11 +1,11 @@
 from docutils import nodes
 from docutils.parsers.rst import directives
 
-from mlx.traceability_item_element import ItemElement
-from mlx.traceable_base_directive import BaseDirective
+from mlx.traceable_base_directive import TraceableBaseDirective
+from mlx.traceable_base_node import TraceableBaseNode
 
 
-class Item2DMatrix(ItemElement):
+class Item2DMatrix(TraceableBaseNode):
     '''Matrix for cross referencing documentation items in 2 dimensions'''
 
     def perform_replacement(self, app, collection):
@@ -55,7 +55,7 @@ class Item2DMatrix(ItemElement):
         self.replace_self(top_node)
 
 
-class Item2DMatrixDirective(BaseDirective):
+class Item2DMatrixDirective(TraceableBaseDirective):
     """
     Directive to generate a 2D-matrix of item cross-references, based on
     a given set of relationship types.
@@ -71,7 +71,6 @@ class Item2DMatrixDirective(BaseDirective):
     """
     # Optional argument: title (whitespace allowed)
     optional_arguments = 1
-    final_argument_whitespace = True
     # Options
     option_spec = {'class': directives.class_option,
                    'target': directives.unchanged,

--- a/mlx/directives/item_attribute_directive.py
+++ b/mlx/directives/item_attribute_directive.py
@@ -1,13 +1,13 @@
 from docutils import nodes
 
 from mlx.traceability import report_warning
-from mlx.traceability_item_element import ItemElement
 from mlx.traceable_attribute import TraceableAttribute
-from mlx.traceable_base_directive import BaseDirective
+from mlx.traceable_base_directive import TraceableBaseDirective
+from mlx.traceable_base_node import TraceableBaseNode
 from mlx.traceable_item import TraceableItem
 
 
-class ItemAttribute(ItemElement):
+class ItemAttribute(TraceableBaseNode):
     '''Attribute to documentation item'''
 
     def perform_replacement(self, app, collection):
@@ -32,7 +32,7 @@ class ItemAttribute(ItemElement):
         self.replace_self(top_node)
 
 
-class ItemAttributeDirective(BaseDirective):
+class ItemAttributeDirective(TraceableBaseDirective):
     """
     Directive to declare attribute for items
 
@@ -47,7 +47,6 @@ class ItemAttributeDirective(BaseDirective):
     required_arguments = 1
     # Optional argument: caption (whitespace allowed)
     optional_arguments = 1
-    final_argument_whitespace = True
     # Content allowed
     has_content = True
 

--- a/mlx/directives/item_attributes_matrix_directive.py
+++ b/mlx/directives/item_attributes_matrix_directive.py
@@ -1,11 +1,11 @@
 from docutils import nodes
 from docutils.parsers.rst import directives
 
-from mlx.traceability_item_element import ItemElement
-from mlx.traceable_base_directive import BaseDirective
+from mlx.traceable_base_directive import TraceableBaseDirective
+from mlx.traceable_base_node import TraceableBaseNode
 
 
-class ItemAttributesMatrix(ItemElement):
+class ItemAttributesMatrix(TraceableBaseNode):
     '''Matrix for referencing documentation items with their attributes'''
 
     def perform_replacement(self, app, collection):
@@ -55,7 +55,7 @@ class ItemAttributesMatrix(ItemElement):
         self.replace_self(top_node)
 
 
-class ItemAttributesMatrixDirective(BaseDirective):
+class ItemAttributesMatrixDirective(TraceableBaseDirective):
     """
     Directive to generate a matrix of items with their attribute values.
 
@@ -71,7 +71,6 @@ class ItemAttributesMatrixDirective(BaseDirective):
     """
     # Optional argument: title (whitespace allowed)
     optional_arguments = 1
-    final_argument_whitespace = True
     # Options
     option_spec = {'class': directives.class_option,
                    'filter': directives.unchanged,

--- a/mlx/directives/item_link_directive.py
+++ b/mlx/directives/item_link_directive.py
@@ -2,11 +2,11 @@ from docutils.parsers.rst import directives
 
 from mlx.traceability import report_warning
 from mlx.traceability_exception import TraceabilityException
-from mlx.traceability_item_element import ItemElement
-from mlx.traceable_base_directive import BaseDirective
+from mlx.traceable_base_directive import TraceableBaseDirective
+from mlx.traceable_base_node import TraceableBaseNode
 
 
-class ItemLink(ItemElement):
+class ItemLink(TraceableBaseNode):
     '''List of documentation items'''
 
     def perform_replacement(self, app, collection):
@@ -19,7 +19,7 @@ class ItemLink(ItemElement):
         self.replace_self([])
 
 
-class ItemLinkDirective(BaseDirective):
+class ItemLinkDirective(TraceableBaseDirective):
     """
     Directive to add additional relations between lists of items.
 
@@ -31,7 +31,6 @@ class ItemLinkDirective(BaseDirective):
          :type: relationship_type
 
     """
-    final_argument_whitespace = True
     # Options
     option_spec = {'sources': directives.unchanged,
                    'targets': directives.unchanged,

--- a/mlx/directives/item_list_directive.py
+++ b/mlx/directives/item_list_directive.py
@@ -1,11 +1,11 @@
 from docutils import nodes
 from docutils.parsers.rst import directives
 
-from mlx.traceability_item_element import ItemElement
-from mlx.traceable_base_directive import BaseDirective
+from mlx.traceable_base_directive import TraceableBaseDirective
+from mlx.traceable_base_node import TraceableBaseNode
 
 
-class ItemList(ItemElement):
+class ItemList(TraceableBaseNode):
     '''List of documentation items'''
 
     def perform_replacement(self, app, collection):
@@ -29,7 +29,7 @@ class ItemList(ItemElement):
         self.replace_self(top_node)
 
 
-class ItemListDirective(BaseDirective):
+class ItemListDirective(TraceableBaseDirective):
     """
     Directive to generate a list of items.
 
@@ -43,7 +43,6 @@ class ItemListDirective(BaseDirective):
     """
     # Optional argument: title (whitespace allowed)
     optional_arguments = 1
-    final_argument_whitespace = True
     # Options
     option_spec = {'class': directives.class_option,
                    'filter': directives.unchanged,

--- a/mlx/directives/item_matrix_directive.py
+++ b/mlx/directives/item_matrix_directive.py
@@ -1,10 +1,11 @@
 from docutils import nodes
 from docutils.parsers.rst import directives
 
-from mlx.traceability_item_element import ItemElement, REGEXP_EXTERNAL_RELATIONSHIP
-from mlx.traceable_base_directive import BaseDirective
+from mlx.traceable_base_directive import TraceableBaseDirective
+from mlx.traceable_base_node import TraceableBaseNode, REGEXP_EXTERNAL_RELATIONSHIP
 
-class ItemMatrix(ItemElement):
+
+class ItemMatrix(TraceableBaseNode):
     '''Matrix for cross referencing documentation items'''
 
     def perform_replacement(self, app, collection):
@@ -82,7 +83,7 @@ class ItemMatrix(ItemElement):
         self.replace_self(top_node)
 
 
-class ItemMatrixDirective(BaseDirective):
+class ItemMatrixDirective(TraceableBaseDirective):
     """
     Directive to generate a matrix of item cross-references, based on
     a given set of relationship types.
@@ -101,7 +102,6 @@ class ItemMatrixDirective(BaseDirective):
     """
     # Optional argument: title (whitespace allowed)
     optional_arguments = 1
-    final_argument_whitespace = True
     # Options
     option_spec = {'class': directives.class_option,
                    'target': directives.unchanged,

--- a/mlx/directives/item_pie_chart_directive.py
+++ b/mlx/directives/item_pie_chart_directive.py
@@ -10,8 +10,8 @@ if not environ.get('DISPLAY'):
 import matplotlib.pyplot as plt  # pylint: disable=wrong-import-order
 
 from mlx.traceability import report_warning
-from mlx.traceability_item_element import ItemElement
-from mlx.traceable_base_directive import BaseDirective
+from mlx.traceable_base_directive import TraceableBaseDirective
+from mlx.traceable_base_node import TraceableBaseNode
 from mlx.traceable_item import TraceableItem
 
 def pct_wrapper(sizes):
@@ -26,7 +26,7 @@ def pct_wrapper(sizes):
     return make_pct
 
 
-class ItemPieChart(ItemElement):
+class ItemPieChart(TraceableBaseNode):
     '''Pie chart on documentation items'''
     collection = None
     relationships = []
@@ -231,7 +231,7 @@ class ItemPieChart(ItemElement):
         return image_node
 
 
-class ItemPieChartDirective(BaseDirective):
+class ItemPieChartDirective(TraceableBaseDirective):
     """
     Directive to generate a pie chart for coverage of item cross-references.
 
@@ -245,7 +245,6 @@ class ItemPieChartDirective(BaseDirective):
     """
     # Optional argument: title (whitespace allowed)
     optional_arguments = 1
-    final_argument_whitespace = True
     # Options
     option_spec = {'class': directives.class_option,
                    'id_set': directives.unchanged,

--- a/mlx/traceability.py
+++ b/mlx/traceability.py
@@ -15,8 +15,8 @@ from sphinx.util.nodes import make_refnode
 from sphinx.environment import NoUri
 from docutils import nodes
 from docutils.parsers.rst import directives
-from mlx.traceability_item_element import ItemElement
 from mlx.traceable_attribute import TraceableAttribute
+from mlx.traceable_base_node import TraceableBaseNode
 from mlx.traceable_item import TraceableItem
 from mlx.traceable_collection import TraceableCollection
 from mlx.traceability_exception import TraceabilityException, MultipleTraceabilityExceptions, report_warning
@@ -93,7 +93,7 @@ def build_class_name(inputs, class_names):
 # Pending item cross reference node
 
 
-class PendingItemXref(ItemElement):
+class PendingItemXref(TraceableBaseNode):
     """Node for item cross-references that cannot be resolved without complete information about all documents."""
 
     def perform_replacement(self, app, collection):

--- a/mlx/traceability.py
+++ b/mlx/traceability.py
@@ -10,6 +10,7 @@ See readme for more details.
 from __future__ import print_function
 from collections import OrderedDict
 from os import path
+from sphinx import __version__ as sphinx_version
 from sphinx.roles import XRefRole
 from sphinx.util.nodes import make_refnode
 from sphinx.environment import NoUri
@@ -29,7 +30,6 @@ from mlx.directives.item_list_directive import ItemList, ItemListDirective
 from mlx.directives.item_matrix_directive import ItemMatrix, ItemMatrixDirective
 from mlx.directives.item_pie_chart_directive import ItemPieChart, ItemPieChartDirective
 from mlx.directives.item_tree_directive import ItemTree, ItemTreeDirective
-from sphinx import __version__ as sphinx_version
 
 
 def generate_color_css(app, hyperlink_colors):

--- a/mlx/traceable_base_directive.py
+++ b/mlx/traceable_base_directive.py
@@ -6,8 +6,10 @@ from mlx.traceability_exception import report_warning
 from mlx.traceable_item import TraceableItem
 
 
-class BaseDirective(Directive, ABC):
+class TraceableBaseDirective(Directive, ABC):
     """ Base class for all Traceability directives. """
+
+    final_argument_whitespace = True
 
     @abstractmethod
     def run(self):
@@ -30,7 +32,7 @@ class BaseDirective(Directive, ABC):
         """ Adds found attributes to item. Attribute data is a single string.
 
         Args:
-            node (ItemElement): Node object for which to add found attributes to.
+            node (TraceableBaseNode): Node object for which to add found attributes to.
         """
         node['filter-attributes'] = {}
         for attr in TraceableItem.defined_attributes.keys():
@@ -67,7 +69,7 @@ class BaseDirective(Directive, ABC):
         """ Checks the nocaptions flag.
 
         Args:
-            node (ItemElement): Node object for which to set the nocaptions flag.
+            node (TraceableBaseNode): Node object for which to set the nocaptions flag.
             no_captions_config (bool): Value for nocaptions option in configuration
         """
         node['nocaptions'] = bool(no_captions_config or 'nocaptions' in self.options)
@@ -76,7 +78,7 @@ class BaseDirective(Directive, ABC):
         """ Processes ``target`` & ``source`` options.
 
         Args:
-            node (ItemElement): Node object for which to set the target and source options.
+            node (TraceableBaseNode): Node object for which to set the target and source options.
             options (tuple): Tuple of optoins (str).
         """
         for option in options:


### PR DESCRIPTION
Used as source by #109.

Renamed `ItemElement` to `TraceableBaseNode`.
Renamed `BaseDirective` to `TraceableBaseDirective`.
Converted public attributes and functions to protected where viable.
Updated design chart as requested in #104.