### PR TITLE
Allow collapsing the traceability information for item

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -209,8 +209,8 @@ Rendering of relationships per documentation object
 
 When rendering the documentation objects, the user has the option to include/exclude the rendering of the
 relationships to other documentation objects. This can be done through the Python variable
-*traceability_render_relationship_per_item* which is *boolean*: a value of 'True' will enable rendering
-of relationships per documentation object, while a value of 'False' will disable this rendering.
+*traceability_render_relationship_per_item* which is *boolean*: a value of ``True`` will enable rendering
+of relationships per documentation object, while a value of ``False`` will disable this rendering.
 
 Example configuration of enable rendering relationships per item:
 
@@ -222,8 +222,8 @@ Rendering of attributes per documentation object
 ================================================
 
 The rendering of attributes of documentation objects can be controlled through the *boolean* variable
-*traceability_render_attributes_per_item*: rendering of attributes is enabled by setting it to 'True' (the default)
-while a value of 'False' will prevent the attribute list from being rendered.
+*traceability_render_attributes_per_item*: rendering of attributes is enabled by setting it to ``True`` (the default)
+while a value of ``False`` will prevent the attribute list from being rendered.
 
 Example configuration of disabling per item attribute rendering:
 
@@ -234,15 +234,17 @@ Example configuration of disabling per item attribute rendering:
 Ability to collapse the list of relationships and attributes per documentation object
 =====================================================================================
 
-A button can be added to each documentation object that has rendered relationships and/or attributes to hide this
-traceablility information. This feature is disabled by default. It can be enabled through the *boolean* variable
-*traceability_collapsible_links* by setting it to 'True'.
+A button is added to each documentation object that has rendered relationships and/or attributes to be able to show and
+hide these traceability links. The *boolean* configuration variable *traceability_collapse_links* allows selecting
+between hiding and showing the list of links for all items on page load: setting its value to ``True`` results in the
+list of links being hidden (collapsed) on page load, while a value of ``False`` results in the list being shown
+(uncollapsed)(the default).
 
-Example configuration to add a button per item to collapse traceability information:
+Example configuration of hiding the traceability links on page load:
 
 .. code-block:: python
 
-    traceability_collapsible_links = True
+    traceability_collapse_links = True
 
 .. _traceability_config_no_captions:
 

--- a/README.rst
+++ b/README.rst
@@ -231,6 +231,19 @@ Example configuration of disabling per item attribute rendering:
 
     traceability_render_attributes_per_item = False
 
+Ability to collapse the list of relationships and attributes per documentation object
+=====================================================================================
+
+A button can be added to each documentation object that has rendered relationships and/or attributes to hide this
+traceablility information. This feature is disabled by default. It can be enabled through the *boolean* variable
+*traceability_collapsible_links* by setting it to 'True'.
+
+Example configuration to add a button per item to collapse traceability information:
+
+.. code-block:: python
+
+    traceability_collapsible_links = True
+
 .. _traceability_config_no_captions:
 
 No captions

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -325,6 +325,7 @@ traceability_relationships = {
 }
 
 traceability_render_relationship_per_item = True
