### PR TITLE
Use latest sphinx_selective_exclude in test environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ as a requirements management tool for e.g. ISO26262 projects.
 - [Installation](https://melexis.github.io/sphinx-traceability-extension/installation.html)
 - [Configuration](https://melexis.github.io/sphinx-traceability-extension/configuration.html)
 - [Usage](https://melexis.github.io/sphinx-traceability-extension/usage.html)
-- [Process](#process)
 
 ### Process
 

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ deps=
     natsort
     matplotlib
     sphinx-testing >= 0.5.2
-    sphinx_selective_exclude==1.0.3
+    sphinx_selective_exclude>=1.0.3
     sphinx_rtd_theme
 commands=
     {posargs:py.test --cov=mlx --cov-report=term-missing -vv tests/}

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ deps=
     natsort
     matplotlib
     sphinx-testing >= 0.5.2
-    sphinx_selective_exclude==1.0.1
+    sphinx_selective_exclude==1.0.3
     sphinx_rtd_theme
 commands=
     {posargs:py.test --cov=mlx --cov-report=term-missing -vv tests/}


### PR DESCRIPTION
Let tox use `sphinx_selective_exclude>=1.0.3`. Version `1.0.2` is broken.

Removed Process section from toctree since it felt out of place and its link is broken on PyPI anyway. https://github.com/pypa/warehouse/issues/4064