### PR TITLE
Add configurability for attribute sorting

### DIFF
--- a/doc/design.rst
+++ b/doc/design.rst
@@ -166,6 +166,11 @@ Design for mlx.traceability
             + {static} dict query_results
         }
 
+        class AttributeSortDirective {
+            + {static} dict option_spec
+            + {static} has_content = False
+        }
+
         abstract class TraceableBaseNode {
             + {abstract} perform_replacement(app, collection)
             + {static} create_top_node(title)
@@ -224,6 +229,9 @@ Design for mlx.traceability
             # generate_bullet_list_tree(app, collection, item_id, captions=True)
         }
 
+        class AttributeSort {
+        }
+
         class PendingItemXref {
         }
 
@@ -264,6 +272,7 @@ Design for mlx.traceability
         ItemMatrixDirective "1" *-- "1" ItemMatrix
         ItemPieChartDirective "1" *-- "1" ItemPieChart
         ItemTreeDirective "1" *-- "1" ItemTree
+        AttributeSortDirective "1" *-- "1" AttributeSort
         Exception <|-- TraceabilityException
         Exception <|-- MultipleTraceabilityExceptions
         @enduml
@@ -308,7 +317,7 @@ Design for mlx.traceability
 
     Attributes shall be able to be added to the documentation parts.
     Attributes have a key and an optional value.
-    The set of attributes and the validness of the attribute values shall be configurable.
+    The set of attributes, their order and the validness of the attribute values shall be configurable.
 
 .. item:: DESIGN-RELATIONS Documentation parts can be linked to each other
     :depends_on: DESIGN-ITEMIZE
@@ -349,6 +358,11 @@ Design for mlx.traceability
     :depends_on: DESIGN-ATTRIBUTES
 
     An overview table of the attribute values for documentation parts shall be generated.
+
+.. item:: DESIGN-ATTRIBUTE_SORT Custom sorting of items' attributes
+    :depends_on: DESIGN-ATTRIBUTES
+
+    The plugin shall have a directive that allows configurability of the order of items' attributes.
 
 -------------------
 Traceability matrix

--- a/doc/design.rst
+++ b/doc/design.rst
@@ -315,54 +315,52 @@ Design for mlx.traceability
 .. item:: DESIGN-ATTRIBUTES Documentation parts can have attributes
     :depends_on: DESIGN-ITEMIZE
 
-    Attributes shall be able to be added to the documentation parts.
+    Attributes can be added to the documentation parts.
     Attributes have a key and an optional value.
-    The set of attributes, their order and the validness of the attribute values shall be configurable.
+    The set of attributes, their order and the validness of the attribute values are configurable.
 
 .. item:: DESIGN-RELATIONS Documentation parts can be linked to each other
     :depends_on: DESIGN-ITEMIZE
 
-    Documentation parts shall be able to link to other documentation parts.
-    The set of relations shall be configurable.
+    Documentation parts can be linked to other documentation parts.
+    The set of relations is configurable.
 
 .. item:: DESIGN-AUTO_REVERSE Automatic creation of reverse relations
     :depends_on: DESIGN-RELATIONS
 
     When a documentation part <A> is related to a documentation part <B> (forward relation), the reverse
-    relation from documentation part <B> to documentation part <A> shall be automatically created.
+    relation from documentation part <B> to documentation part <A> gets created automatically.
 
 .. item:: DESIGN-LIST Listing documentation parts
     :depends_on: DESIGN-ITEMIZE
 
-    A list of documentation parts matching a certain query shall be able to be retrieved.
+    A list of documentation parts matching a certain query can be retrieved.
 
 .. item:: DESIGN-COVERAGE Calculation of coverage for relations between documentation parts
     :depends_on: DESIGN-RELATIONS
 
