### PR TITLE
Add requirements txt for GitHub dependency detection

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -19,3 +19,9 @@ recursive-include doc Makefile
 recursive-include tests *.py
 recursive-include tests *.rst
 recursive-include tests *.txt
+
+# added by check_manifest.py
+include .coveragerc
+
+# added by check_manifest.py
+include *.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+# Requirements file is made purely for GitHub to track dependencies. It should be automatically taken from setup.py
+.

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist =
     clean,
     check,
-    {py36},
+    {py37},
     {sphinx1.6,sphinx-latest},
 
 [testenv]


### PR DESCRIPTION
Requirements.txt is needed for automatic dependency detection in GitHub, so that we spread the word around.