### PR TITLE
Redirect missing references of linked items to notification item

### DIFF
--- a/mlx/traceability.py
+++ b/mlx/traceability.py
@@ -186,7 +186,7 @@ def perform_consistency_check(app, doctree):
     env = app.builder.env
 
     try:
-        env.traceability_collection.self_test(app)
+        env.traceability_collection.self_test(app.config.traceability_notifications.get('undefined-reference'))
     except TraceabilityException as err:
         report_warning(str(err), err.get_document())
     except MultipleTraceabilityExceptions as errs:

--- a/mlx/traceability.py
+++ b/mlx/traceability.py
@@ -186,7 +186,7 @@ def perform_consistency_check(app, doctree):
     env = app.builder.env
 
     try:
-        env.traceability_collection.self_test()
+        env.traceability_collection.self_test(app)
     except TraceabilityException as err:
         report_warning(str(err), err.get_document())
     except MultipleTraceabilityExceptions as errs:

--- a/mlx/traceable_base_node.py
+++ b/mlx/traceable_base_node.py
@@ -59,42 +59,54 @@ class TraceableBaseNode(nodes.General, nodes.Element, ABC):
         """
         env = app.builder.env
         item_info = env.traceability_collection.get_item(item_id)
+        notification_item = None
 
         p_node = nodes.paragraph()
 
-        # Only create link when target item exists, warn otherwise (in html and terminal)
-        if self.has_warned_about_undefined(item_info):
-            txt = nodes.Text('%s not defined, broken link' % item_id)
-            p_node.append(txt)
-        else:
-            caption_on_hover = None
-            caption = ''
-            if item_info.caption:
-                if show_caption:
-                    caption = ' : {}'.format(item_info.caption)
-                else:
-                    caption_on_hover = nodes.inline('', item_info.caption)
-                    caption_on_hover['classes'].append('popup_caption')
+        # Only create link when target item (or notification item) exists, warn otherwise (in html and terminal)
+        if item_info.is_placeholder():
+            notification_item_id = app.config.traceability_notifications.get('undefined-reference')
+            notification_item = app.env.traceability_collection.get_item(notification_item_id)
+            if not notification_item:
+                self.has_warned_about_undefined(item_info)
+                txt = nodes.Text('%s not defined, broken link' % item_id)
+                p_node.append(txt)
+                return p_node
 
-            newnode = nodes.reference('', '')
-            innernode = nodes.emphasis(item_id + caption, item_id + caption)
-            newnode['refdocname'] = item_info.docname
-            try:
+        caption_on_hover = None
+        caption = ''
+        if item_info and item_info.caption:
+            if show_caption:
+                caption = ' : {}'.format(item_info.caption)
+            else:
+                caption_on_hover = nodes.inline('', item_info.caption)
+                caption_on_hover['classes'].append('popup_caption')
+
+        newnode = nodes.reference('', '')
+        innernode = nodes.emphasis(item_id + caption, item_id + caption)
+        try:
+            if not notification_item:
                 newnode['refuri'] = app.builder.get_relative_uri(self['document'], item_info.docname)
                 newnode['refuri'] += '#' + item_id
-            except NoUri:
-                # ignore if no URI can be determined, e.g. for LaTeX output :(
-                pass
-            # change text color if item_id matches a regex in traceability_hyperlink_colors
-            colors = self._find_colors_for_class(app.config.traceability_hyperlink_colors, item_id)
-            if colors:
-                class_name = app.config.traceability_class_names[colors]
-                newnode['classes'].append(class_name)
-            if caption_on_hover and not isinstance(app.builder, LaTeXBuilder):
-                innernode['classes'].append('has_hidden_caption')
-                innernode.append(caption_on_hover)  # set to hidden in traceability.js
-            newnode.append(innernode)
-            p_node += newnode
+                newnode['refdocname'] = item_info.docname
+            else:
+                newnode['refuri'] = app.builder.get_relative_uri(self['document'], notification_item.docname)
+                newnode['refuri'] += '#' + notification_item_id
+                newnode['refdocname'] = notification_item.docname
+        except NoUri:
+            # ignore if no URI can be determined, e.g. for LaTeX output :(
+            pass
+
+        # change text color if item_id matches a regex in traceability_hyperlink_colors
+        colors = self._find_colors_for_class(app.config.traceability_hyperlink_colors, item_id)
+        if colors:
+            class_name = app.config.traceability_class_names[colors]
+            newnode['classes'].append(class_name)
+        if caption_on_hover and not isinstance(app.builder, LaTeXBuilder):
+            innernode['classes'].append('has_hidden_caption')
+            innernode.append(caption_on_hover)  # set to hidden in traceability.js
+        newnode.append(innernode)
+        p_node += newnode
 
         return p_node
 

--- a/mlx/traceable_base_node.py
+++ b/mlx/traceable_base_node.py
@@ -73,14 +73,7 @@ class TraceableBaseNode(nodes.General, nodes.Element, ABC):
                 p_node.append(txt)
                 return p_node
 
-        caption_on_hover = None
-        caption = ''
-        if item_info and item_info.caption:
-            if show_caption:
-                caption = ' : {}'.format(item_info.caption)
-            else:
-                caption_on_hover = nodes.inline('', item_info.caption)
-                caption_on_hover['classes'].append('popup_caption')
+        caption, caption_on_hover = self._get_caption_info(item_info, show_caption=show_caption)
 
         newnode = nodes.reference('', '')
         innernode = nodes.emphasis(item_id + caption, item_id + caption)
@@ -200,6 +193,29 @@ class TraceableBaseNode(nodes.General, nodes.Element, ABC):
             if re.search(regex, item_id):
                 return tuple(colors)
         return None
+
+    @staticmethod
+    def _get_caption_info(item_info, show_caption=True):
+        """ Gets either the caption or the caption to show on hover, depending on the item's configuration.
+
+        Args:
+            item_info (TraceableItem): TraceableItem object.
+            show_caption (bool): True if the caption should always be shown, False to only show caption on hover.
+
+        Returns:
+            str: Caption to append to the item's ID, or empty string when item has no caption or it is configured to be
+                shown on hover
+            nodes.inline/None: Inline node containing the item's caption, or None if caption should always be shown.
+        """
+        caption = ''
+        caption_on_hover = None
+        if item_info and item_info.caption:
+            if show_caption:
+                caption = ' : {}'.format(item_info.caption)
+            else:
+                caption_on_hover = nodes.inline('', item_info.caption)
+                caption_on_hover['classes'].append('popup_caption')
+        return caption, caption_on_hover
 
     def has_warned_about_undefined(self, item_info):
         """