-    The plugin shall be able to calculate the coverage for a certain type of relation between
+    The plugin is able to calculate the coverage for a certain type of relation between
     documentation parts.
 
 .. item:: DESIGN-MATRIX Auto-generation of a traceability matrix
     :depends_on: DESIGN-RELATIONS
 
-    The relations between documentation parts shall be able to be queried, and an overview matrix
-    shall be able to be generated.
+    The relations between documentation parts can be queried, and an overview matrix can be generated.
 
 .. item:: DESIGN-TREE Auto-generation of a traceability tree
     :depends_on: DESIGN-RELATIONS
 
-    The relations between documentation parts shall be able to be queried, and an overview tree
-    shall be able to be generated.
+    The relations between documentation parts can be queried, and an overview tree can be generated.
 
 .. item:: DESIGN-ATTRIBUTES_MATRIX Overview of attributes on documentation parts
     :depends_on: DESIGN-ATTRIBUTES
 
-    An overview table of the attribute values for documentation parts shall be generated.
+    An overview table of the attribute values for documentation parts can be generated.
 
 .. item:: DESIGN-ATTRIBUTE_SORT Custom sorting of items' attributes
     :depends_on: DESIGN-ATTRIBUTES
 
-    The plugin shall have a directive that allows configurability of the order of items' attributes.
+    The plugin has a directive that allows configurability of the order of items' attributes.
 
 -------------------
 Traceability matrix

--- a/doc/integration_test_report.rst
+++ b/doc/integration_test_report.rst
@@ -19,6 +19,15 @@ SRS and SSS
 Other requirements
 ==================
 
+.. attribute-sort::
+    :filter: r003
+    :sort: status
+
+.. attribute-sort::
+    :sort: aspice nonexistent
+
+.. triggers a warning about r003 already having a configuration for attribute-sort
+
 .. item:: r001 First requirement
     :class: functional requirement
     :status: Draft
@@ -73,6 +82,7 @@ This text is not part of any item
 .. item:: r006 Depends on all
     :class: terciary
     :asil: C
+    :aspice: 2
     :value: 12
     :trace: r001
         r002
@@ -185,6 +195,8 @@ Attribute details
 .. item-attribute:: ASPICE The level for A-SPICE
 
     Similar to ASIL, ASPICE is an automitve safety standard. Levels are ASPICE 1/2/3.
+
+.. item-attribute:: status The approval status
 
 .. item-attribute:: non_existing_attribute This should trigger a warning
 

--- a/doc/requirements.rst
+++ b/doc/requirements.rst
@@ -85,7 +85,7 @@ Requirements for mlx.traceability
 
 .. item:: RQT-ATTRIBUTE_SORT Custom sorting of items' attributes
     :depends_on: RQT-ATTRIBUTES
-    :fullfilled_by: DESIGN-ATTRIBUTE_SORT
+    :fulfilled_by: DESIGN-ATTRIBUTE_SORT
 
     The plugin shall be able to allow configurability of the order of items' attributes.
 

--- a/doc/requirements.rst
+++ b/doc/requirements.rst
@@ -83,6 +83,12 @@ Requirements for mlx.traceability
 
     An overview table of the attribute values for documentation parts shall be generated.
 
+.. item:: RQT-ATTRIBUTE_SORT Custom sorting of items' attributes
+    :depends_on: RQT-ATTRIBUTES
+    :fullfilled_by: DESIGN-ATTRIBUTE_SORT
+
+    The plugin shall be able to allow configurability of the order of items' attributes.
+
 -------------------
 Traceability matrix
 -------------------

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -113,6 +113,22 @@ to add content to the attributes. A detailed description can be added to an attr
 
         The status of the requirement explains whether it is *draft*, *under-review*, *approved* or *invalid*.
 
