### PR TITLE
Clarify warning about missing reference to source document.

### DIFF
--- a/mlx/directives/item_attributes_matrix_directive.py
+++ b/mlx/directives/item_attributes_matrix_directive.py
@@ -109,6 +109,7 @@ class ItemAttributesMatrixDirective(TraceableBaseDirective):
         # Process ``attributes`` option, given as a string with attributes
         # separated by space. It is converted to a list.
         if 'attributes' in self.options and self.options['attributes']:
+            self._warn_if_comma_separated('attributes', env)
             node['attributes'] = self.options['attributes'].split()
         else:
             node['attributes'] = list(app.config.traceability_attributes.keys())
@@ -117,6 +118,7 @@ class ItemAttributesMatrixDirective(TraceableBaseDirective):
         # Process ``sort`` option, given as a string with attributes
         # separated by space. It is converted to a list.
         if 'sort' in self.options and self.options['sort']:
+            self._warn_if_comma_separated('sort', env)
             node['sort'] = self.options['sort'].split()
             self.remove_unknown_attributes(node['sort'], 'sorting attribute', env)
         else:

--- a/mlx/directives/item_directive.py
+++ b/mlx/directives/item_directive.py
@@ -195,6 +195,7 @@ class ItemDirective(TraceableBaseDirective):
         # item ids separated by space. It is split in a list of item ids.
         for rel in env.traceability_collection.iter_relations():
             if rel in self.options:
+                self._warn_if_comma_separated(rel, env)
                 related_ids = self.options[rel].split()
                 self._add_relation_to_ids(rel, target_id, related_ids, env)
 

--- a/mlx/directives/item_pie_chart_directive.py
+++ b/mlx/directives/item_pie_chart_directive.py
@@ -274,7 +274,8 @@ class ItemPieChartDirective(TraceableBaseDirective):
 
     def _process_id_set(self, node, env):
         """ Processes id_set option. At least two arguments are required. Otherwise, a warning is reported. """
-        if 'id_set' in self.options and len(self.options['id_set']) >= 2:
+        if 'id_set' in self.options and len(self.options['id_set'].split()) >= 2:
+            self._warn_if_comma_separated('id_set', env)
             node['id_set'] = self.options['id_set'].split()
         else:
             node['id_set'] = []

--- a/mlx/traceable_base_class.py
+++ b/mlx/traceable_base_class.py
@@ -191,5 +191,5 @@ class TraceableBaseClass(object):
         '''
         # should hold a reference to a document
         if self.get_document() is None:
-            raise TraceabilityException('{identification} has no reference to source document'
+            raise TraceabilityException("Item '{identification}' has no reference to source document."
                                         .format(identification=self.get_id()))

--- a/mlx/traceable_base_directive.py
+++ b/mlx/traceable_base_directive.py
@@ -103,6 +103,7 @@ class TraceableBaseDirective(Directive, ABC):
         for option, default_value in options.items():
             if option in self.options:
                 if isinstance(default_value, list):
+                    self._warn_if_comma_separated(option, env)
                     node[option] = self.options[option].split()
                 else:
                     node[option] = self.options[option]
@@ -127,3 +128,17 @@ class TraceableBaseDirective(Directive, ABC):
             node[option] = True
         else:
             node[option] = False
+
+    def _warn_if_comma_separated(self, option, env):
+        """ Reports a warning if the option's arguments are comma-separated.
+
+        Args:
+            option (str): Option name.
+            env (sphinx.environment.BuildEnvironment): Sphinx's build environment.
+        """
+        if len(self.options[option].split(',')) > 1:
+            report_warning(env,
+                           "The arguments of the '{}' option must be space-separated without commas; "
+                           "got '{}'.".format(option, self.options[option]),
+                           env.docname,
+                           self.lineno)

--- a/mlx/traceable_base_node.py
+++ b/mlx/traceable_base_node.py
@@ -185,7 +185,7 @@ class TraceableBaseNode(nodes.General, nodes.Element, ABC):
             env (sphinx.environment.BuildEnvironment): Sphinx' build environment.
         """
         if item_info.is_placeholder():
-            report_warning(env, 'Traceability: cannot link to %s, item is not defined' % item_info.get_id(),
+            report_warning(env, "Traceability: cannot link to '%s', item is not defined" % item_info.get_id(),
                            self['document'], self['line'])
             return True
         return False


### PR DESCRIPTION
The quotes should highlight the trailing comma more. Not sure how this can be clarified more without adding more code.