### PR TITLE
Fix setting of Original Estimate field

### DIFF
--- a/mlx/jira_interaction.py
+++ b/mlx/jira_interaction.py
@@ -109,7 +109,7 @@ def push_item_to_jira(jira, fields, item, attendees):
     effort = item.get_attribute('effort')
     if effort:
         try:
-            issue.update(update={"timetracking": [{"edit": {"timeestimate": effort}}]}, notify=False)
+            issue.update(update={"timetracking": [{"edit": {"originalEstimate": effort}}]}, notify=False)
         except JIRAError:
             issue.update(description="{}\n\nEffort estimation: {}".format(item.get_content(), effort), notify=False)
 
@@ -117,7 +117,8 @@ def push_item_to_jira(jira, fields, item, attendees):
         try:
             jira.add_watcher(issue, attendee.strip())
         except JIRAError as err:
-            report_warning("Jira interaction failed: error code {}: {}".format(err.status_code, err.response.text))
+            report_warning("Jira interaction failed: item {}: error code {}: {}"
+                           .format(item.id, err.status_code, err.response.text))
 
 
 def determine_jira_project(key_regex, key_prefix, default_project, item_id):

--- a/tests/test_jira_interaction.py
+++ b/tests/test_jira_interaction.py
@@ -56,7 +56,7 @@ class TestJiraInteraction(TestCase):
         TraceableItem.define_attribute(attendees_attr)
 
         parent.add_attribute('attendees', 'ABC, ZZZ')
-        action1.add_attribute('effort', '1mo 2w 3d 4h 55m')
+        action1.add_attribute('effort', '2w 3d 4h 55m')
         action1.add_attribute('assignee', 'ABC')
         action2.add_attribute('assignee', 'ZZZ')
         action3.add_attribute('assignee', 'ABC')
@@ -155,7 +155,7 @@ class TestJiraInteraction(TestCase):
 
         self.assertEqual(
             issue.update.call_args_list,
-            [mock.call(notify=False, update={'timetracking': [{"edit": {"timeestimate": '1mo 2w 3d 4h 55m'}}]})]
+            [mock.call(notify=False, update={'timetracking': [{"edit": {"originalEstimate": '2w 3d 4h 55m'}}]})]
         )
 
         # attendees added for action1 since it is linked with depends_on to parent item with ``attendees`` attribute
@@ -180,8 +180,8 @@ class TestJiraInteraction(TestCase):
         self.assertEqual(
             issue.update.call_args_list,
             [
-                mock.call(notify=False, update={'timetracking': [{"edit": {"timeestimate": '1mo 2w 3d 4h 55m'}}]}),
-                mock.call(notify=False, description="Description for action 1\n\nEffort estimation: 1mo 2w 3d 4h 55m"),
+                mock.call(notify=False, update={'timetracking': [{"edit": {"originalEstimate": '2w 3d 4h 55m'}}]}),
+                mock.call(notify=False, description="Description for action 1\n\nEffort estimation: 2w 3d 4h 55m"),
             ]
         )
 
@@ -253,7 +253,8 @@ class TestJiraInteraction(TestCase):
         with self.assertLogs(level=WARNING) as cm:
             dut.create_jira_issues(self.settings, self.coll)
 
-        error_msg = "WARNING:sphinx.mlx.traceability_exception:Jira interaction failed: error code 401: dummy msg"
+        error_msg = ("WARNING:sphinx.mlx.traceability_exception:Jira interaction failed: item ACTION-12345_ACTION_1: "
+                     "error code 401: dummy msg")
         self.assertEqual(
             cm.output,
             [error_msg, error_msg]


### PR DESCRIPTION
Fixed the name of the field used to set the Original Estimate field of a Jira ticket.