### PR TITLE
Tweak generated admonitions

### DIFF
--- a/mlx/directives/item_directive.py
+++ b/mlx/directives/item_directive.py
@@ -18,20 +18,17 @@ class Item(TraceableBaseNode):
             app: Sphinx's application object to use.
             collection (TraceableCollection): Collection for which to generate the nodes.
         """
-
         self._item = collection.get_item(self['id'])
         header = self._item.get_id()
         if self._item.caption:
             header += ' : ' + self._item.caption
         top_node = self.create_top_node(header)
-        par_node = nodes.paragraph()
         dl_node = nodes.definition_list()
         if app.config.traceability_render_attributes_per_item:
             self._process_attributes(dl_node, app)
         if app.config.traceability_render_relationship_per_item:
             self._process_relationships(collection, dl_node, app)
-        par_node.append(dl_node)
-        top_node.append(par_node)
+        top_node.append(dl_node)
         # Note: content should be displayed during read of RST file, as it contains other RST objects
         self.replace_self(top_node)
 

--- a/mlx/traceable_base_node.py
+++ b/mlx/traceable_base_node.py
@@ -31,6 +31,7 @@ class TraceableBaseNode(nodes.General, nodes.Element, ABC):
         '''
         top_node = nodes.container()
         admon_node = nodes.admonition()
+        admon_node['classes'].append('item')
         title_node = nodes.title()
         title_node += nodes.Text(title)
         admon_node += title_node


### PR DESCRIPTION
In HTML: the dl element is not placed inside the paragraph, but after it as a sibling. This change removes the empty paragraph. No side effect in LaTeX.

Adding a css class called _item_ to the admonition node to give users the ability to change the CSS for only these admonitions.