### PR TITLE
Tweak Jira ticket description

### DIFF
--- a/mlx/jira_interaction.py
+++ b/mlx/jira_interaction.py
@@ -87,7 +87,7 @@ def create_unique_issues(item_ids, jira, general_fields, settings, traceability_
         content = item.get_content()
         if not content:
             content = item.caption
-        fields['description'] = content
+        fields['description'] = settings.get('description_head', '') + content
         if assignee:
             fields['assignee'] = {'name': item.get_attribute('assignee')}
 

--- a/mlx/jira_interaction.py
+++ b/mlx/jira_interaction.py
@@ -84,10 +84,10 @@ def create_unique_issues(item_ids, jira, general_fields, settings, traceability_
 
         fields['project'] = project_id_or_key
         fields[jira_field_id] = jira_field
-        content = item.get_content()
-        if not content:
-            content = item.caption
-        fields['description'] = settings.get('description_head', '') + content
+        body = item.get_content()
+        if not body:
+            body = item.caption
+        fields['description'] = settings.get('description_head', '') + body
         if assignee:
             fields['assignee'] = {'name': item.get_attribute('assignee')}
 

--- a/mlx/jira_interaction.py
+++ b/mlx/jira_interaction.py
@@ -84,7 +84,10 @@ def create_unique_issues(item_ids, jira, general_fields, settings, traceability_
 
         fields['project'] = project_id_or_key
         fields[jira_field_id] = jira_field
-        fields['description'] = item.get_content()
+        content = item.get_content()
+        if not content:
+            content = item.caption
+        fields['description'] = content
         if assignee:
             fields['assignee'] = {'name': item.get_attribute('assignee')}
 

--- a/mlx/jira_interaction.py
+++ b/mlx/jira_interaction.py
@@ -69,7 +69,7 @@ def create_unique_issues(item_ids, jira, general_fields, settings, traceability_
             if parent_ids:
                 parent_id = parent_ids[0]
                 parent = traceability_collection.get_item(parent_id)
-                jira_field = "{id} {field}".format(id=parent_id, field=jira_field)  # prepend item ID of parent
+                jira_field = "{id}: {field}".format(id=parent_id, field=jira_field)  # prepend item ID of parent
                 attendees = parent.get_attribute('attendees').split(',')
 
         jira_field_id = settings['jira_field_id']

--- a/tests/test_jira_interaction.py
+++ b/tests/test_jira_interaction.py
@@ -131,7 +131,7 @@ class TestJiraInteraction(TestCase):
                                    basic_auth=('my_username', 'my_password')))
         self.assertEqual(jira_mock.search_issues.call_args_list,
                          [
-                             mock.call("project=MLX12345 and summary ~ 'MEETING-12345_2 Caption for action 1'"),
+                             mock.call("project=MLX12345 and summary ~ 'MEETING-12345_2: Caption for action 1'"),
                              mock.call("project=MLX12345 and summary ~ 'Caption for action 2'"),
                          ])
 
@@ -140,14 +140,14 @@ class TestJiraInteraction(TestCase):
             jira_mock.create_issue.call_args_list,
             [
                 mock.call(
-                    summary='MEETING-12345_2 Caption for action 1',
+                    summary='MEETING-12345_2: Caption for action 1',
                     description='Description for action 1',
                     assignee={'name': 'ABC'},
                     **self.general_fields
                 ),
                 mock.call(
                     summary='Caption for action 2',
-                    description='',
+                    description='Caption for action 2',
                     assignee={'name': 'ZZZ'},
                     **self.general_fields
                 ),
@@ -228,14 +228,14 @@ class TestJiraInteraction(TestCase):
             jira_mock.create_issue.call_args_list,
             [
                 mock.call(
-                    summary='MEETING-12345_2 Caption for action 1',
+                    summary='MEETING-12345_2: Caption for action 1',
                     description='Description for action 1',
                     assignee={'name': 'ABC'},
                     **self.general_fields
                 ),
                 mock.call(
                     summary='Caption for action 2',
-                    description='',
+                    description='Caption for action 2',
                     assignee={'name': 'ZZZ'},
                     **self.general_fields
                 ),


### PR DESCRIPTION
- A colon will be added to the summary of the Jira ticket after the id of the parent item.
- If the item to create a Jira ticket for has no body, its caption will be used as the description of the ticket.
- Optional setting `description_head` has been added, allowing users to add something to the description of the ticket via conf.py.