### PR TITLE
Add checklist example

### DIFF
--- a/doc/checklist.rst
+++ b/doc/checklist.rst
@@ -20,11 +20,11 @@ Checklist items
 
     Have you tested the package?
 
-.. checklist-item:: QUE-PROCESS Followed process
+.. checklist-item:: QUE-PROCESS Followed the process
 
     Did you follow the process?
 
-.. checklist-item:: ITEM_MISSING_FROM_CHECKLIST Should trigger a warning
+.. checklist-item:: ITEM_MISSING_FROM_CHECKLIST Triggers a warning
 
     This item ID is not present in the checklist of the pull request and should trigger a warning.
 

--- a/doc/checklist.rst
+++ b/doc/checklist.rst
@@ -1,0 +1,27 @@
+=========
+Checklist
+=========
+
+.. contents:: `Contents`
+    :depth: 3
+    :local:
+
+---------------
+Checklist items
+---------------
+
+.. checklist-item:: QUE-UNIT_TESTS Added unit tests
+
+    Have you written unit tests for regression detection?
+
+.. checklist-item:: QUE-PACKAGE_TEST Tested the package
+
+    Have you tested the package?
+
+-------------------------
+Matrix of checklist items
+-------------------------
+
+.. item-attributes-matrix:: Checklist attribute values
+    :filter: QUE
+    :attributes: checked

--- a/doc/checklist.rst
+++ b/doc/checklist.rst
@@ -11,12 +11,22 @@ Checklist items
 ---------------
 
 .. checklist-item:: QUE-UNIT_TESTS Added unit tests
+    :depends_on: QUE-PROCESS
 
     Have you written unit tests for regression detection?
 
 .. checklist-item:: QUE-PACKAGE_TEST Tested the package
+    :depends_on: QUE-PROCESS
 
     Have you tested the package?
+
+.. checklist-item:: QUE-PROCESS Followed process
+
+    Did you follow the process?
+
+.. checklist-item:: ITEM_MISSING_FROM_CHECKLIST Should trigger a warning
+
+    This item ID is not present in the checklist of the pull request and should trigger a warning.
 
 -------------------------
 Matrix of checklist items

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -15,4 +15,4 @@ Documentation mlx.traceability
     design
     implementation
     integration_test_report
-
+    checklist

--- a/mlx/directives/checklist_item_directive.py
+++ b/mlx/directives/checklist_item_directive.py
@@ -27,7 +27,7 @@ class ChecklistItemDirective(ItemDirective):
             report_warning(env, err, env.docname, self.lineno)
         except KeyError as err:
             report_warning(env,
-                           "Could not find item '{}' in a checklist; only {}."
+                           "Could not find item {} in a checklist; only {}."
                            .format(err, list(self.query_results.keys())),
                            env.docname,
                            self.lineno)

--- a/tox.ini
+++ b/tox.ini
@@ -60,9 +60,9 @@ whitelist_externals =
     mlx-warnings
 commands=
     bash -c 'make -C doc html 2>&1 | tee .tox/doc_html.log'
-    mlx-warnings --sphinx --maxwarnings 16 --minwarnings 16 .tox/doc_html.log
+    mlx-warnings --sphinx --maxwarnings 17 --minwarnings 17 .tox/doc_html.log
     bash -c 'make -C doc latexpdf 2>&1 | tee .tox/doc_pdf.log'
-    mlx-warnings --sphinx --maxwarnings 16 --minwarnings 16 .tox/doc_pdf.log
+    mlx-warnings --sphinx --maxwarnings 17 --minwarnings 17 .tox/doc_pdf.log
 
 [testenv:sphinx1.7]
 deps=
@@ -77,9 +77,9 @@ whitelist_externals =
     mlx-warnings
 commands=
     bash -c 'make -C doc html 2>&1 | tee .tox/doc_html.log'
-    mlx-warnings --sphinx --maxwarnings 16 --minwarnings 16 .tox/doc_html.log
+    mlx-warnings --sphinx --maxwarnings 17 --minwarnings 17 .tox/doc_html.log
     bash -c 'make -C doc latexpdf 2>&1 | tee .tox/doc_pdf.log'
-    mlx-warnings --sphinx --maxwarnings 16 --minwarnings 16 .tox/doc_pdf.log
+    mlx-warnings --sphinx --maxwarnings 17 --minwarnings 17 .tox/doc_pdf.log
 
 [testenv:sphinx1.8]
 deps=
@@ -94,9 +94,9 @@ whitelist_externals =
     mlx-warnings
 commands=
     bash -c 'make -C doc html 2>&1 | tee .tox/doc_html.log'
-    mlx-warnings --sphinx --maxwarnings 16 --minwarnings 16 .tox/doc_html.log
+    mlx-warnings --sphinx --maxwarnings 17 --minwarnings 17 .tox/doc_html.log
     bash -c 'make -C doc latexpdf 2>&1 | tee .tox/doc_pdf.log'
-    mlx-warnings --sphinx --maxwarnings 16 --minwarnings 16 .tox/doc_pdf.log
+    mlx-warnings --sphinx --maxwarnings 17 --minwarnings 17 .tox/doc_pdf.log
 
 [testenv:sphinx-latest]
 deps=
@@ -111,9 +111,9 @@ whitelist_externals =
     mlx-warnings
 commands=
     bash -c 'make -C doc html 2>&1 | tee .tox/doc_html.log'
-    mlx-warnings --sphinx --maxwarnings 16 --minwarnings 16 .tox/doc_html.log
+    mlx-warnings --sphinx --maxwarnings 17 --minwarnings 17 .tox/doc_html.log
     bash -c 'make -C doc latexpdf 2>&1 | tee .tox/doc_pdf.log'
-    mlx-warnings --sphinx --maxwarnings 16 --minwarnings 16 .tox/doc_pdf.log
+    mlx-warnings --sphinx --maxwarnings 17 --minwarnings 17 .tox/doc_pdf.log
 
 [testenv:coveralls]
 deps =


### PR DESCRIPTION
This is an example to showcase the new _checklist-item_ directive. The checkboxes below are followed by item IDs that are defined using `.. checklist-item:: ` in _doc/checklist.rst_. The plugin adds an additional attribute to these items. For this example the name and values of this attribute are taken from the default values for the configuration variable `traceability_checklist` in _doc/conf.py_.

- [ ] QUE-UNIT_TESTS Did you add unit tests?
- [x] QUE-PACKAGE_TEST Did you test the package?
- [x] QUE-DOCUMENTATION Did you complete the documentation?
- [ ] QUE-PROCESS Did you follow the process?
