### PR TITLE
Allow spaces at the start of a line in a checklist in Markdown

### DIFF
--- a/mlx/traceability.py
+++ b/mlx/traceability.py
@@ -357,7 +357,7 @@ def _parse_description(description, attr_values):
     description_lines = description.split('\n')
     for line in description_lines:
         # catch the content of checkbox and the item ID after the checkbox
-        match = search(r"^[\*-]\s+\[(?P<checkbox>[\sx])\]\s+(?P<target_id>[\w\-]+)", line)
+        match = search(r"^\s*[\*-]\s+\[(?P<checkbox>[\sx])\]\s+(?P<target_id>[\w\-]+)", line)
         if match:
             if match.group('checkbox') == 'x':
                 attr_value = attr_values[0]


### PR DESCRIPTION
Without this change the plugin ignores a checklist line in a pull/merge request that starts with a space before `- [ ]` . Spaces should be allowed.