+traceability_collapsible_links = True
 
 traceability_relationship_to_string = {
     'trace': 'Traces',

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -325,7 +325,6 @@ traceability_relationships = {
 }
 
 traceability_render_relationship_per_item = True
-traceability_collapsible_links = True
 
 traceability_relationship_to_string = {
     'trace': 'Traces',
@@ -362,6 +361,7 @@ traceability_hyperlink_colors = OrderedDict([
 # traceability_matrix_no_captions = True
 # traceability_tree_no_captions = True
 # traceability_render_attributes_per_item = False
+# traceability_collapse_links = True
 
 # Point to plantuml jar file
 # confirm we have plantuml in the path

--- a/mlx/assets/traceability.js
+++ b/mlx/assets/traceability.js
@@ -1,31 +1,41 @@
+// item-tree
 jQuery(function () {
     $('ul.bonsai').bonsai();
 });
 
+// item (traceability_collapsible_links == True)
 jQuery.fn.extend({
-    prependHideLinks: function () {
-        var relations = $(this)
-        var hideLinks = $('<a>', {
-            text: 'Hide links',
-            click: function () {
-                if (relations.is(':visible')) {
-                    relations.hide();
-                    $(this).text('Show links');
-                } else {
-                    relations.show();
-                    $(this).text('Hide links');
-                }
-            }
-        });
+    prependHideLinks: function (admonition) {
+        var relations = $(this);
+
         if (relations.children().length > 0) {
-            console.log(relations.children().length);
-            $(this).before(hideLinks);
+            var arrow = $('<i>', {
+                class: "fa fa-angle-up",
+                click: function () {
+                    relations.toggle();
+                    $(this).toggleClass("fa-angle-up fa-angle-down");
+                }
+            });
+
+            var linkColor = relations.children('dt').first().css('color');
+            console.log(linkColor);
+            var arrowDiv = $('<div>', {
+                css: {
+                    'display': 'inline-block',
+                    'float': 'right',
+                    'font-size': '150%',
+                    'color': linkColor,
+                    'padding-right': '1rem'
+                },
+                append: arrow
+            });
+            admonition.after(arrowDiv);
         }
     }
 });
 
 $(document).ready(function () {
-    $('div.toggle_links div.admonition:first-child').each(function (i) {
-        $(this).siblings('dl.simple').prependHideLinks();
+    $('div.collapsible_links div.admonition:first-child').each(function (i) {
+        $(this).siblings('dl.simple').prependHideLinks($(this));
     });
 });

--- a/mlx/assets/traceability.js
+++ b/mlx/assets/traceability.js
@@ -3,39 +3,43 @@ jQuery(function () {
     $('ul.bonsai').bonsai();
 });
 
-// item (traceability_collapsible_links == True)
+
+// item
+$(document).ready(function () {
+    $('div.collapsible_links div.admonition:first-child').each(function (i) {
+        $(this).siblings('dl.simple').addCollapseButton($(this));
+    });
+});
+
 jQuery.fn.extend({
-    prependHideLinks: function (admonition) {
+    addCollapseButton: function (admonition) {
         var relations = $(this);
 
         if (relations.children().length > 0) {
+            if (admonition.parent().hasClass('collapse')) {
+                // collapse relations and attributes list for each item on page load
+                relations.toggle();
+                arrowDirection = 'down';
+            } else {
+                arrowDirection = 'up';
+            }
+
+            var linkColor = relations.children('dt').first().css('color');
             var arrow = $('<i>', {
-                class: "fa fa-angle-up",
+                class: "fa fa-angle-" + arrowDirection,
+                css: {
+                    'font-size': '135%',
+                    'color': linkColor,
+                    'float': 'right',
+                    'transform': 'translate(-0.5rem, -1.4rem)'
+                },
                 click: function () {
-                    relations.toggle();
+                    relations.toggle('fold');
                     $(this).toggleClass("fa-angle-up fa-angle-down");
                 }
             });
+            admonition.after(arrow);
 
-            var linkColor = relations.children('dt').first().css('color');
-            console.log(linkColor);
-            var arrowDiv = $('<div>', {
-                css: {
-                    'display': 'inline-block',
-                    'float': 'right',
-                    'font-size': '150%',
-                    'color': linkColor,
-                    'padding-right': '1rem'
-                },
-                append: arrow
-            });
-            admonition.after(arrowDiv);
         }
     }
-});
-
-$(document).ready(function () {
-    $('div.collapsible_links div.admonition:first-child').each(function (i) {
-        $(this).siblings('dl.simple').prependHideLinks($(this));
-    });
 });

--- a/mlx/assets/traceability.js
+++ b/mlx/assets/traceability.js
@@ -39,7 +39,6 @@ jQuery.fn.extend({
                 }
             });
             admonition.after(arrow);
-
         }
     }
 });

--- a/mlx/assets/traceability.js
+++ b/mlx/assets/traceability.js
@@ -1,4 +1,22 @@
+$(document).ready(function () {
+    $('<a>', {
+        text: 'Hide links',
+        click: function () {
+            //alert($(this).siblings()[0].innerHTML);
+            var p = $(this).siblings()[0];
+            //alert(p.innerHTML);
+            var relations = $(this).siblings('dl.simple')
+            if (relations.is(':visible')) {
+                relations.hide();
+                $(this).text('Show links');
+            } else {
+                relations.show();
+                $(this).text('Hide links');
+            }
+        }
+    }).insertAfter('div.toggle_links div.admonition:first-child');
+});
+
 jQuery(function() {
     $('ul.bonsai').bonsai();
 });
-

--- a/mlx/assets/traceability.js
+++ b/mlx/assets/traceability.js
@@ -1,22 +1,31 @@
-$(document).ready(function () {
-    $('<a>', {
-        text: 'Hide links',
-        click: function () {
-            //alert($(this).siblings()[0].innerHTML);
-            var p = $(this).siblings()[0];
-            //alert(p.innerHTML);
-            var relations = $(this).siblings('dl.simple')
-            if (relations.is(':visible')) {
-                relations.hide();
-                $(this).text('Show links');
-            } else {
-                relations.show();
-                $(this).text('Hide links');
-            }
-        }
-    }).insertAfter('div.toggle_links div.admonition:first-child');
+jQuery(function () {
+    $('ul.bonsai').bonsai();
 });
 
-jQuery(function() {
-    $('ul.bonsai').bonsai();
+jQuery.fn.extend({
+    prependHideLinks: function () {
+        var relations = $(this)
+        var hideLinks = $('<a>', {
+            text: 'Hide links',
+            click: function () {
+                if (relations.is(':visible')) {
+                    relations.hide();
+                    $(this).text('Show links');
+                } else {
+                    relations.show();
+                    $(this).text('Hide links');
+                }
+            }
+        });
+        if (relations.children().length > 0) {
+            console.log(relations.children().length);
+            $(this).before(hideLinks);
+        }
+    }
+});
+
+$(document).ready(function () {
+    $('div.toggle_links div.admonition:first-child').each(function (i) {
+        $(this).siblings('dl.simple').prependHideLinks();
+    });
 });

--- a/mlx/directives/item_directive.py
+++ b/mlx/directives/item_directive.py
@@ -151,7 +151,8 @@ class ItemDirective(TraceableBaseDirective):
         item_node['document'] = env.docname
         item_node['line'] = self.lineno
         item_node['id'] = target_id
-        item_node['classes'].append('toggle_links')
+        if app.config.traceability_collapsible_links:
+            item_node['classes'].append('collapsible_links')  # traceability.js adds the 'Hide links' "button"
 
         target_node = self._store_item_info(target_id, env)
 

--- a/mlx/directives/item_directive.py
+++ b/mlx/directives/item_directive.py
@@ -151,8 +151,9 @@ class ItemDirective(TraceableBaseDirective):
         item_node['document'] = env.docname
         item_node['line'] = self.lineno
         item_node['id'] = target_id
-        if app.config.traceability_collapsible_links:
-            item_node['classes'].append('collapsible_links')  # traceability.js adds the 'Hide links' "button"
+        item_node['classes'].append('collapsible_links')  # traceability.js adds the arrowhead button
+        if app.config.traceability_collapse_links:
+            item_node['classes'].append('collapse')
 
         target_node = self._store_item_info(target_id, env)
 

--- a/mlx/directives/item_directive.py
+++ b/mlx/directives/item_directive.py
@@ -151,6 +151,7 @@ class ItemDirective(TraceableBaseDirective):
         item_node['document'] = env.docname
         item_node['line'] = self.lineno
         item_node['id'] = target_id
+        item_node['classes'].append('toggle_links')
 
         target_node = self._store_item_info(target_id, env)
 

--- a/mlx/traceability.py
+++ b/mlx/traceability.py
@@ -339,6 +339,10 @@ def setup(app):
     app.add_config_value('traceability_item_no_captions',
                          False, 'env')
 
+    # Configuration for enabling the ability to collapse the list of attributes and relations for item
+    app.add_config_value('traceability_collapsible_links',
+                         False, 'env')
+
     # Configuration for disabling the rendering of the captions for item-list
     app.add_config_value('traceability_list_no_captions',
                          False, 'env')

--- a/mlx/traceability.py
+++ b/mlx/traceability.py
@@ -340,7 +340,7 @@ def setup(app):
                          False, 'env')
 
     # Configuration for enabling the ability to collapse the list of attributes and relations for item
-    app.add_config_value('traceability_collapsible_links',
+    app.add_config_value('traceability_collapse_links',
                          False, 'env')
 
     # Configuration for disabling the rendering of the captions for item-list


### PR DESCRIPTION
If an _item_ has any rendered _relationships_ or _attributes_, a button will be added on the right hand side that allows you to hide this info. 
Hiding (collapsing) all links on page load can be enabled by setting `traceability_collapse_links` to `True` in `conf.py`. The links are shown (uncollapsed) by default.

<img src="https://user-images.githubusercontent.com/28319872/61730280-5928b980-ad79-11e9-81bc-95279060beeb.png" width="500" >

Closes #92