### PR TITLE
Improve performance of plugin

### DIFF
--- a/mlx/directives/item_directive.py
+++ b/mlx/directives/item_directive.py
@@ -60,7 +60,7 @@ class Item(TraceableBaseNode):
         Args:
             collection (TraceableCollection): Collection of all TraceableItems.
         """
-        for rel in collection.iter_relations():
+        for rel in collection.relations:
             targets = self._item.iter_targets(rel)
             if targets:
                 self._list_targets_for_relation(rel, targets, *args)
@@ -192,7 +192,7 @@ class ItemDirective(TraceableBaseDirective):
 
         # Add found relationships to item. All relationship data is a string of
         # item ids separated by space. It is split in a list of item ids.
-        for rel in env.traceability_collection.iter_relations():
+        for rel in env.traceability_collection.relations:
             if rel in self.options:
                 self._warn_if_comma_separated(rel, env.docname)
                 related_ids = self.options[rel].split()

--- a/mlx/directives/item_directive.py
+++ b/mlx/directives/item_directive.py
@@ -60,7 +60,7 @@ class Item(TraceableBaseNode):
         Args:
             collection (TraceableCollection): Collection of all TraceableItems.
         """
-        for rel in collection.relations:
+        for rel in collection.iter_relations():
             targets = self._item.iter_targets(rel)
             if targets:
                 self._list_targets_for_relation(rel, targets, *args)

--- a/mlx/directives/item_pie_chart_directive.py
+++ b/mlx/directives/item_pie_chart_directive.py
@@ -97,7 +97,7 @@ class ItemPieChart(TraceableBaseNode):
             match_function (func): Function to be called when the regular expression hits.
         """
         for relationship in self.relationships:
-            for target_id in source_item.iter_targets(relationship, True, True):
+            for target_id in source_item.iter_targets(relationship, explicit=True, implicit=True):
                 target_item = self.collection.get_item(target_id)
                 # placeholders don't end up in any item-matrix (less duplicate warnings for missing items)
                 if not target_item or target_item.is_placeholder():

--- a/mlx/directives/item_tree_directive.py
+++ b/mlx/directives/item_tree_directive.py
@@ -115,7 +115,7 @@ class ItemTreeDirective(TraceableBaseDirective):
         # Combination of forward + matching reverse relationship cannot be in the same list, as it will give
         # endless treeview (and endless recursion in python --> exception)
         for rel in item_tree_node['type']:
-            if rel not in env.traceability_collection.iter_relations():
+            if rel not in env.traceability_collection.relations:
                 report_warning('Traceability: unknown relation for item-tree: %s' % rel, env.docname, self.lineno)
                 continue
             if env.traceability_collection.get_reverse_relation(rel) in item_tree_node['type']:

--- a/mlx/traceable_base_directive.py
+++ b/mlx/traceable_base_directive.py
@@ -74,7 +74,7 @@ class TraceableBaseDirective(Directive, ABC):
             env (sphinx.environment.BuildEnvironment): Sphinx's build environment.
         """
         for rel in relationships:
-            if rel not in env.traceability_collection.iter_relations():
+            if rel not in env.traceability_collection.relations:
                 report_warning('Traceability: unknown relation for %s: %s' % (self.name, rel),
                                env.docname, self.lineno)
 

--- a/mlx/traceable_base_node.py
+++ b/mlx/traceable_base_node.py
@@ -138,7 +138,7 @@ class TraceableBaseNode(nodes.General, nodes.Element, ABC):
         '''
         item = env.traceability_collection.get_item(item_id)
         for relation in self['top_relation_filter']:
-            tgts = item.iter_targets(relation)
+            tgts = item.iter_targets(relation, sort=False)
             for tgt in tgts:
                 if re.match(self['top'], tgt):
                     return False

--- a/mlx/traceable_collection.py
+++ b/mlx/traceable_collection.py
@@ -54,13 +54,12 @@ class TraceableCollection:
         '''
         Iterate over available relations: naturally sorted
 
-        Yields:
+        Returns:
             Naturally sorted list over available relations in the collection
         '''
         if len(self.relations) != len(self.relations_sorted):
             self.relations_sorted = natsorted(self.relations)
-        for rel in self.relations_sorted:
-            yield rel
+        return self.relations_sorted
 
     def add_item(self, item):
         '''

--- a/mlx/traceable_collection.py
+++ b/mlx/traceable_collection.py
@@ -21,6 +21,7 @@ class TraceableCollection:
         '''Initializer for container of traceable items'''
         self.relations = {}
         self.items = {}
+        self.relations_sorted = {}
 
     def add_relation_pair(self, forward, reverse=NO_RELATION_STR):
         '''
@@ -53,10 +54,13 @@ class TraceableCollection:
         '''
         Iterate over available relations: naturally sorted
 
