### PR TITLE
Add group attribute to item-matrix directive

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@
 
 .. image:: https://badge.fury.io/py/mlx.traceability.png
     :target: https://badge.fury.io/py/mlx.traceability
-    :alt: Pypi packaged release
+    :alt: PyPI packaged release
 
 .. image:: https://travis-ci.org/melexis/sphinx-traceability-extension.png?branch=master
     :target: https://travis-ci.org/melexis/sphinx-traceability-extension
@@ -665,6 +665,7 @@ A traceability matrix of documentation items can be generated using:
         :type: validated_by
         :nocaptions:
         :stats:
+        :group: bottom
 
 where the *source* and *target* arguments can be replaced by any Python regular expression.
 
@@ -688,6 +689,9 @@ matrix. The plugin counts the number of items having a target item in the target
 and the number of items having no target in the target-column (=not covered or allocated). And calculates a
 coverage/allocation percentage from these counts. If the *stats* flag is not given, this percentage is not
 displayed.
+
+The *group* argument can be used to group source items that don't have any target items. You can explicitly specify to
+have them grouped at the *top* or *bottom* of the matrix. If no argument is given, they will be grouped at the top.
 
 Optionally, the *class* attribute can be specified to customize table output, especially useful when rendering to
 LaTeX. Normally the *longtable* class is used when the number of rows is greater than 30 which allows long tables to

--- a/doc/integration_test_report.rst
+++ b/doc/integration_test_report.rst
@@ -253,6 +253,7 @@ All relationships
 .. item-matrix:: All (no captions)
     :nocaptions:
     :stats:
+    :group: bottom
 
 All relationships with items having ASIL-C/D attribute
 ------------------------------------------------------

--- a/mlx/directives/item_matrix_directive.py
+++ b/mlx/directives/item_matrix_directive.py
@@ -1,6 +1,8 @@
+from collections import namedtuple
 from docutils import nodes
 from docutils.parsers.rst import directives
 
+from mlx.traceability_exception import report_warning
 from mlx.traceable_base_directive import TraceableBaseDirective
 from mlx.traceable_base_node import TraceableBaseNode, REGEXP_EXTERNAL_RELATIONSHIP
 
@@ -17,6 +19,7 @@ class ItemMatrix(TraceableBaseNode):
             app: Sphinx application object to use.
             collection (TraceableCollection): Collection for which to generate the nodes.
         """
+        Rows = namedtuple('Rows', "covered uncovered", defaults=([], []))
         showcaptions = not self['nocaptions']
         source_ids = collection.get_items(self['source'], self['filter-attributes'])
         target_ids = collection.get_items(self['target'])
@@ -42,7 +45,7 @@ class ItemMatrix(TraceableBaseNode):
 
         count_total = 0
         count_covered = 0
-
+        rows_container = Rows()
         for source_id in source_ids:
             source_item = collection.get_item(source_id)
             count_total += 1
@@ -60,11 +63,25 @@ class ItemMatrix(TraceableBaseNode):
                 if collection.are_related(source_id, relationships, target_id):
                     right += self.make_internal_item_ref(app, target_id, showcaptions)
                     covered = True
-            if covered:
-                count_covered += 1
+
             row += left
             row += right
-            tbody += row
+
+            if covered:
+                count_covered += 1
+                rows_container.covered.append(row)
+            else:
+                rows_container.uncovered.append(row)
+
+            if not self['group']:
+                tbody += row
+
+        if self['group'] == 'top':
+            tbody += rows_container.uncovered
+            tbody += rows_container.covered
+        elif self['group'] == 'bottom':
+            tbody += rows_container.covered
+            tbody += rows_container.uncovered
 
         try:
             percentage = int(100 * count_covered / count_total)
@@ -97,6 +114,7 @@ class ItemMatrixDirective(TraceableBaseDirective):
          :targettitle: Target column header
          :sourcetitle: Source column header
          :type: <<relationship>> ...
+         :group: top | bottom
          :stats:
          :nocaptions:
     """
@@ -110,6 +128,7 @@ class ItemMatrixDirective(TraceableBaseDirective):
         'targettitle': directives.unchanged,
         'sourcetitle': directives.unchanged,
         'type': directives.unchanged,  # a string with relationship types separated by space
+        'group': directives.unchanged,
         'stats': directives.flag,
         'nocaptions': directives.flag,
     }