--- a/mlx/traceable_collection.py
+++ b/mlx/traceable_collection.py
@@ -180,16 +180,16 @@ class TraceableCollection:
                 data.append(item.to_dict())
             json.dump(data, outfile, indent=4, sort_keys=True)
 
-    def self_test(self, app, docname=None):
+    def self_test(self, notification_item_id, docname=None):
         '''
         Perform self test on collection content
 
         Args:
-            app: Sphinx application object to use.
+            notification_item_id (str/None): ID of the configured notification item, None if not configured.
             docname (str): Document on which to run the self test, None for all.
         '''
         errors = []
-        notification_item = self.get_item(app.config.traceability_notifications.get('undefined-reference'))
+        notification_item = self.get_item(notification_item_id)
         # Having no valid relations, is invalid
         if not self.relations:
             raise TraceabilityException('No relations configured', 'configuration')

--- a/mlx/traceable_collection.py
+++ b/mlx/traceable_collection.py
@@ -180,14 +180,16 @@ class TraceableCollection:
                 data.append(item.to_dict())
             json.dump(data, outfile, indent=4, sort_keys=True)
 
-    def self_test(self, docname=None):
+    def self_test(self, app, docname=None):
         '''
         Perform self test on collection content
 
         Args:
+            app: Sphinx application object to use.
             docname (str): Document on which to run the self test, None for all.
         '''
         errors = []
+        notification_item = self.get_item(app.config.traceability_notifications.get('undefined-reference'))
         # Having no valid relations, is invalid
         if not self.relations:
             raise TraceabilityException('No relations configured', 'configuration')
@@ -196,6 +198,9 @@ class TraceableCollection:
             item = self.get_item(itemid)
             # Only for relevant items, filtered on document name
             if docname is not None and item.get_document() != docname and item.get_document() is not None:
+                continue
+            # Check if docname of notification item will be used
+            if item.get_document() is None and notification_item:
                 continue
             # On item level
             try:

--- a/tests/test_traceable_collection.py
+++ b/tests/test_traceable_collection.py
@@ -31,7 +31,7 @@ class TestTraceableCollection(TestCase):
         coll = dut.TraceableCollection()
         # Self test should fail as no relations configured
         with self.assertRaises(exception.TraceabilityException):
-            coll.self_test()
+            coll.self_test(None)
 
     def test_add_relation_pair_bidir(self):
         coll = dut.TraceableCollection()
