### PR TITLE
Use match instead of search with leading caret, and fullmatch where sensible

### DIFF
--- a/mlx/traceability.py
+++ b/mlx/traceability.py
@@ -8,7 +8,7 @@ See readme for more details.
 '''
 
 from collections import OrderedDict, namedtuple
-from re import match
+from re import fullmatch, match
 from os import path
 
 from requests import Session
@@ -185,7 +185,7 @@ def process_item_nodes(app, doctree, fromdocname):
 
     regex = app.config.traceability_checklist['checklist_item_regex']
     for item_id in list(ChecklistItemDirective.query_results):
-        if match(regex, item_id):
+        if fullmatch(regex, item_id):
             item_info = ChecklistItemDirective.query_results.pop(item_id)
             report_warning("List item {!r} in merge/pull request {} is not defined as a checklist-item."
                            .format(item_id, item_info.mr_id))

--- a/mlx/traceability.py
+++ b/mlx/traceability.py
@@ -8,7 +8,7 @@ See readme for more details.
 '''
 
 from collections import OrderedDict, namedtuple
-from re import match, search
+from re import match
 from os import path
 
 from requests import Session
@@ -184,11 +184,11 @@ def process_item_nodes(app, doctree, fromdocname):
         node.perform_replacement(app, env.traceability_collection)
 
     regex = app.config.traceability_checklist['checklist_item_regex']
-    for item_id, item_info in ChecklistItemDirective.query_results.copy().items():
+    for item_id in list(ChecklistItemDirective.query_results):
         if match(regex, item_id):
+            item_info = ChecklistItemDirective.query_results.pop(item_id)
             report_warning("List item {!r} in merge/pull request {} is not defined as a checklist-item."
                            .format(item_id, item_info.mr_id))
-            ChecklistItemDirective.query_results.pop(item_id)
 
 
 def init_available_relationships(app):
@@ -356,7 +356,7 @@ def _parse_description(description, attr_values, merge_request_id, regex):
     query_results = {}
     for line in description.split('\n'):
         # catch the content of checkbox and the item ID after the checkbox
-        cli_match = search(r"^\s*[\*\-]\s+\[(?P<checkbox>[\sx])\]\s+(?P<target_id>{})".format(regex), line)
+        cli_match = match(r"\s*[\*\-]\s+\[(?P<checkbox>[\sx])\]\s+(?P<target_id>{})".format(regex), line)
         if cli_match:
             if cli_match.group('checkbox') == 'x':
                 item_info = ItemInfo(attr_values[0], merge_request_id)


### PR DESCRIPTION
- `match` does the same thing as `search` with a leading `^`, but is faster.
- `fullmatch` is now used instead of `match` when trying to match leftover item IDs in the `query_results` dictionary. This won't change the behavior, however. It just clarifies the code.