### PR TITLE
Add transpose option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -94,7 +94,7 @@ First the plugin needs to be enabled in the *extensions* variable:
 .. code-block:: bash
 
     extensions = [
-        'mlx.traceability.traceability',
+        'mlx.traceability',
         ...
     ]
 
@@ -614,6 +614,7 @@ A matrix listing the attributes of documentation items can be generated using:
         :attributes: status
         :sort: status
         :reverse:
+        :transpose:
         :nocaptions:
 
 where the *filter* argument can be replaced by any Python regular expression. Documentation items matching
@@ -637,6 +638,10 @@ caption can be omitted. This gives a smaller table, but also less details.
 By default, items are sorted naturally based on their name. With the *sort* argument it is possible to sort on one
 or more attribute values alphabetically. When providing multiple attributes to sort on, the attribute keys are
 space-separated. With the *reverse* argument, the sorting is reversed.
+
+By default, the attribute names are listed the header row and every item takes up a row. Depending on the number of
+items and attributes it could be better to transpose the generated matrix (swap columns for row) by providing the
+*transpose* flag.
 
 Optionally, the *class* attribute can be specified to customize table output, especially useful when rendering to
 LaTeX. Normally the *longtable* class is used when the number of rows is greater than 30 which allows long tables to

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -42,7 +42,7 @@ extensions = [
     'sphinx.ext.napoleon',
     'sphinx.ext.viewcode',
     'sphinx.ext.graphviz',
-    'traceability',
+    'mlx.traceability',
     'sphinx_selective_exclude.eager_only',
     'sphinx_selective_exclude.modindex_exclude',
     'sphinx_selective_exclude.search_auto_exclude',

--- a/doc/integration_test_report.rst
+++ b/doc/integration_test_report.rst
@@ -356,11 +356,13 @@ All attributes for items having a non-empty attribute
     :asil: ^.+$
     :sort: asil
 
-.. item-attributes-matrix:: All attributes for items having a non-empty asil+aspice attribute
+.. item-attributes-matrix:: All attributes for items having a non-empty asil+aspice attribute; transposed
     :asil: ^.+$
     :aspice: ^.+$
     :sort: asil aspice
     :reverse:
+    :transpose:
+    :nocaptions:
 
 All attributes for non-matching-filter
 --------------------------------------

--- a/doc/integration_test_report.rst
+++ b/doc/integration_test_report.rst
@@ -356,7 +356,14 @@ All attributes for items having a non-empty attribute
     :asil: ^.+$
     :sort: asil
 
-.. item-attributes-matrix:: All attributes for items having a non-empty asil+aspice attribute; transposed
+.. item-attributes-matrix:: All attributes for items having a non-empty asil+aspice attribute
+    :asil: ^.+$
+    :aspice: ^.+$
+    :sort: asil aspice
+    :reverse:
+    :nocaptions:
+
+.. item-attributes-matrix:: Transposed version of the previous matrix
     :asil: ^.+$
     :aspice: ^.+$
     :sort: asil aspice

--- a/mlx/directives/item_attributes_matrix_directive.py
+++ b/mlx/directives/item_attributes_matrix_directive.py
@@ -27,31 +27,85 @@ class ItemAttributesMatrix(TraceableBaseNode):
         tgroup = nodes.tgroup()
         colspecs = [nodes.colspec(colwidth=5)]
         hrow = nodes.row('', nodes.entry('', nodes.paragraph('', '')))
+
+        #for attr in self['attributes']:
+        #    colspecs.append(nodes.colspec(colwidth=5))
+        #    p_node = nodes.paragraph()
+        #    p_node += self.make_attribute_ref(app, attr)
+        #    hrow.append(nodes.entry('', p_node))
+
+
+        tbody = nodes.tbody()
+
+        # fill header row
+
+        for item_id in item_ids:
+            p_node = self.make_internal_item_ref(app, item_id, showcaptions)  # 1st col
+            if self['transpose']:
+                colspecs.append(nodes.colspec(colwidth=5))
+                hrow.append(nodes.entry('', p_node))
+            else:
+                row = nodes.row()
+                row.append(nodes.entry('', p_node))
+                item = collection.get_item(item_id)
+                self.fill_item_row(row, item)
+                tbody += row
+
+
         for attr in self['attributes']:
-            colspecs.append(nodes.colspec(colwidth=5))
             p_node = self.make_attribute_ref(app, attr)
-            hrow.append(nodes.entry('', p_node))
+            if self['transpose']:
+                row = nodes.row()
+                row.append(nodes.entry('', p_node))
+                self.fill_attribute_row(row, attr, item_ids, collection)
+                tbody += row
+            else:
+                colspecs.append(nodes.colspec(colwidth=5))
+                hrow.append(nodes.entry('', p_node))
+
+
+
+        #for item_id in item_ids:
+        #    item = collection.get_item(item_id)
+        #    row = nodes.row()
+        #    cell = nodes.entry()
+        #    cell += self.make_internal_item_ref(app, item_id, showcaptions)  # 1st col
+        #    row += cell
+        #    for attr in self['attributes']:
+        #        cell = nodes.entry()
+        #        p_node = nodes.paragraph()
+        #        txt = item.get_attribute(attr)
+        #        p_node += nodes.Text(txt)
+        #        cell += p_node
+        #        row += cell
+        #    tbody += row
+
         tgroup += colspecs
         tgroup += nodes.thead('', hrow)
-        tbody = nodes.tbody()
-        for item_id in item_ids:
-            item = collection.get_item(item_id)
-            row = nodes.row()
-            cell = nodes.entry()
-            cell += self.make_internal_item_ref(app, item_id, showcaptions)  # 1st col
-            row += cell
-            for attr in self['attributes']:
-                cell = nodes.entry()
-                p_node = nodes.paragraph()
-                txt = item.get_attribute(attr)
-                p_node += nodes.Text(txt)
-                cell += p_node
-                row += cell
-            tbody += row
+
         tgroup += tbody
         table += tgroup
         top_node += table
         self.replace_self(top_node)
+
+    def fill_item_row(self, row, item):
+        for attr in self['attributes']:
+            cell = nodes.entry()
+            p_node = nodes.paragraph()
+            txt = item.get_attribute(attr)
+            p_node += nodes.Text(txt)
+            cell += p_node
+            row += cell
+
+    def fill_attribute_row(self, row, attr, item_ids, collection):
+        for item_id in item_ids:
+            item = collection.get_item(item_id)
+            cell = nodes.entry()
+            p_node = nodes.paragraph()
+            txt = item.get_attribute(attr)
+            p_node += nodes.Text(txt)
+            cell += p_node
+            row += cell
 
 
 class ItemAttributesMatrixDirective(TraceableBaseDirective):

--- a/mlx/directives/item_attributes_matrix_directive.py
+++ b/mlx/directives/item_attributes_matrix_directive.py
@@ -60,6 +60,12 @@ class ItemAttributesMatrix(TraceableBaseNode):
         self.replace_self(top_node)
 
     def fill_item_row(self, row, item):
+        """ Fills the row for one item with the specified attributes.
+
+        Args:
+            row (nodes.row): Row node to fill.
+            item (TraceableItem): TraceableItem object to get attributes from.
+        """
         for attr in self['attributes']:
             cell = nodes.entry()
             p_node = nodes.paragraph()
@@ -69,6 +75,14 @@ class ItemAttributesMatrix(TraceableBaseNode):
             row += cell
 
     def fill_attribute_row(self, row, attr, item_ids, collection):
+        """ Fills the row for a particular attribute with attribute values from item IDs.
+
+        Args:
+            row (nodes.row): Row node to fill.
+            attr (str): Attribute name.
+            item_ids (list): List of item IDs.
+            collection (TraceableCollection): Storage object for a collection of TraceableItems.
+        """
         for item_id in item_ids:
             item = collection.get_item(item_id)
             cell = nodes.entry()

--- a/mlx/directives/item_attributes_matrix_directive.py
+++ b/mlx/directives/item_attributes_matrix_directive.py
@@ -29,8 +29,7 @@ class ItemAttributesMatrix(TraceableBaseNode):
         hrow = nodes.row('', nodes.entry('', nodes.paragraph('', '')))
         for attr in self['attributes']:
             colspecs.append(nodes.colspec(colwidth=5))
-            p_node = nodes.paragraph()
-            p_node += self.make_attribute_ref(app, attr)
+            p_node = self.make_attribute_ref(app, attr)
             hrow.append(nodes.entry('', p_node))
         tgroup += colspecs
         tgroup += nodes.thead('', hrow)
@@ -39,7 +38,7 @@ class ItemAttributesMatrix(TraceableBaseNode):
             item = collection.get_item(item_id)
             row = nodes.row()
             cell = nodes.entry()
-            cell += self.make_internal_item_ref(app, item_id, showcaptions)
+            cell += self.make_internal_item_ref(app, item_id, showcaptions)  # 1st col
             row += cell
             for attr in self['attributes']:
                 cell = nodes.entry()
@@ -79,6 +78,7 @@ class ItemAttributesMatrixDirective(TraceableBaseDirective):
         'sort': directives.unchanged,
         'reverse': directives.flag,
         'nocaptions': directives.flag,
+        'transpose': directives.flag,
     }
     # Content disallowed
     has_content = False
@@ -122,8 +122,8 @@ class ItemAttributesMatrixDirective(TraceableBaseDirective):
         else:
             node['sort'] = []
 
-        # Check reverse flag
         self.check_option_presence(node, 'reverse')
+        self.check_option_presence(node, 'transpose')
 
         self.check_no_captions_flag(node, app.config.traceability_attributes_matrix_no_captions)
 

--- a/mlx/directives/item_attributes_matrix_directive.py
+++ b/mlx/directives/item_attributes_matrix_directive.py
@@ -74,7 +74,8 @@ class ItemAttributesMatrix(TraceableBaseNode):
             cell += p_node
             row += cell
 
-    def fill_attribute_row(self, row, attr, item_ids, collection):
+    @staticmethod
+    def fill_attribute_row(row, attr, item_ids, collection):
         """ Fills the row for a particular attribute with attribute values from item IDs.
 
         Args:


### PR DESCRIPTION
Closes #83

Added consistency to the module name used to add the plugin to the list of Sphinx extensions. It is now 'mlx.traceability' in conf.py and README. This is the way the plugin is added in mlx.coverity. I don't see a reason to have it differently here.