### PR TITLE
No longer generate empty bullet list in case of an empty item-list

### DIFF
--- a/mlx/directives/item_list_directive.py
+++ b/mlx/directives/item_list_directive.py
@@ -18,14 +18,15 @@ class ItemList(TraceableBaseNode):
         item_ids = collection.get_items(self['filter'], self['filter-attributes'])
         showcaptions = not self['nocaptions']
         top_node = self.create_top_node(self['title'])
-        ul_node = nodes.bullet_list()
-        for i in item_ids:
-            bullet_list_item = nodes.list_item()
-            p_node = nodes.paragraph()
-            p_node.append(self.make_internal_item_ref(app, i, showcaptions))
-            bullet_list_item.append(p_node)
-            ul_node.append(bullet_list_item)
-        top_node += ul_node
+        if item_ids:
+            ul_node = nodes.bullet_list()
+            for i in item_ids:
+                bullet_list_item = nodes.list_item()
+                p_node = nodes.paragraph()
+                p_node.append(self.make_internal_item_ref(app, i, showcaptions))
+                bullet_list_item.append(p_node)
+                ul_node.append(bullet_list_item)
+            top_node += ul_node
         self.replace_self(top_node)
 
 


### PR DESCRIPTION
This change prevents the generation of an empty bullet_list node when for each empty _item-list_ to fix the LaTeX error below, reported by @dryodon :
`LaTeX Error: Something's wrong--perhaps a missing \item.`
The plugin wants to generate an emtpy bullet list for an empty _item-list_, which results in the code below in traceability.tex:
```
\begin{itemize}
\end{itemize}
```
LaTeX expects at least one `\item`.