+---------------------------
+Configuring attribute order
+---------------------------
+
+By default, attributes get sorted naturally. This default behavior can be changed by use of the dedicated
+``attribute-sort`` directive. The ``filter`` option allows filtering on item IDs. Its value gets treated as a regular
+expression. If this option is missing, the configuration will be applied to all items. The ``sort`` option must be a
+list of attributes, of which the order is used to sort the attributes of those items that match the filter regex.
+Attributes that are missing from this list get sorted naturally and appended afterwards.
+
+.. code-block:: rest
+
+    .. attribute-sort::
+        :filter: RQT-
+        :sort: status value aspice
+
 .. _traceability_usage_item_linking:
 
 ----------------------------------

--- a/mlx/directives/attribute_sort_directive.py
+++ b/mlx/directives/attribute_sort_directive.py
@@ -6,7 +6,7 @@ from mlx.traceable_base_node import TraceableBaseNode
 
 
 class AttributeSort(TraceableBaseNode):
-    '''List of documentation items'''
+    """Node that configures the order of filtered items' attributes in the generated output."""
 
     def perform_replacement(self, app, collection):
         """ Processes the attribute-sort items.
@@ -26,7 +26,9 @@ class AttributeSort(TraceableBaseNode):
 
 class AttributeSortDirective(TraceableBaseDirective):
     """
-    Directive to configure the order of items' attributes in the generated output.
+    Directive to store the configuration of the order of filtered items' attributes.
+
+    The node will be responsible for applying the configuration to the Item. First, all directives must be parsed.
 
     Syntax::
 
@@ -43,7 +45,7 @@ class AttributeSortDirective(TraceableBaseDirective):
     has_content = False
 
     def run(self):
-        """ Processes the contents of the directive. """
+        """ Processes the contents of the directive. Just store the configuration. """
         env = self.state.document.settings.env
 
         node = AttributeSort('')

--- a/mlx/directives/attribute_sort_directive.py
+++ b/mlx/directives/attribute_sort_directive.py
@@ -33,7 +33,6 @@ class AttributeSortDirective(TraceableBaseDirective):
       .. attribute-sort::
          :filter: regex
          :sort: list_of_attributes
-
     """
     # Options
     option_spec = {

--- a/mlx/directives/attribute_sort_directive.py
+++ b/mlx/directives/attribute_sort_directive.py
@@ -53,7 +53,5 @@ class AttributeSortDirective(TraceableBaseDirective):
         node['filter'] = r"\S+"
         node['sort'] = []
 
-        if self.process_options(node, {'sort': [], 'filter': r"\S+"}):
-            return [node]
-
-        return []
+        self.process_options(node, {'sort': [], 'filter': r"\S+"})
+        return [node]

--- a/mlx/directives/attribute_sort_directive.py
+++ b/mlx/directives/attribute_sort_directive.py
@@ -1,0 +1,59 @@
+from docutils.parsers.rst import directives
+
+from mlx.traceability import report_warning
+from mlx.traceable_base_directive import TraceableBaseDirective
+from mlx.traceable_base_node import TraceableBaseNode
+
+
+class AttributeSort(TraceableBaseNode):
+    '''List of documentation items'''
+
+    def perform_replacement(self, app, collection):
+        """ Processes the attribute-sort items.
+
+        The AttributeSort node has no final representation, so it is removed from the tree.
+
+        Args:
+            app: Sphinx application object to use.
+            collection (TraceableCollection): Collection for which to generate the nodes.
+        """
+        ignored_items = collection.add_attribute_sorting_rule(self['filter'], self['sort'])
+        for item in ignored_items:
+            report_warning("The sorting of the attributes of item {} has already been configured by {}; ignoring {}"
+                           .format(item.id, item.attribute_order, self['sort']), self['document'], self['line'])
+        self.replace_self([])
+
+
+class AttributeSortDirective(TraceableBaseDirective):
+    """
+    Directive to configure the order of items' attributes in the generated output.
+
+    Syntax::
+
+      .. attribute-sort::
+         :filter: regex
+         :sort: list_of_attributes
+
+    """
+    # Options
+    option_spec = {
+        'filter': directives.unchanged,
+        'sort': directives.unchanged,
+    }
+    # Content disallowed
+    has_content = False
+
+    def run(self):
+        """ Processes the contents of the directive. """
+        env = self.state.document.settings.env
+
+        node = AttributeSort('')
+        node['document'] = env.docname
+        node['line'] = self.lineno
+        node['filter'] = r"\S+"
+        node['sort'] = []
+
+        if self.process_options(node, {'sort': [], 'filter': r"\S+"}):
+            return [node]
+
+        return []

--- a/mlx/directives/item_directive.py
+++ b/mlx/directives/item_directive.py
@@ -38,13 +38,14 @@ class Item(TraceableBaseNode):
             dl_node (nodes.definition_list): Definition list of the item.
             app: Sphinx's application object to use.
         """
