### PR TITLE
Install plantuml in Travis CI using Xenial dist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 sudo: false
 cache: pip
+dist: bionic
 env:
   global:
     - LD_PRELOAD=/lib/x86_64-linux-gnu/libSegFault.so

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
-sudo: false
+sudo: true
 cache: pip
-dist: trusty
+dist: xenial
 env:
   global:
     - LD_PRELOAD=/lib/x86_64-linux-gnu/libSegFault.so
@@ -35,6 +35,8 @@ install:
   - easy_install --version
   - pip --version
   - tox --version
+  - sudo apt-get install graphviz
+  - sudo apt-get install plantuml
 
 script:
   - tox -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 sudo: false
 cache: pip
-dist: bionic
+dist: trusty
 env:
   global:
     - LD_PRELOAD=/lib/x86_64-linux-gnu/libSegFault.so


### PR DESCRIPTION
8 days ago Travis CI switched from using its default trusty dist to the newer xenial dist. Since then, plantuml could not be found so it didn't build. Apparently plantuml was contained in the trusty dist, but removed from the xenial dist. Explicitly installing plantuml fixes the issue. Travis CI should build the documentation now.

Closes #119 