### PR TITLE
Fix behavior in case of overlap between custom attributes and directive options

### DIFF
--- a/doc/integration_test_report.rst
+++ b/doc/integration_test_report.rst
@@ -179,7 +179,7 @@ Attribute details
 
 .. item-attribute:: ASIL The level for ASIL
 
-    In ISO26262 ASIL is defined as Automotive Safety Integrety Level. The level can be
+    In ISO26262 ASIL is defined as Automotive Safety Integrity Level. The level can be
     at A/B/C/D for increasing safety requirements.
 
 .. item-attribute:: ASPICE The level for A-SPICE

--- a/mlx/traceability.py
+++ b/mlx/traceability.py
@@ -198,6 +198,9 @@ def init_available_relationships(app):
     """
     Update directive option_spec with custom attributes defined in
     configuration file ``traceability_attributes`` variable.
+    Report a warning when the custom attribute overlaps with a
+    predefined directive attribute, in which case the custom attribute
+    will be ignored in that directive.
 
     Update directive option_spec with custom relationships defined in
     configuration file ``traceability_relationships`` variable. Both
@@ -209,16 +212,28 @@ def init_available_relationships(app):
     Function also passes relationships to traceability collection.
     """
     env = app.builder.env
+    directive_classes = (
+        ItemDirective,
+        ItemListDirective,
+        ItemMatrixDirective,
+        ItemPieChartDirective,
+        ItemAttributesMatrixDirective,
+        Item2DMatrixDirective,
+        ItemTreeDirective,
+    )
 
     for attr in app.config.traceability_attributes:
-        ItemDirective.option_spec[attr] = directives.unchanged
-        ItemListDirective.option_spec[attr] = directives.unchanged
-        ItemMatrixDirective.option_spec[attr] = directives.unchanged
-        ItemPieChartDirective.option_spec[attr] = directives.unchanged
-        ItemAttributesMatrixDirective.option_spec[attr] = directives.unchanged
-        Item2DMatrixDirective.option_spec[attr] = directives.unchanged
-        ItemTreeDirective.option_spec[attr] = directives.unchanged
+        conflicting_directives = []
+        for directive_class in directive_classes:
+            if attr in directive_class.option_spec:
+                conflicting_directives.append(directive_class.__name__)
+                directive_class.conflicting_options.append(attr)
+            else:
+                directive_class.option_spec[attr] = directives.unchanged
         define_attribute(attr, app)
+        if conflicting_directives:
+            report_warning("Your custom attribute {!r} is an attribute of directive(s) {!r} in which your attribute "
+                           "definition will be ignored.".format(attr, conflicting_directives))
 
     for rel in app.config.traceability_relationships:
         revrel = app.config.traceability_relationships[rel]

--- a/mlx/traceability.py
+++ b/mlx/traceability.py
@@ -199,8 +199,8 @@ def init_available_relationships(app):
     Update directive option_spec with custom attributes defined in
     configuration file ``traceability_attributes`` variable.
     Report a warning when the custom attribute overlaps with a
-    predefined directive attribute, in which case the custom attribute
-    will be ignored in that directive.
+    directive option, in which case the custom attribute will be
+    ignored in that directive.
 
     Update directive option_spec with custom relationships defined in
     configuration file ``traceability_relationships`` variable. Both
@@ -232,8 +232,8 @@ def init_available_relationships(app):
                 directive_class.option_spec[attr] = directives.unchanged
         define_attribute(attr, app)
         if conflicting_directives:
-            report_warning("Your custom attribute {!r} is an attribute of directive(s) {!r} in which your attribute "
-                           "definition will be ignored.".format(attr, conflicting_directives))
+            report_warning("Your custom attribute {!r} overlaps with an option of directive(s) {!r} in which your "
+                           "attribute definition will be ignored.".format(attr, conflicting_directives))
 
     for rel in app.config.traceability_relationships:
         revrel = app.config.traceability_relationships[rel]

--- a/mlx/traceable_base_directive.py
+++ b/mlx/traceable_base_directive.py
@@ -10,6 +10,7 @@ class TraceableBaseDirective(Directive, ABC):
     """ Base class for all Traceability directives. """
 
     final_argument_whitespace = True
+    conflicting_options = []
 
     @abstractmethod
     def run(self):
@@ -48,7 +49,7 @@ class TraceableBaseDirective(Directive, ABC):
         """
         node['filter-attributes'] = {}
         for attr in TraceableItem.defined_attributes:
-            if attr in self.options:
+            if attr in self.options and attr not in self.conflicting_options:
                 node['filter-attributes'][attr] = self.options[attr]
 
     def remove_unknown_attributes(self, attributes, description, docname):

--- a/tox.ini
+++ b/tox.ini
@@ -51,12 +51,12 @@ deps=
     {[testenv]deps}
     sphinx <= 2.1.9999
     sphinxcontrib-plantuml
-    mlx.warnings
+    mlx.warnings >= 1.2.0
 whitelist_externals =
     bash
     make
     tee
-    mlx-warnings==1.1.0
+    mlx-warnings
 commands=
     bash -c 'make -C doc html 2>&1 | tee .tox/doc_html.log'
     mlx-warnings --sphinx --maxwarnings 17 --minwarnings 17 .tox/doc_html.log
@@ -68,12 +68,12 @@ deps=
     {[testenv]deps}
     sphinx
     sphinxcontrib-plantuml
-    mlx.warnings
+    mlx.warnings >= 1.2.0
 whitelist_externals =
     bash
     make
     tee
-    mlx-warnings==1.1.0
+    mlx-warnings
 commands=
     bash -c 'make -C doc html 2>&1 | tee .tox/doc_html.log'
     mlx-warnings --sphinx --maxwarnings 17 --minwarnings 17 .tox/doc_html.log

--- a/tox.ini
+++ b/tox.ini
@@ -59,7 +59,7 @@ whitelist_externals =
     mlx-warnings==1.1.0
 commands=
     bash -c 'make -C doc html 2>&1 | tee .tox/doc_html.log'
-    mlx-warnings --sphinx --maxwarnings 18 --minwarnings 18 .tox/doc_html.log
+    mlx-warnings --sphinx --maxwarnings 17 --minwarnings 17 .tox/doc_html.log
     bash -c 'make -C doc latexpdf 2>&1 | tee .tox/doc_pdf.log'
     mlx-warnings --sphinx --maxwarnings 17 --minwarnings 17 .tox/doc_pdf.log
 
@@ -76,7 +76,7 @@ whitelist_externals =
     mlx-warnings==1.1.0
 commands=
     bash -c 'make -C doc html 2>&1 | tee .tox/doc_html.log'
-    mlx-warnings --sphinx --maxwarnings 18 --minwarnings 18 .tox/doc_html.log
+    mlx-warnings --sphinx --maxwarnings 17 --minwarnings 17 .tox/doc_html.log
     bash -c 'make -C doc latexpdf 2>&1 | tee .tox/doc_pdf.log'
     mlx-warnings --sphinx --maxwarnings 17 --minwarnings 17 .tox/doc_pdf.log
 


### PR DESCRIPTION
The plugin will now report a warning when a custom attribute overlaps with a directive option, in which case the custom attribute definition will be ignored. 

Example of a warning when a custom traceability attribute `source` is defined by the user:
`WARNING: Your custom attribute 'source' overlaps with an option of directive(s) ['ItemMatrixDirective', 'Item2DMatrixDirective'] in which your attribute definition will be ignored.`

Closes #148 