### PR TITLE
Remove unused env argument

### DIFF
--- a/mlx/traceability.py
+++ b/mlx/traceability.py
@@ -230,8 +230,7 @@ def initialize_environment(app):
     if app.config.traceability_checklist:
         add_checklist_attribute(app.config.traceability_checklist,
                                 app.config.traceability_attributes,
-                                app.config.traceability_attribute_to_string,
-                                env)
+                                app.config.traceability_attribute_to_string)
 
     init_available_relationships(app)
 
@@ -246,7 +245,7 @@ def initialize_environment(app):
 # ----------------------------------------------------------------------------
 # Event handler helper functions
 
-def add_checklist_attribute(checklist_config, attributes_config, attribute_to_string_config, env):
+def add_checklist_attribute(checklist_config, attributes_config, attribute_to_string_config):
     """ Adds the specified attribute for checklist items to the application configuration variables.
 
     Reports a warning when the TARGET_ATTRIBUTE_VALUES variable is not string of two comma-separated attribute values.
@@ -255,7 +254,6 @@ def add_checklist_attribute(checklist_config, attributes_config, attribute_to_st
         checklist_config (dict): Dictionary containing the attribute configuration parameters for checklist items.
         attributes_config (dict): Dictionary containing the attribute configuration parameters for regular items.
         attribute_to_string_config (dict): Dictionary mapping an attribute to its string representation.
-        env (sphinx.environment.BuildEnvironment): Sphinx's build environment.
     """
     attr_values = checklist_config['attribute_values'].split(',')
     if len(attr_values) != 2:
@@ -265,7 +263,7 @@ def add_checklist_attribute(checklist_config, attributes_config, attribute_to_st
         regexp = "[{}|{}]".format(attr_values[0], attr_values[1])
         attributes_config[checklist_config['attribute_name']] = regexp
         attribute_to_string_config[checklist_config['attribute_name']] = checklist_config['attribute_to_str']
-        ChecklistItemDirective.query_results = query_checklist(checklist_config, attr_values, env)
+        ChecklistItemDirective.query_results = query_checklist(checklist_config, attr_values)
 
 
 def define_attribute(attr, app):
@@ -278,7 +276,7 @@ def define_attribute(attr, app):
     TraceableItem.define_attribute(attrobject)
 
 
-def query_checklist(settings, attr_values, env):
+def query_checklist(settings, attr_values):
     """ Queries specified API host name for the description of the specified merge request.
 
     Reports a warning if the API host name is invalid or the response does not contain a description.
@@ -286,7 +284,6 @@ def query_checklist(settings, attr_values, env):
     Args:
         settings (dict): Dictionary with the environment variables specified for the checklist feature.
         attr_values (list): List of the two possible attribute values (str).
-        env (sphinx.environment.BuildEnvironment): Sphinx's build environment.
 
     Returns:
         (dict) The query results with zero or more key-value pairs in the form of {item ID: attribute value}.

--- a/mlx/traceable_collection.py
+++ b/mlx/traceable_collection.py
@@ -185,20 +185,20 @@ class TraceableCollection:
                 for tgt in item.iter_targets(relation):
                     # Target item exists?
                     if tgt not in self.items:
-                        errors.append(TraceabilityException('''{source} {relation} {target},
-                                      but {target} is not known'''.format(source=itemid,
-                                                                          relation=relation,
-                                                                          target=tgt),
-                                      item.get_document()))
+                        errors.append(TraceabilityException("{source} {relation} {target}, but {target} is not known"
+                                                            .format(source=itemid,
+                                                                    relation=relation,
+                                                                    target=tgt),
+                                                            item.get_document()))
                         continue
                     # Reverse relation exists?
                     target = self.get_item(tgt)
                     if itemid not in target.iter_targets(rev_relation):
-                        errors.append(TraceabilityException('''No automatic reverse relation:
-                                      {source} {relation} {target}'''.format(source=tgt,
-                                                                             relation=rev_relation,
-                                                                             target=itemid),
-                                      item.get_document()))
+                        errors.append(TraceabilityException("No automatic reverse relation: {source} {relation} "
+                                                            "{target}".format(source=tgt,
+                                                                              relation=rev_relation,
+                                                                              target=itemid),
+                                                            item.get_document()))
         if errors:
             raise MultipleTraceabilityExceptions(errors)
 


### PR DESCRIPTION
Removed unused `env` argument in `add_checklist_attribute` and `query_checklist` functions.
Minor style fixes regarding indentation.