@@ -138,6 +157,19 @@ class ItemMatrixDirective(TraceableBaseDirective):
                               'sourcetitle': 'Source',
                               'type': [],
                               })
+
+        # Process ``group`` option, given as a string that is either top or bottom or empty ().
+        if 'group' in self.options:
+            group_attr = self.options['group']
+            if group_attr == 'bottom':
+                item_matrix_node['group'] = 'bottom'
+            else:
+                if group_attr and group_attr != 'top':
+                    report_warning("Argument for 'group' attribute should be 'top' or 'bottom'; got '{}'. "
+                                   "Using default 'top'.".format(group_attr), env.docname, self.lineno)
+                item_matrix_node['group'] = 'top'
+        else:
+            item_matrix_node['group'] = ''
 
         self.check_relationships(item_matrix_node['type'], env)
 

--- a/mlx/directives/item_matrix_directive.py
+++ b/mlx/directives/item_matrix_directive.py
@@ -19,7 +19,7 @@ class ItemMatrix(TraceableBaseNode):
             app: Sphinx application object to use.
             collection (TraceableCollection): Collection for which to generate the nodes.
         """
-        Rows = namedtuple('Rows', "covered uncovered", defaults=([], []))
+        Rows = namedtuple('Rows', "covered uncovered")
         showcaptions = not self['nocaptions']
         source_ids = collection.get_items(self['source'], self['filter-attributes'])
         target_ids = collection.get_items(self['target'])
@@ -45,7 +45,7 @@ class ItemMatrix(TraceableBaseNode):
 
         count_total = 0
         count_covered = 0
-        rows_container = Rows()
+        rows_container = Rows([], [])
         for source_id in source_ids:
             source_item = collection.get_item(source_id)
             count_total += 1

--- a/tox.ini
+++ b/tox.ini
@@ -51,12 +51,12 @@ deps=
     {[testenv]deps}
     sphinx <= 2.1.9999
     sphinxcontrib-plantuml
-    mlx.warnings
+    mlx.warnings >= 1.2.0
 whitelist_externals =
     bash
     make
     tee
-    mlx-warnings==1.1.0
+    mlx-warnings
 commands=
     bash -c 'make -C doc html 2>&1 | tee .tox/doc_html.log'
     mlx-warnings --sphinx --maxwarnings 17 --minwarnings 17 .tox/doc_html.log
@@ -68,12 +68,12 @@ deps=
     {[testenv]deps}
     sphinx
     sphinxcontrib-plantuml
-    mlx.warnings
+    mlx.warnings >= 1.2.0
 whitelist_externals =
     bash
     make
     tee
-    mlx-warnings==1.1.0
+    mlx-warnings
 commands=
     bash -c 'make -C doc html 2>&1 | tee .tox/doc_html.log'
     mlx-warnings --sphinx --maxwarnings 17 --minwarnings 17 .tox/doc_html.log

--- a/tox.ini
+++ b/tox.ini
@@ -59,7 +59,7 @@ whitelist_externals =
     mlx-warnings==1.1.0
 commands=
     bash -c 'make -C doc html 2>&1 | tee .tox/doc_html.log'
-    mlx-warnings --sphinx --maxwarnings 18 --minwarnings 18 .tox/doc_html.log
+    mlx-warnings --sphinx --maxwarnings 17 --minwarnings 17 .tox/doc_html.log
     bash -c 'make -C doc latexpdf 2>&1 | tee .tox/doc_pdf.log'
     mlx-warnings --sphinx --maxwarnings 17 --minwarnings 17 .tox/doc_pdf.log
 
@@ -76,7 +76,7 @@ whitelist_externals =
     mlx-warnings==1.1.0
 commands=
     bash -c 'make -C doc html 2>&1 | tee .tox/doc_html.log'
-    mlx-warnings --sphinx --maxwarnings 18 --minwarnings 18 .tox/doc_html.log
+    mlx-warnings --sphinx --maxwarnings 17 --minwarnings 17 .tox/doc_html.log
     bash -c 'make -C doc latexpdf 2>&1 | tee .tox/doc_pdf.log'
     mlx-warnings --sphinx --maxwarnings 17 --minwarnings 17 .tox/doc_pdf.log
 


### PR DESCRIPTION
Add `group` attribute to item-matrix directive to group source items that do not have a target item.
Closes #145 

TODO:
- [x] Implementation
- [x] Use attribute in example documentation
- [x] Add feature to documentation