### PR TITLE
Install Tex Live and latexmk packages for pdf build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,18 @@ env:
     - SEGFAULT_SIGNALS=all
   matrix:
     - TOXENV=check
+
+ addons:
+  apt:
+    packages:
+      # for building latex/pdf
+      - texlive-base
+      - texlive-latex-base
+      - texlive-latex-recommended
+      - texlive-latex-extra
+      - texlive-fonts-recommended
+      - latexmk
+
 matrix:
   include:
     - python: 3.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
   matrix:
     - TOXENV=check
 
- addons:
+addons:
   apt:
     packages:
       # for building latex/pdf


### PR DESCRIPTION
Currently the CI build fails the pdf build:
```
latexmk -pdf -dvi- -ps- -silent 'traceability.tex'
make[1]: latexmk: Command not found
Makefile:33: recipe for target 'traceability.pdf' failed
```