### PR TITLE
Fix layout for item-tree directive

### DIFF
--- a/mlx/jira_interaction.py
+++ b/mlx/jira_interaction.py
@@ -111,7 +111,7 @@ def push_item_to_jira(jira, fields, item, attendees):
         try:
             issue.update(update={"timetracking": [{"edit": {"originalEstimate": effort}}]}, notify=False)
         except JIRAError:
-            issue.update(description="{}\n\nEffort estimation: {}".format(item.get_content(), effort), notify=False)
+            issue.update(description="{}\n\nEffort estimate: {}".format(item.get_content(), effort), notify=False)
 
     for attendee in attendees:
         try:

--- a/mlx/traceability.py
+++ b/mlx/traceability.py
@@ -470,7 +470,7 @@ def setup(app):
     # Javascript and stylesheet for the tree-view
     # app.add_js_file('jquery.js') #note: can only be included once
     app.add_js_file('https://cdn.rawgit.com/aexmachina/jquery-bonsai/master/jquery.bonsai.js')
-    app.add_js_file('https://cdn.rawgit.com/aexmachina/jquery-bonsai/master/jquery.bonsai.css')
+    app.add_css_file('https://cdn.rawgit.com/aexmachina/jquery-bonsai/master/jquery.bonsai.css')
     app.add_js_file('traceability.js')
 
     # Configuration for exporting collection to json

--- a/tests/test_jira_interaction.py
+++ b/tests/test_jira_interaction.py
@@ -181,7 +181,7 @@ class TestJiraInteraction(TestCase):
             issue.update.call_args_list,
             [
                 mock.call(notify=False, update={'timetracking': [{"edit": {"originalEstimate": '2w 3d 4h 55m'}}]}),
-                mock.call(notify=False, description="Description for action 1\n\nEffort estimation: 2w 3d 4h 55m"),
+                mock.call(notify=False, description="Description for action 1\n\nEffort estimate: 2w 3d 4h 55m"),
             ]
         )
 


### PR DESCRIPTION
Fix layout for `item-tree` directive. Bug introduced since since [v4.7.0](https://github.com/melexis/sphinx-traceability-extension/releases/tag/v4.7.0) by https://github.com/melexis/sphinx-traceability-extension/pull/167.

Also, changed *Effort estimation* into *Effort estimate* when appending the value of the `:effort:` attribute to the description of a Jira ticket.