### PR TITLE
Refactor processing of options

### DIFF
--- a/mlx/directives/item_2d_matrix_directive.py
+++ b/mlx/directives/item_2d_matrix_directive.py
@@ -72,12 +72,14 @@ class Item2DMatrixDirective(TraceableBaseDirective):
     # Optional argument: title (whitespace allowed)
     optional_arguments = 1
     # Options
-    option_spec = {'class': directives.class_option,
-                   'target': directives.unchanged,
-                   'source': directives.unchanged,
-                   'hit': directives.unchanged,
-                   'miss': directives.unchanged,
-                   'type': directives.unchanged}
+    option_spec = {
+        'class': directives.class_option,
+        'target': directives.unchanged,
+        'source': directives.unchanged,
+        'hit': directives.unchanged,
+        'miss': directives.unchanged,
+        'type': directives.unchanged,  # a string with relationship types separated by space
+    }
     # Content disallowed
     has_content = False
 
@@ -97,29 +99,16 @@ class Item2DMatrixDirective(TraceableBaseDirective):
         else:
             node['title'] = '2D traceability matrix of items'
 
-        self.process_options(node, ('target', 'source'))
+        self.process_options(node,
+                             {'target': '',
+                              'source': '',
+                              'type': [],
+                              'hit': 'x',
+                              'miss': '',
+                              })
 
         self.add_found_attributes(node)
 
-        # Process ``type`` option, given as a string with relationship types
-        # separated by space. It is converted to a list.
-        if 'type' in self.options:
-            node['type'] = self.options['type'].split()
-        else:
-            node['type'] = []
-
         self.check_relationships(node['type'], env)
-
-        # Check hit string
-        if 'hit' in self.options:
-            node['hit'] = self.options['hit']
-        else:
-            node['hit'] = 'x'
-
-        # Check miss string
-        if 'miss' in self.options:
-            node['miss'] = self.options['miss']
-        else:
-            node['miss'] = ''
 
         return [node]

--- a/mlx/directives/item_2d_matrix_directive.py
+++ b/mlx/directives/item_2d_matrix_directive.py
@@ -84,6 +84,7 @@ class Item2DMatrixDirective(TraceableBaseDirective):
     has_content = False
 
     def run(self):
+        """ Processes the contents of the directive. """
         env = self.state.document.settings.env
 
         node = Item2DMatrix('')
@@ -93,11 +94,7 @@ class Item2DMatrixDirective(TraceableBaseDirective):
         if self.options.get('class'):
             node.get('classes').extend(self.options.get('class'))
 
