### PR TITLE
Tweak layout of example documentation

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -16,6 +16,7 @@ include doc/.env.example
 recursive-include doc *.bat
 recursive-include doc *.py
 recursive-include doc *.rst
+recursive-include doc *.css
 recursive-include doc Makefile
 recursive-include tests *.py
 recursive-include tests *.rst

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -27,3 +27,5 @@ include .coveragerc
 
 # added by check_manifest.py
 include *.txt
+
+recursive-exclude doc/_build *

--- a/doc/_static/css/extra.css
+++ b/doc/_static/css/extra.css
@@ -1,0 +1,8 @@
+.rst-content .section ul.bonsai li>* {
+    margin-top: auto!important;
+    margin-bottom: 2px!important;
+}
+
+.rst-content .section ul.bonsai li {
+    margin-left: 0!important;
+}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -142,7 +142,7 @@ html_theme = 'sphinx_rtd_theme'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = [os.path.join(os.path.dirname(mlx.traceability.__file__), 'assets')]
+html_static_path = [os.path.join(os.path.dirname(mlx.traceability.__file__), 'assets'), '_static']
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.
@@ -408,3 +408,5 @@ def setup(app):
     # using a different name. Item template can be customized for
     # these types
     app.add_directive('requirement', ItemDirective)
+
+    app.add_css_file('css/extra.css')

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,7 @@ deps=
     matplotlib
     sphinx-testing >= 0.5.2
     sphinx_selective_exclude>=1.0.3
-    sphinx_rtd_theme
+    sphinx_rtd_theme==0.4.3
 commands=
     {posargs:py.test --cov=mlx --cov-report=term-missing -vv tests/}
 

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,7 @@ deps=
     matplotlib
     sphinx-testing >= 0.5.2
     sphinx_selective_exclude>=1.0.3
-    sphinx_rtd_theme==0.4.3
+    sphinx_rtd_theme==0.5.0
 commands=
     {posargs:py.test --cov=mlx --cov-report=term-missing -vv tests/}
 


### PR DESCRIPTION
Pinning the version of [sphinx_rtd_theme](https://github.com/readthedocs/sphinx_rtd_theme) to 0.5.0 to generate the example documentation. This upgrade introduces an unwanted effect to the rendered `item-tree` directive that we now override by an extra stylesheet on top.