### PR TITLE
Facilitate configuration of multiple merge request IDs in traceability_checklist dict

### DIFF
--- a/doc/.env.example
+++ b/doc/.env.example
@@ -1,7 +1,7 @@
 PRIVATE_TOKEN = ''
 API_HOST_NAME = 'your_api_host_name'
 PROJECT_ID = 'your_project_id'
-MERGE_REQUEST_ID = 'your_merge_request_id'
+MERGE_REQUEST_ID = 'your_merge_request_id(s)'
 ATTRIBUTE_NAME = 'attribute_name'
 ATTRIBUTE_TO_STRING = 'attribute_representation'
 ATTRIBUTE_VALUES = 'yes,no'

--- a/doc/checklist.rst
+++ b/doc/checklist.rst
@@ -42,9 +42,9 @@ Checklist items
     The item ID is present in the queried PR description, but won't get the configured checklist-attribute added since
     its defined with the regular item directive.
 
--------------------------
+---------------------------
 Matrices of checklist items
--------------------------
+---------------------------
 
 .. item-attributes-matrix:: Questions and answers
     :filter: QUE-

--- a/doc/checklist.rst
+++ b/doc/checklist.rst
@@ -28,10 +28,28 @@ Checklist items
 
     This item ID is not present in the checklist of the pull request and should trigger a warning.
 
+.. checklist-item:: CL-SOME_ITEM A checklist item from a different PR
+    :nocaptions:
+
+    Checklist item with hidden caption.
+
+.. checklist-item:: CL-ANOTHER_ONE Another checklist item
+
+    Checklist items inherit from regular items.
+
+.. item:: CL-LUCKY_ONE Item that should be a checklist-item
+
+    The item ID is present in the queried PR description, but won't get the configured checklist-attribute added since
+    its defined with the regular item directive.
+
 -------------------------
-Matrix of checklist items
+Matrices of checklist items
 -------------------------
 
-.. item-attributes-matrix:: Checklist attribute values
-    :filter: QUE
+.. item-attributes-matrix:: Questions and answers
+    :filter: QUE-
+    :attributes: checked
+
+.. item-attributes-matrix:: Checklist attribute matrix
+    :filter: ^CL-
     :attributes: checked

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -370,7 +370,10 @@ traceability_checklist = {
     'private_token': config('PRIVATE_TOKEN', ''),
     'api_host_name': config('API_HOST_NAME', 'https://api.github.com'),
     'project_id': config('PROJECT_ID', 'melexis/sphinx-traceability-extension'),
-    'merge_request_id': config('MERGE_REQUEST_ID', '121'),
+    'merge_request_id': {
+        "QUE-": "121",
+        "CL-": "138",
+    },
     'attribute_name': config('ATTRIBUTE_NAME', 'checked'),
     'attribute_to_str': config('ATTRIBUTE_TO_STRING', 'Answer'),
     'attribute_values': config('ATTRIBUTE_VALUES', 'yes,no'),

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -370,10 +370,7 @@ traceability_checklist = {
     'private_token': config('PRIVATE_TOKEN', ''),
     'api_host_name': config('API_HOST_NAME', 'https://api.github.com'),
     'project_id': config('PROJECT_ID', 'melexis/sphinx-traceability-extension'),
-    'merge_request_id': {
-        "QUE-": "121",
-        "CL-": "138",
-    },
+    'merge_request_id': config('MERGE_REQUEST_ID', '121,138'),
     'attribute_name': config('ATTRIBUTE_NAME', 'checked'),
     'attribute_to_str': config('ATTRIBUTE_TO_STRING', 'Answer'),
     'attribute_values': config('ATTRIBUTE_VALUES', 'yes,no'),


### PR DESCRIPTION
Multiple merge request IDs can be defined as a string with comma-separation, e.g. `'121,138'`. This string can be added to the `traceability_checklist` dict as a value for `'merge_request_id'` or as an environment variable called `MERGE_REQUEST_ID`.

Closes #137 

The checklist below gets queried when building the example documentation:
- [x] CL-SOME_ITEM Insert some question here.
- [ ] CL-ANOTHER_ONE Insert another question here.
- [x] CL-LUCKY_ONE These captions are independent from those in the example documentation.