### PR TITLE
Don't add dl element when it's empty

### DIFF
--- a/mlx/directives/item_directive.py
+++ b/mlx/directives/item_directive.py
@@ -28,7 +28,8 @@ class Item(TraceableBaseNode):
             self._process_attributes(dl_node, app)
         if app.config.traceability_render_relationship_per_item:
             self._process_relationships(collection, dl_node, app)
-        top_node.append(dl_node)
+        if dl_node.children:
+            top_node.append(dl_node)
         # Note: content should be displayed during read of RST file, as it contains other RST objects
         self.replace_self(top_node)
 

--- a/mlx/traceable_base_directive.py
+++ b/mlx/traceable_base_directive.py
@@ -51,7 +51,6 @@ class TraceableBaseDirective(Directive, ABC):
             if attr in self.options:
                 node['filter-attributes'][attr] = self.options[attr]
 
-
     def remove_unknown_attributes(self, attributes, description, env):
         """ Removes any unknown attributes from the given list while reporting a warning.
 


### PR DESCRIPTION
When using a custom stylesheet the addition of an empty definition list element can cause unwanted whitespace between the item's title bar and the item's content. This fixes that issue.