-        # Process title (optional argument)
-        if self.arguments:
-            node['title'] = self.arguments[0]
-        else:
-            node['title'] = '2D traceability matrix of items'
+        self.process_title(node, '2D traceability matrix of items')
 
         self.process_options(node,
                              {'target': '',

--- a/mlx/directives/item_attribute_directive.py
+++ b/mlx/directives/item_attribute_directive.py
@@ -51,6 +51,7 @@ class ItemAttributeDirective(TraceableBaseDirective):
     has_content = True
 
     def run(self):
+        """ Processes the contents of the directive. """
         env = self.state.document.settings.env
 
         # Convert to lower-case as sphinx only allows lowercase arguments (attribute to item directive)

--- a/mlx/directives/item_attributes_matrix_directive.py
+++ b/mlx/directives/item_attributes_matrix_directive.py
@@ -17,7 +17,7 @@ class ItemAttributesMatrix(TraceableBaseNode):
         """
         showcaptions = not self['nocaptions']
         item_ids = collection.get_items(self['filter'],
-                                        self['filter-attributes'],
+                                        attributes=self['filter-attributes'],
                                         sortattributes=self['sort'],
                                         reverse=self['reverse'])
         top_node = self.create_top_node(self['title'])
@@ -72,12 +72,14 @@ class ItemAttributesMatrixDirective(TraceableBaseDirective):
     # Optional argument: title (whitespace allowed)
     optional_arguments = 1
     # Options
-    option_spec = {'class': directives.class_option,
-                   'filter': directives.unchanged,
-                   'attributes': directives.unchanged,
-                   'sort': directives.unchanged,
-                   'reverse': directives.flag,
-                   'nocaptions': directives.flag}
+    option_spec = {
+        'class': directives.class_option,
+        'filter': directives.unchanged,
+        'attributes': directives.unchanged,
+        'sort': directives.unchanged,
+        'reverse': directives.flag,
+        'nocaptions': directives.flag,
+    }
     # Content disallowed
     has_content = False
 
@@ -99,7 +101,7 @@ class ItemAttributesMatrixDirective(TraceableBaseDirective):
             node['title'] = 'Matrix of items and attributes'
 
         # Process ``filter`` options
-        self.process_options(node, ('filter', ))
+        self.process_options(node, {'filter': ''})
 
         self.add_found_attributes(node)
 
@@ -117,13 +119,10 @@ class ItemAttributesMatrixDirective(TraceableBaseDirective):
             node['sort'] = self.options['sort'].split()
             self.remove_unknown_attributes(node['sort'], 'sorting attribute', env)
         else:
-            node['sort'] = None
+            node['sort'] = []
 
         # Check reverse flag
-        if 'reverse' in self.options:
-            node['reverse'] = True
-        else:
-            node['reverse'] = False
+        self.check_option_presence(node, 'reverse')
 
         self.check_no_captions_flag(node, app.config.traceability_attributes_matrix_no_captions)
 

--- a/mlx/directives/item_attributes_matrix_directive.py
+++ b/mlx/directives/item_attributes_matrix_directive.py
@@ -84,6 +84,7 @@ class ItemAttributesMatrixDirective(TraceableBaseDirective):
     has_content = False
 
     def run(self):
+        """ Processes the contents of the directive. """
         env = self.state.document.settings.env
         app = env.app
 

--- a/mlx/directives/item_directive.py
+++ b/mlx/directives/item_directive.py
@@ -141,6 +141,7 @@ class ItemDirective(TraceableBaseDirective):
     has_content = True
 
     def run(self):
+        """ Processes the contents of the directive. """
         env = self.state.document.settings.env
         app = env.app
 

--- a/mlx/directives/item_directive.py
+++ b/mlx/directives/item_directive.py
@@ -133,8 +133,10 @@ class ItemDirective(TraceableBaseDirective):
     optional_arguments = 1
     # Options: the typical ones plus every relationship (and reverse)
     # defined in env.config.traceability_relationships
-    option_spec = {'class': directives.class_option,
-                   'nocaptions': directives.flag}
+    option_spec = {
+        'class': directives.class_option,
+        'nocaptions': directives.flag,
+    }
     # Content allowed
     has_content = True
 

--- a/mlx/directives/item_link_directive.py
+++ b/mlx/directives/item_link_directive.py
@@ -32,9 +32,11 @@ class ItemLinkDirective(TraceableBaseDirective):
 
     """
     # Options
-    option_spec = {'sources': directives.unchanged,
-                   'targets': directives.unchanged,
-                   'type': directives.unchanged}
+    option_spec = {
+        'sources': directives.unchanged,
+        'targets': directives.unchanged,
+        'type': directives.unchanged,
+    }
     # Content disallowed
     has_content = False
 

--- a/mlx/directives/item_link_directive.py
+++ b/mlx/directives/item_link_directive.py
@@ -41,6 +41,7 @@ class ItemLinkDirective(TraceableBaseDirective):
     has_content = False
 
     def run(self):
+        """ Processes the contents of the directive. """
         env = self.state.document.settings.env
 
         node = ItemLink('')

--- a/mlx/directives/item_list_directive.py
+++ b/mlx/directives/item_list_directive.py
@@ -44,9 +44,11 @@ class ItemListDirective(TraceableBaseDirective):
     # Optional argument: title (whitespace allowed)
     optional_arguments = 1
     # Options
-    option_spec = {'class': directives.class_option,
-                   'filter': directives.unchanged,
-                   'nocaptions': directives.flag}
+    option_spec = {
+        'class': directives.class_option,
+        'filter': directives.unchanged,
+        'nocaptions': directives.flag,
+    }
     # Content disallowed
     has_content = False
 
@@ -65,7 +67,7 @@ class ItemListDirective(TraceableBaseDirective):
             item_list_node['title'] = 'List of items'
 
         # Process ``filter`` option
-        self.process_options(item_list_node, ('filter', ))
+        self.process_options(item_list_node, {'filter': ''})
 
         self.add_found_attributes(item_list_node)
 

--- a/mlx/directives/item_list_directive.py
+++ b/mlx/directives/item_list_directive.py
@@ -53,6 +53,7 @@ class ItemListDirective(TraceableBaseDirective):
     has_content = False
 
     def run(self):
+        """ Processes the contents of the directive. """
         env = self.state.document.settings.env
         app = env.app
 
@@ -60,11 +61,7 @@ class ItemListDirective(TraceableBaseDirective):
         item_list_node['document'] = env.docname
         item_list_node['line'] = self.lineno
 
-        # Process title (optional argument)
-        if self.arguments:
-            item_list_node['title'] = self.arguments[0]
-        else:
-            item_list_node['title'] = 'List of items'
+        self.process_title(item_list_node, 'List of items')
 
         # Process ``filter`` option
         self.process_options(item_list_node, {'filter': ''})

--- a/mlx/directives/item_matrix_directive.py
+++ b/mlx/directives/item_matrix_directive.py
@@ -103,14 +103,16 @@ class ItemMatrixDirective(TraceableBaseDirective):
     # Optional argument: title (whitespace allowed)
     optional_arguments = 1
     # Options
-    option_spec = {'class': directives.class_option,
-                   'target': directives.unchanged,
-                   'source': directives.unchanged,
-                   'targettitle': directives.unchanged,
-                   'sourcetitle': directives.unchanged,
-                   'type': directives.unchanged,
-                   'stats': directives.flag,
-                   'nocaptions': directives.flag}
+    option_spec = {
+        'class': directives.class_option,
+        'target': directives.unchanged,
+        'source': directives.unchanged,
+        'targettitle': directives.unchanged,
+        'sourcetitle': directives.unchanged,
+        'type': directives.unchanged,  # a string with relationship types separated by space
+        'stats': directives.flag,
+        'nocaptions': directives.flag,
+    }
     # Content disallowed
     has_content = False
 
@@ -133,35 +135,18 @@ class ItemMatrixDirective(TraceableBaseDirective):
 
         self.add_found_attributes(item_matrix_node)
 
-        self.process_options(item_matrix_node, ('target', 'source'))
-
-        # Process ``type`` option, given as a string with relationship types
-        # separated by space. It is converted to a list.
-        if 'type' in self.options:
-            item_matrix_node['type'] = self.options['type'].split()
-        else:
-            item_matrix_node['type'] = []
+        self.process_options(item_matrix_node,
+                             {'target': '',
+                              'source': '',
+                              'targettitle': 'Target',
+                              'sourcetitle': 'Source',
+                              'type': [],
+                              })
 
         self.check_relationships(item_matrix_node['type'], env)
 
-        # Check statistics flag
-        if 'stats' in self.options:
-            item_matrix_node['stats'] = True
-        else:
-            item_matrix_node['stats'] = False
+        self.check_option_presence(item_matrix_node, 'stats')
 
         self.check_no_captions_flag(item_matrix_node, app.config.traceability_matrix_no_captions)
-
-        # Check source title
-        if 'sourcetitle' in self.options:
-            item_matrix_node['sourcetitle'] = self.options['sourcetitle']
-        else:
-            item_matrix_node['sourcetitle'] = 'Source'
-
-        # Check target title
-        if 'targettitle' in self.options:
-            item_matrix_node['targettitle'] = self.options['targettitle']
-        else:
-            item_matrix_node['targettitle'] = 'Target'
 
         return [item_matrix_node]

--- a/mlx/directives/item_matrix_directive.py
+++ b/mlx/directives/item_matrix_directive.py
@@ -127,11 +127,7 @@ class ItemMatrixDirective(TraceableBaseDirective):
         if self.options.get('class'):
             item_matrix_node.get('classes').extend(self.options.get('class'))
 
-        # Process title (optional argument)
-        if self.arguments:
-            item_matrix_node['title'] = self.arguments[0]
-        else:
-            item_matrix_node['title'] = 'Traceability matrix of items'
+        self.process_title(item_matrix_node, 'Traceability matrix of items')
 
         self.add_found_attributes(item_matrix_node)
 

--- a/mlx/directives/item_pie_chart_directive.py
+++ b/mlx/directives/item_pie_chart_directive.py
@@ -246,9 +246,11 @@ class ItemPieChartDirective(TraceableBaseDirective):
     # Optional argument: title (whitespace allowed)
     optional_arguments = 1
     # Options
-    option_spec = {'class': directives.class_option,
-                   'id_set': directives.unchanged,
-                   'label_set': directives.unchanged}
+    option_spec = {
+        'class': directives.class_option,
+        'id_set': directives.unchanged,
+        'label_set': directives.unchanged,
+    }
     # Content disallowed
     has_content = False
 

--- a/mlx/directives/item_pie_chart_directive.py
+++ b/mlx/directives/item_pie_chart_directive.py
@@ -262,9 +262,7 @@ class ItemPieChartDirective(TraceableBaseDirective):
         item_chart_node['document'] = env.docname
         item_chart_node['line'] = self.lineno
 
-        # Process title (optional argument)
-        if self.arguments:
-            item_chart_node['title'] = self.arguments[0]
+        self.process_title(item_chart_node)
 
         self._process_id_set(item_chart_node, env)
 
@@ -286,6 +284,7 @@ class ItemPieChartDirective(TraceableBaseDirective):
                            node['line'])
 
     def _process_label_set(self, node):
+        """ Processes label_set option. If not (fully) used, default labels are used. """
         default_labels = ['uncovered', 'covered', 'executed']
         if 'label_set' in self.options:
             node['label_set'] = [x.strip(' ') for x in self.options['label_set'].split(',')]

--- a/mlx/directives/item_tree_directive.py
+++ b/mlx/directives/item_tree_directive.py
@@ -91,6 +91,7 @@ class ItemTreeDirective(TraceableBaseDirective):
     has_content = False
 
     def run(self):
+        """ Processes the contents of the directive. """
         env = self.state.document.settings.env
         app = env.app
 
@@ -98,13 +99,8 @@ class ItemTreeDirective(TraceableBaseDirective):
         item_tree_node['document'] = env.docname
         item_tree_node['line'] = self.lineno
 
-        # Process title (optional argument)
-        if self.arguments:
-            item_tree_node['title'] = self.arguments[0]
-        else:
-            item_tree_node['title'] = 'Tree of items'
+        self.process_title(item_tree_node, 'Tree of items')
 
-        # Process ``top`` option
         self.process_options(item_tree_node,
                              {'top': '',
                               'top_relation_filter': [],

--- a/mlx/directives/item_tree_directive.py
+++ b/mlx/directives/item_tree_directive.py
@@ -80,11 +80,13 @@ class ItemTreeDirective(TraceableBaseDirective):
     # Optional argument: title (whitespace allowed)
     optional_arguments = 1
     # Options
-    option_spec = {'class': directives.class_option,
-                   'top': directives.unchanged,
-                   'top_relation_filter': directives.unchanged,
-                   'type': directives.unchanged,
-                   'nocaptions': directives.flag}
+    option_spec = {
+        'class': directives.class_option,
+        'top': directives.unchanged,
+        'top_relation_filter': directives.unchanged,  # a string with relationship types separated by space
+        'type': directives.unchanged,  # a string with relationship types separated by space
+        'nocaptions': directives.flag,
+    }
     # Content disallowed
     has_content = False
 
@@ -103,25 +105,15 @@ class ItemTreeDirective(TraceableBaseDirective):
             item_tree_node['title'] = 'Tree of items'
 
         # Process ``top`` option
-        self.process_options(item_tree_node, ('top', ))
-
-        # Process ``top_relation_filter`` option, given as a string with relationship types
-        # separated by space. It is converted to a list.
-        if 'top_relation_filter' in self.options:
-            item_tree_node['top_relation_filter'] = self.options['top_relation_filter'].split()
-        else:
-            item_tree_node['top_relation_filter'] = ''
+        self.process_options(item_tree_node,
+                             {'top': '',
+                              'top_relation_filter': [],
+                              'type': [],
+                              })
 
         self.add_found_attributes(item_tree_node)
 
         self.check_relationships(item_tree_node['top_relation_filter'], env)
-
-        # Process ``type`` option, given as a string with relationship types
-        # separated by space. It is converted to a list.
-        if 'type' in self.options:
-            item_tree_node['type'] = self.options['type'].split()
-        else:
-            item_tree_node['type'] = []
 
         # Check if given relationships are in configuration
         # Combination of forward + matching reverse relationship cannot be in the same list, as it will give

--- a/mlx/traceable_base_directive.py
+++ b/mlx/traceable_base_directive.py
@@ -70,19 +70,34 @@ class TraceableBaseDirective(Directive, ABC):
 
         Args:
             node (TraceableBaseNode): Node object for which to set the nocaptions flag.
-            no_captions_config (bool): Value for nocaptions option in configuration
+            no_captions_config (bool): Value for nocaptions option in configuration.
         """
         node['nocaptions'] = bool(no_captions_config or 'nocaptions' in self.options)
 
     def process_options(self, node, options):
-        """ Processes ``target`` & ``source`` options.
+        """ Processes given options.
 
         Args:
             node (TraceableBaseNode): Node object for which to set the target and source options.
-            options (tuple): Tuple of optoins (str).
+            options (dict): Dictionary with options (str) as keys and default values (str) as values.
         """
-        for option in options:
+        for option, default_value in options.items():
             if option in self.options:
-                node[option] = self.options[option]
+                if isinstance(default_value, list):
+                    node[option] = self.options[option].split()
+                else:
+                    node[option] = self.options[option]
             else:
-                node[option] = ''
+                node[option] = default_value
+
+    def check_option_presence(self, node, option):
+        """ Checks the presence of the given option. Set the value to True if the option is present, False otherwise.
+
+        Args:
+            node (TraceableBaseNode): Node object for which to set the nocaptions flag.
+            option (str): Name of the option.
+        """
+        if option in self.options:
+            node[option] = True
+        else:
+            node[option] = False

--- a/mlx/traceable_base_directive.py
+++ b/mlx/traceable_base_directive.py
@@ -15,6 +15,18 @@ class TraceableBaseDirective(Directive, ABC):
     def run(self):
         """ Processes directive's contents. Called by Sphinx. """
 
+    def process_title(self, node, default_title=''):
+        """ Adds the title to the item. If no title is specified, the given default title is used.
+
+        Args:
+            node (TraceableBaseNode): Node object for which to add found attributes to.
+            default_title (str): Default title.
+        """
+        if self.arguments:
+            node['title'] = self.arguments[0]
+        else:
+            node['title'] = default_title
+
     def get_caption(self):
         """ Gets the item's caption.
 

--- a/mlx/traceable_base_node.py
+++ b/mlx/traceable_base_node.py
@@ -1,3 +1,4 @@
+""" Module for the base class for all Traceability node classes. """
 import re
 from abc import abstractmethod, ABC
 
@@ -16,6 +17,7 @@ EXTERNAL_LINK_FIELDNAME = 'field'
 
 
 class TraceableBaseNode(nodes.General, nodes.Element, ABC):
+    """ Base class for all Traceability node classes. """
 
     @staticmethod
     def create_top_node(title):

--- a/mlx/traceable_collection.py
+++ b/mlx/traceable_collection.py
@@ -221,9 +221,9 @@ class TraceableCollection(object):
         Placeholders are excluded
 
         Args:
-            - source_id (str): id of the source item
-            - relations (list): list of relations, empty list for wildcard
-            - target_id (str): id of the target item
+            source_id (str): id of the source item
+            relations (list): list of relations, empty list for wildcard
+            target_id (str): id of the target item
         Returns:
             (boolean) True if both items are related through the given relationships, false otherwise
         '''
@@ -241,17 +241,17 @@ class TraceableCollection(object):
             relations = self.iter_relations()
         return self.items[source_id].is_related(relations, target_id)
 
-    def get_items(self, regex, attributes={}, sortattributes=None, reverse=False):
+    def get_items(self, regex, attributes=None, sortattributes=None, reverse=False):
         '''
         Get all items that match a given regular expression
 
         Placeholders are excluded
 
         Args:
-            - regex (str): Regex to match the items in this collection against
-            - attributes (dict): Dictionary with attribute-regex pairs to match the items in this collection against
-            - sortattributes (list): List of attributes on which to alphabetically sort the items
-            - reverse (bool): True for reverse sorting
+            regex (str): Regex to match the items in this collection against
+            attributes (dict): Dictionary with attribute-regex pairs to match the items in this collection against
+            sortattributes (list): List of attributes on which to alphabetically sort the items
+            reverse (bool): True for reverse sorting
         Returns:
             A sorted list of item-id's matching the given regex. Sorting is done naturally when sortattributes is
             unused.
@@ -260,7 +260,8 @@ class TraceableCollection(object):
         for itemid in self.items:
             if self.items[itemid].is_placeholder():
                 continue
-            if self.items[itemid].is_match(regex) and self.items[itemid].attributes_match(attributes):
+            if self.items[itemid].is_match(regex) and \
+                (not attributes or self.items[itemid].attributes_match(attributes)):
                 matches.append(itemid)
         if sortattributes:
             matches = sorted(matches, key=lambda itemid: self.get_item(itemid).get_attributes(sortattributes),


### PR DESCRIPTION
Refactored `process_options` to allow specifying the default value for a wider application of the function.
Refactored code that processes option flags by defining `check_option_presence()`.
Improved style of `option_spec` dictionary.
Fixed args documentation in `traceable_collection.py`.
Refactor the processing of the directive title by defining `process_title()`.
Add some missing docstrings.