-        Returns:
+        Yields:
             Naturally sorted list over available relations in the collection
         '''
-        return natsorted(self.relations)
+        if len(self.relations) != len(self.relations_sorted):
+            self.relations_sorted = natsorted(self.relations)
+        for rel in self.relations_sorted:
+            yield rel
 
     def add_item(self, item):
         '''

--- a/mlx/traceable_collection.py
+++ b/mlx/traceable_collection.py
@@ -224,7 +224,7 @@ class TraceableCollection:
                         continue
                     # Reverse relation exists?
                     target = self.get_item(tgt)
-                    if itemid not in target.iter_targets(rev_relation):
+                    if itemid not in target.iter_targets(rev_relation, sort=False):
                         errors.append(TraceabilityException("No automatic reverse relation: {source} {relation} "
                                                             "{target}".format(source=tgt,
                                                                               relation=rev_relation,
@@ -269,7 +269,7 @@ class TraceableCollection:
         if not target or target.is_placeholder():
             return False
         if not relations:
-            relations = self.iter_relations()
+            relations = self.relations
         return self.items[source_id].is_related(relations, target_id)
 
     def get_items(self, regex, attributes=None, sortattributes=None, reverse=False):

--- a/mlx/traceable_item.py
+++ b/mlx/traceable_item.py
@@ -148,31 +148,41 @@ class TraceableItem(TraceableBaseClass):
                 if target_id in database[relation]:
                     database[relation].remove(target_id)
 
-    def iter_targets(self, relation, explicit=True, implicit=True):
-        ''' Gets a naturally sorted list of targets to other traceable item(s).
+    def iter_targets(self, relation, explicit=True, implicit=True, sort=True):
+        ''' Gets a list of targets to other traceable item(s), naturally sorted by default.
 
         Args:
             relation (str): Name of the relation.
             explicit (bool): If True, explicitly expressed relations are included in the returned list.
             implicit (bool): If True, implicitly expressed relations are included in the returned list.
+            sort (bool): True if the relations should be sorted naturally, False if no sorting is needed
 
         Returns:
-            (list) Naturally sorted list of targets to other traceable item(s).
+            (list) List of targets to other traceable item(s), naturally sorted by default
         '''
         relations = []
         if explicit and relation in self.explicit_relations:
             relations.extend(self.explicit_relations[relation])
         if implicit and relation in self.implicit_relations:
             relations.extend(self.implicit_relations[relation])
-        return natsorted(relations)
+        if sort:
+            return natsorted(relations)
+        return relations
 
-    def iter_relations(self):
-        ''' Iterates over available relations: naturally sorted.
+    def iter_relations(self, sort=True):
+        ''' Iterates over available relations: naturally sorted by default.
+
+        Args:
+            sort (bool): True if the relations should be sorted naturally, False if no sorting is needed
 
         Returns:
-            (list) Naturally sorted list containing available relations in the item.
+            (list) List containing available relations in the item, naturally sorted by default
         '''
-        return natsorted(list(self.explicit_relations) + list(self.implicit_relations))
+        relations = list(self.explicit_relations) + list(self.implicit_relations)
+        if sort:
+            return natsorted(relations)
+        return relations
+
 
     @staticmethod
     def define_attribute(attr):
@@ -328,7 +338,7 @@ class TraceableItem(TraceableBaseClass):
             (bool) True if given item is related through the given relationships, False otherwise.
         '''
         for relation in relations:
-            if target_id in self.iter_targets(relation, explicit=True, implicit=True):
+            if target_id in self.iter_targets(relation, explicit=True, implicit=True, sort=False):
                 return True
         return False
 
@@ -367,8 +377,8 @@ class TraceableItem(TraceableBaseClass):
                 raise TraceabilityException('item {item} has invalid attribute value for {attribute}'
                                             .format(item=self.get_id(), attribute=attribute))
         # Targets should have no duplicates
-        for relation in self.iter_relations():
-            tgts = self.iter_targets(relation)
+        for relation in self.iter_relations(sort=False):
+            tgts = self.iter_targets(relation, sort=False)
             cnt_duplicate = len(tgts) - len(set(tgts))
             if cnt_duplicate:
                 raise TraceabilityException('{cnt} duplicate target(s) found for {item} {relation})'

--- a/mlx/traceable_item.py
+++ b/mlx/traceable_item.py
@@ -183,7 +183,6 @@ class TraceableItem(TraceableBaseClass):
             return natsorted(relations)
         return relations
 
-
     @staticmethod
     def define_attribute(attr):
         ''' Defines an attribute that can be assigned to traceable items.


### PR DESCRIPTION
Removed unnecessary calls to `natsort.natsorted`. 96.3% of the calls to this function while building the example documentation was unnecessary.