@@ -50,7 +50,7 @@ class TestTraceableCollection(TestCase):
         self.assertIn(self.fwd_relation, relations_iterator)
         self.assertIn(self.rev_relation, relations_iterator)
         # Self test should pass
-        coll.self_test()
+        coll.self_test(None)
 
     def test_add_relation_pair_unidir(self):
         coll = dut.TraceableCollection()
@@ -61,7 +61,7 @@ class TestTraceableCollection(TestCase):
         # Reverse for fwd should be nothing
         self.assertEqual(coll.NO_RELATION_STR, coll.get_reverse_relation(self.unidir_relation))
         # Self test should pass
-        coll.self_test()
+        coll.self_test(None)
 
     def test_add_item(self):
         coll = dut.TraceableCollection()
@@ -97,7 +97,7 @@ class TestTraceableCollection(TestCase):
         self.assertIn(self.identification_tgt, item_iterator)
         # Self test should pass
         coll.add_relation_pair(self.fwd_relation, self.rev_relation)
-        coll.self_test()
+        coll.self_test(None)
 
     def test_add_item_overwrite(self):
         coll = dut.TraceableCollection()
@@ -153,7 +153,7 @@ class TestTraceableCollection(TestCase):
         self.assertEqual(0, len(relations))
         # Self test should fail, as we have a placeholder item
         with self.assertRaises(dut.MultipleTraceabilityExceptions):
-            coll.self_test()
+            coll.self_test(None)
 
     def test_add_relation_unknown_relation(self):
         # with unknown relation, warning is expected
@@ -174,7 +174,7 @@ class TestTraceableCollection(TestCase):
         self.assertEqual(0, len(relations))
         # Self test should pass
         coll.add_relation_pair(self.fwd_relation, self.rev_relation)
-        coll.self_test()
+        coll.self_test(None)
 
     def test_add_relation_unknown_target(self):
         # With unknown target item, the generation of a placeholder is expected
@@ -205,7 +205,7 @@ class TestTraceableCollection(TestCase):
         self.assertEqual(0, len(relations))
         # Self test should fail, as we have a placeholder item
         with self.assertRaises(dut.MultipleTraceabilityExceptions):
-            coll.self_test()
+            coll.self_test(None)
 
     def test_add_relation_happy(self):
         # Normal addition of relation, everything is there
@@ -237,7 +237,7 @@ class TestTraceableCollection(TestCase):
         relations = item2.iter_targets(self.fwd_relation, explicit=True, implicit=False)
         self.assertEqual(0, len(relations))
         # Self test should pass
-        coll.self_test()
+        coll.self_test(None)
 
     def test_add_relation_unidirectional(self):
         # Normal addition of uni-directional relation
@@ -258,7 +258,7 @@ class TestTraceableCollection(TestCase):
         # Assert item2 is not existent
         self.assertIsNone(coll.get_item(self.identification_tgt))
         # Self test should pass
-        coll.self_test()
+        coll.self_test(None)
 
     def test_stringify(self):
         coll = dut.TraceableCollection()
@@ -357,7 +357,7 @@ class TestTraceableCollection(TestCase):
         coll = dut.TraceableCollection()
         coll.add_relation_pair(self.fwd_relation, self.rev_relation)
         # Self test should pass
-        coll.self_test()
+        coll.self_test(None)
         # Create first item
         item1 = item.TraceableItem(self.identification_src)
         item1.set_document(self.docname)
@@ -369,18 +369,18 @@ class TestTraceableCollection(TestCase):
         coll.add_item(item1)
         # Self test should fail as target item is not in collection
         with self.assertRaises(dut.MultipleTraceabilityExceptions):
-            coll.self_test()
+            coll.self_test(None)
         # Self test one limited scope (no matching document), should pass
-        coll.self_test('document-does-not-exist.rst')
+        coll.self_test(None, docname='document-does-not-exist.rst')
         # Creating and adding second item, self test should still fail as no automatic reverse relation
         item2 = item.TraceableItem(self.identification_tgt)
         item2.set_document(self.docname)
         coll.add_item(item2)
         with self.assertRaises(dut.MultipleTraceabilityExceptions):
-            coll.self_test()
+            coll.self_test(None)
         # Mimicing the automatic reverse relation, self test should pass
         item2.add_target(self.rev_relation, self.identification_src)
-        coll.self_test()
+        coll.self_test(None)
 
     def test_export_no_items(self):
         open_mock = mock_open()


### PR DESCRIPTION
Items with no reference to their source document and with a relationship to a defined item can now get redirected to the configured notification item.

Completes functionality in https://github.com/melexis/sphinx-traceability-extension/pull/162