-        if self._item.iter_attributes():
+        attributes = self._item.iter_attributes()
+        if attributes:
             li_node = nodes.definition_list_item()
             dt_node = nodes.term()
             txt = nodes.Text('Attributes')
             dt_node.append(txt)
             li_node.append(dt_node)
-            for attr in self._item.iter_attributes():
+            for attr in attributes:
                 dd_node = nodes.definition()
                 p_node = nodes.paragraph()
                 link = self.make_attribute_ref(app, attr, self._item.get_attribute(attr))

--- a/mlx/traceability.py
+++ b/mlx/traceability.py
@@ -23,6 +23,7 @@ from mlx.traceable_base_node import TraceableBaseNode
 from mlx.traceable_item import TraceableItem
 from mlx.traceable_collection import TraceableCollection
 from mlx.traceability_exception import TraceabilityException, MultipleTraceabilityExceptions, report_warning
+from mlx.directives.attribute_sort_directive import AttributeSort, AttributeSortDirective
 from mlx.directives.checkbox_result_directive import CheckboxResultDirective
 from mlx.directives.checklist_item_directive import ChecklistItemDirective
 from mlx.directives.item_directive import Item, ItemDirective
@@ -175,8 +176,8 @@ def process_item_nodes(app, doctree, fromdocname):
     """
     env = app.builder.env
 
-    for node_class in (ItemLink, ItemMatrix, ItemPieChart, ItemAttributesMatrix, Item2DMatrix, ItemList, ItemTree,
-                       ItemAttribute, Item):
+    for node_class in (AttributeSort, ItemLink, ItemMatrix, ItemPieChart, ItemAttributesMatrix, Item2DMatrix, ItemList,
+                       ItemTree, ItemAttribute, Item):  # order is important: e.g. AttributeSort before Item
         for node in doctree.traverse(node_class):
             node.perform_replacement(app, env.traceability_collection)
 
@@ -522,6 +523,7 @@ def setup(app):
     app.add_node(ItemList)
     app.add_node(ItemAttribute)
     app.add_node(Item)
+    app.add_node(AttributeSort)
 
     app.add_directive('item', ItemDirective)
     app.add_directive('checklist-item', ChecklistItemDirective)
@@ -534,6 +536,7 @@ def setup(app):
     app.add_directive('item-2d-matrix', Item2DMatrixDirective)
     app.add_directive('item-tree', ItemTreeDirective)
     app.add_directive('item-link', ItemLinkDirective)
+    app.add_directive('attribute-sort', AttributeSortDirective)
 
     app.connect('doctree-resolved', process_item_nodes)
     app.connect('env-check-consistency', perform_consistency_check)

--- a/mlx/traceable_collection.py
+++ b/mlx/traceable_collection.py
@@ -142,6 +142,29 @@ class TraceableCollection:
             # Add reverse relation to target-item
             self.items[target_id].add_target(reverse_relation, source_id, implicit=True)
 
+    def add_attribute_sorting_rule(self, filter_regex, attributes):
+        """ Configures how the attributes of matching items should be sorted.
+
+        The attributes that are missing from the given list will be sorted alphabetically underneath. The items that
+        already have their attributes sorted will be returned as a list; used to report a warning.
+
+        Args:
+            filter_regex (str): Regular expression used to match items to apply the attribute sorting to.
+            attributes (list): List of attributes (str) in the order they should be sorted on.
+
+        Returns:
+            list: Items that already have the order of their attributes configured.
+        """
+        ignored_items = []
+        item_ids = self.get_items(filter_regex)
+        for item_id in item_ids:
+            item = self.get_item(item_id)
+            if item.attribute_order:
+                ignored_items.append(item)
+            else:
+                item.attribute_order = attributes
+        return ignored_items
+
     def export(self, fname):
         '''
         Exports collection content. The target location of the json file gets created if it doesn't exist yet.

--- a/mlx/traceable_item.py
+++ b/mlx/traceable_item.py
@@ -28,6 +28,7 @@ class TraceableItem(TraceableBaseClass):
         self.explicit_relations = {}
         self.implicit_relations = {}
         self.attributes = {}
+        self.attribute_order = []
         self._placeholder = placeholder
 
     def update(self, other):
@@ -237,21 +238,24 @@ class TraceableItem(TraceableBaseClass):
         Args:
             attr (list): List of names of the attribute
         Returns:
-            (list) List of values matching the given attributes, or [] if attributes do not exist
+            (list) List of values matching the given attributes, or an empty list if no attributes exist
         '''
-        value = []
-        if attrs:
-            for attr in attrs:
-                value.append(self.get_attribute(attr))
-        return value
+        values = []
+        for attr in attrs:
+            values.append(self.get_attribute(attr))
+        return values
 
     def iter_attributes(self):
-        ''' Iterates over available attributes: naturally sorted.
+        ''' Iterates over available attributes.
+
+        Sorted as configured by an attribute-sort directive, with the remaining attributes naturally sorted.
 
         Returns:
-            (list) Naturally sorted list containing available attributes in the item.
+            (list) Sorted list containing available attributes in the item.
         '''
-        return natsorted(list(self.attributes))
+        sorted_attributes = [attr for attr in self.attribute_order if attr in self.attributes]
+        sorted_attributes.extend(natsorted(set(self.attributes).difference(set(self.attribute_order))))
+        return sorted_attributes
 
     def __str__(self, explicit=True, implicit=True):
         ''' Converts object to string.

--- a/tox.ini
+++ b/tox.ini
@@ -59,8 +59,8 @@ whitelist_externals =
     tee
     mlx-warnings
 commands=
-    mlx-warnings --sphinx --maxwarnings 18 --minwarnings 18 --command make -C doc html
-    mlx-warnings --sphinx --maxwarnings 18 --minwarnings 18 --command make -C doc latexpdf
+    mlx-warnings --sphinx --maxwarnings 19 --minwarnings 19 --command make -C doc html
+    mlx-warnings --sphinx --maxwarnings 19 --minwarnings 19 --command make -C doc latexpdf
 
 [testenv:sphinx-latest]
 deps=
@@ -73,8 +73,8 @@ whitelist_externals =
     tee
     mlx-warnings
 commands=
-    mlx-warnings --sphinx --maxwarnings 18 --minwarnings 18 --command make -C doc html
-    mlx-warnings --sphinx --maxwarnings 18 --minwarnings 18 --command make -C doc latexpdf
+    mlx-warnings --sphinx --maxwarnings 19 --minwarnings 19 --command make -C doc html
+    mlx-warnings --sphinx --maxwarnings 19 --minwarnings 19 --command make -C doc latexpdf
 
 [testenv:coveralls]
 deps =


### PR DESCRIPTION
Resolves #160 

- [x] Implemented
- [x] Manually tested
- [x] Added documentation
- [x] Added automated tests

Example usage:
```
.. attribute-sort::
    :filter: RQT-
    :sort: status value aspice
```