### PR TITLE
Convert Jira errors into warnings by default

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -509,8 +509,8 @@ Configuration
         'default_project': 'SWCC',
         'relationship_to_parent': 'depends_on',
         'components': '[SW],[HW]',
-        'warn_if_exists': True,
-        'catch_errors': True,
+        'warn_if_exists': False,
+        'errors_to_warnings': True,
     }
 
 ``project_key_regex`` can optionally be defined. This regular expression with a named group *project* is used to
@@ -520,8 +520,8 @@ project key or id in case the regular expression doesn't come up with a match or
 
 ``item_to_ticket_regex`` defines the regular expression used to filter item IDs to be exported as Jira tickets.
 A warning gets reported when a Jira ticket already exists. These warnings can be disabled by setting
-``warn_if_exists`` to ``True``. Errors raised by this feature can be converted to warnings by means setting the
-optional setting ``catch_errors`` to a truthy value .
+``warn_if_exists`` to ``True``. Errors raised by Jira are converted to warnings by default. If you want these errors to
+crash your build, you can set ``errors_to_warnings`` to a falsy value.
 
 The item ID of a linked item can be added to the summary of the Jira ticket to create by specifying the relationship
 to this item with ``relationship_to_parent``. This makes it possible to create a query link in advance to list all

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -510,6 +510,7 @@ Configuration
         'relationship_to_parent': 'depends_on',
         'components': '[SW],[HW]',
         'warn_if_exists': True,
+        'catch_errors': True,
     }
 
 ``project_key_regex`` can optionally be defined. This regular expression with a named group *project* is used to
@@ -519,7 +520,8 @@ project key or id in case the regular expression doesn't come up with a match or
 
 ``item_to_ticket_regex`` defines the regular expression used to filter item IDs to be exported as Jira tickets.
 A warning gets reported when a Jira ticket already exists. These warnings can be disabled by setting
-``warn_if_exists`` to ``True``.
+``warn_if_exists`` to ``True``. Exceptions raised by this feature can be converted to warnings by means setting the
+optional setting ``catch_errors`` to a truthy value .
 
 The item ID of a linked item can be added to the summary of the Jira ticket to create by specifying the relationship
 to this item with ``relationship_to_parent``. This makes it possible to create a query link in advance to list all

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -520,7 +520,7 @@ project key or id in case the regular expression doesn't come up with a match or
 
 ``item_to_ticket_regex`` defines the regular expression used to filter item IDs to be exported as Jira tickets.
 A warning gets reported when a Jira ticket already exists. These warnings can be disabled by setting
-``warn_if_exists`` to ``True``. Exceptions raised by this feature can be converted to warnings by means setting the
+``warn_if_exists`` to ``True``. Errors raised by this feature can be converted to warnings by means setting the
 optional setting ``catch_errors`` to a truthy value .
 
 The item ID of a linked item can be added to the summary of the Jira ticket to create by specifying the relationship

--- a/mlx/jira_interaction.py
+++ b/mlx/jira_interaction.py
@@ -22,9 +22,7 @@ def create_jira_issues(settings, traceability_collection):
         return report_warning("Jira interaction failed: configuration is missing mandatory values for keys {}"
                               .format(missing_keys))
 
-    jira = JIRA({"server": settings['api_endpoint']}, basic_auth=(settings['username'], settings['password']))
     issue_type = settings['issue_type']
-
     general_fields = {}
     general_fields['issuetype'] = {'name': issue_type}
     components = []
@@ -35,7 +33,9 @@ def create_jira_issues(settings, traceability_collection):
         general_fields['components'] = components
 
     relevant_item_ids = traceability_collection.get_items(settings['item_to_ticket_regex'])
-    create_unique_issues(relevant_item_ids, jira, general_fields, settings, traceability_collection)
+    if relevant_item_ids:
+        jira = JIRA({"server": settings['api_endpoint']}, basic_auth=(settings['username'], settings['password']))
+        create_unique_issues(relevant_item_ids, jira, general_fields, settings, traceability_collection)
 
 
 def create_unique_issues(item_ids, jira, general_fields, settings, traceability_collection):

--- a/mlx/jira_interaction.py
+++ b/mlx/jira_interaction.py
@@ -19,8 +19,8 @@ def create_jira_issues(settings, traceability_collection):
         if not settings.get(key, None):
             missing_keys.append(key)
     if missing_keys:
-        return report_warning("Configuration for automated ticket creation via Jira API is missing mandatory values "
-                              "for keys {}".format(missing_keys))
+        return report_warning("Jira interaction failed: configuration is missing mandatory values for keys {}"
+                              .format(missing_keys))
 
     jira = JIRA({"server": settings['api_endpoint']}, basic_auth=(settings['username'], settings['password']))
     issue_type = settings['issue_type']
@@ -117,7 +117,7 @@ def push_item_to_jira(jira, fields, item, attendees):
         try:
             jira.add_watcher(issue, attendee.strip())
         except JIRAError as err:
-            report_warning("Jira API returned error code {}: {}".format(err.status_code, err.response.text))
+            report_warning("Jira interaction failed: error code {}: {}".format(err.status_code, err.response.text))
 
 
 def determine_jira_project(key_regex, key_prefix, default_project, item_id):

