### PR TITLE
Fix collapse button not being generated depending on docutils version

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -16,7 +16,7 @@ checks:
       threshold: 25
   method-lines:
     config:
-      threshold: 25
+      threshold: 40
   nested-control-flow:
     config:
       threshold: 4

--- a/mlx/assets/traceability.js
+++ b/mlx/assets/traceability.js
@@ -24,14 +24,20 @@ jQuery.fn.extend({
                 arrowDirection = 'up';
             }
 
-            var linkColor = relations.children('dt').first().css('color');
+            var linkColor = admonition.children('p').first().css('color');
+            var translateX = '0rem'
+            var translateY = '-2.5rem'
+            if (relations.hasClass('simple')) {
+                translateX = '-0.5rem'
+                translateY = '-3.9rem'
+            }
             var arrow = $('<i>', {
                 class: "fa fa-angle-" + arrowDirection,
                 css: {
                     'font-size': '135%',
                     'color': linkColor,
                     'float': 'right',
-                    'transform': 'translate(-0.5rem, -1.4rem)'
+                    'transform': 'translate(' + translateX + ', ' + translateY + ')'
                 },
                 click: function () {
                     relations.toggle('fold');

--- a/mlx/assets/traceability.js
+++ b/mlx/assets/traceability.js
@@ -7,7 +7,7 @@ jQuery(function () {
 // item
 $(document).ready(function () {
     $('div.collapsible_links div.admonition:first-child').each(function (i) {
-        $(this).siblings('dl.simple').addCollapseButton($(this));
+        $(this).siblings('dl').first().addCollapseButton($(this));
     });
 });
 


### PR DESCRIPTION
No longer rely on the presence of the _simple_ class of a dl element to add the button, but use the first dl element encountered. This fixes the issue where the button wasn't generated when using an older style theme/docutils version.

- [x] Tweak positioning of button