--- a/mlx/traceability.py
+++ b/mlx/traceability.py
@@ -118,7 +118,7 @@ def jira_interaction(app):
     try:
         create_jira_issues(app.config.traceability_jira_automation, app.builder.env.traceability_collection)
     except Exception as err:  # pylint: disable=broad-except
-        if app.config.traceability_jira_automation.get('catch_errors', False):
+        if app.config.traceability_jira_automation.get('errors_to_warnings', True):
             report_warning("Jira interaction failed: {}".format(err))
         else:
             raise err

--- a/mlx/traceability.py
+++ b/mlx/traceability.py
@@ -109,6 +109,21 @@ def warn_missing_checklist_items(regex):
                            .format(item_id, item_info.mr_id))
 
 
+def jira_interaction(app):
+    """ Execute the functionality that creates Jira tickets based on traceable items.
+
+    Args:
+        app: Sphinx application object to use.
+    """
+    try:
+        create_jira_issues(app.config.traceability_jira_automation, app.builder.env.traceability_collection)
+    except Exception as err:  # pylint: disable=broad-except
+        if app.config.traceability_jira_automation.get('catch_errors', False):
+            report_warning("Jira interaction failed: {}".format(err))
+        else:
+            raise err
+
+
 # -----------------------------------------------------------------------------
 # Pending item cross reference node
 
@@ -222,7 +237,7 @@ def perform_consistency_check(app, doctree):
         warn_missing_checklist_items(regex)
 
     if app.config.traceability_jira_automation:
-        create_jira_issues(app.config.traceability_jira_automation, app.builder.env.traceability_collection)
+        jira_interaction(app)
 
 
 def process_item_nodes(app, doctree, fromdocname):

--- a/tests/test_jira_interaction.py
+++ b/tests/test_jira_interaction.py
@@ -35,6 +35,7 @@ class TestJiraInteraction(TestCase):
             'warn_if_exists': True,
             'relationship_to_parent': 'depends_on',
             'components': '[SW],[HW]',
+            'catch_errors': False,
         }
         self.coll = TraceableCollection()
         parent = TraceableItem('MEETING-12345_2')
@@ -74,7 +75,7 @@ class TestJiraInteraction(TestCase):
             dut.create_jira_issues(self.settings, None)
         self.assertEqual(
             cm.output,
-            ["WARNING:sphinx.mlx.traceability_exception:Configuration for automated ticket creation via Jira API is "
+            ["WARNING:sphinx.mlx.traceability_exception:Jira interaction failed: configuration is "
              "missing mandatory values for keys ['api_endpoint']"]
         )
 
@@ -84,7 +85,7 @@ class TestJiraInteraction(TestCase):
             dut.create_jira_issues(self.settings, None)
         self.assertEqual(
             cm.output,
-            ["WARNING:sphinx.mlx.traceability_exception:Configuration for automated ticket creation via Jira API is "
+            ["WARNING:sphinx.mlx.traceability_exception:Jira interaction failed: configuration is "
              "missing mandatory values for keys ['username']"]
         )
 
@@ -96,20 +97,20 @@ class TestJiraInteraction(TestCase):
             dut.create_jira_issues(self.settings, None)
         self.assertEqual(
             cm.output,
-            ["WARNING:sphinx.mlx.traceability_exception:Configuration for automated ticket creation via Jira API is "
+            ["WARNING:sphinx.mlx.traceability_exception:Jira interaction failed: configuration is "
              "missing mandatory values for keys {}".format(mandatory_keys)]
         )
 
     def test_missing_all_optional_one_mandatory(self, *_):
         keys_to_remove = ['components', 'project_key_prefix', 'project_key_regex', 'default_project',
-                          'relationship_to_parent', 'warn_if_exists', 'password']
+                          'relationship_to_parent', 'warn_if_exists', 'catch_errors', 'password']
         for key in keys_to_remove:
             self.settings.pop(key)
         with self.assertLogs(level=WARNING) as cm:
             dut.create_jira_issues(self.settings, None)
         self.assertEqual(
             cm.output,
-            ["WARNING:sphinx.mlx.traceability_exception:Configuration for automated ticket creation via Jira API is "
+            ["WARNING:sphinx.mlx.traceability_exception:Jira interaction failed: configuration is "
              "missing mandatory values for keys ['password']"]
         )
 
@@ -252,7 +253,7 @@ class TestJiraInteraction(TestCase):
         with self.assertLogs(level=WARNING) as cm:
             dut.create_jira_issues(self.settings, self.coll)
 
-        error_msg = "WARNING:sphinx.mlx.traceability_exception:Jira API returned error code 401: dummy msg"
+        error_msg = "WARNING:sphinx.mlx.traceability_exception:Jira interaction failed: error code 401: dummy msg"
         self.assertEqual(
             cm.output,
             [error_msg, error_msg]


### PR DESCRIPTION
Exceptions raised by the [Jira ticket creation feature](https://melexis.github.io/sphinx-traceability-extension/usage.html#jira-ticket-creation) are converted to warnings by default. If you want these errors to keep
crashing your build, you can set ``errors_to_warnings`` to a falsy value.

Most warnings will now start with `'Jira interaction failed:'` to make them easier to get [excluded by mlx-warnings](https://melexis.github.io/warnings-plugin/readme.html?highlight=exclude#exclude-matches-with-regexes) if desired.