### PR TITLE
Add option to notify a Jira ticket's watchers of its existence

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -512,6 +512,7 @@ Configuration
         'description_head': 'Action raised in meeting.\n\n',
         'warn_if_exists': False,
         'errors_to_warnings': True,
+        'notify_watchers': False,
     }
 
 ``project_key_regex`` can optionally be defined. This regular expression with a named group *project* is used to
@@ -530,6 +531,10 @@ related Jira tickets.
 
 A string can be added to the start of a ticket's description by configuring ``description_head``. If the item to create
 a ticket for does not have a body, its caption will be used to build the ticket's description.
+
+Watchers of a ticket can be notified about the creation of the ticket by setting ``notify_watchers`` to ``True``.
+Note that this notification is only sent when the user to assign to the ticket is different from the default assignee
+configured in Jira.
 
 Attributes
 ==========

--- a/mlx/jira_interaction.py
+++ b/mlx/jira_interaction.py
@@ -91,6 +91,7 @@ def push_item_to_jira(jira, fields, item, attendees, assignee):
     The value of the effort option gets added to the Estimated field of the time tracking section. On failure, it gets
     appended to the description instead.
     The attendees are added to the watchers field. A warning is raised for each error returned by Jira.
+    The assignee is set as the last step. When this results in a change in the ticket, the watchers get notified.
 
     Args:
         jira (jira.JIRA): Jira interface object

--- a/mlx/jira_interaction.py
+++ b/mlx/jira_interaction.py
@@ -81,6 +81,9 @@ def create_unique_issues(item_ids, jira, general_fields, settings, traceability_
         if not body:
             body = item.caption
         fields['description'] = settings.get('description_head', '') + body
+        if assignee and not settings.get('notify_watchers', False):
+            fields['assignee'] = {'name': item.get_attribute('assignee')}
+            assignee = ''
 
         push_item_to_jira(jira, {**fields, **general_fields}, item, attendees, assignee)
 
@@ -91,14 +94,14 @@ def push_item_to_jira(jira, fields, item, attendees, assignee):
     The value of the effort option gets added to the Estimated field of the time tracking section. On failure, it gets
     appended to the description instead.
     The attendees are added to the watchers field. A warning is raised for each error returned by Jira.
-    The assignee is set as the last step. When this results in a change in the ticket, the watchers get notified.
+    The assignee can be set as the last step. When this results in a change in the ticket, the watchers get notified.
 
     Args:
         jira (jira.JIRA): Jira interface object
         general_fields (dict): Dictionary containing all fields to include in the initial creation of the Jira ticket
         item (TraceableItem): Traceable item to create the Jira ticket for
         attendees (list): List of attendees that should get added to the watchers field
-        assignee (str): User to assign to the issue; empty in case no assignee has to be set explicitly
+        assignee (str): User to assign to the issue as a last and separate call to Jira; empty to skip this step
     """
     issue = jira.create_issue(**fields)
 

--- a/tests/test_jira_interaction.py
+++ b/tests/test_jira_interaction.py
@@ -142,11 +142,13 @@ class TestJiraInteraction(TestCase):
                 mock.call(
                     summary='MEETING-12345_2: Caption for action 1',
                     description='Description for action 1',
+                    assignee={'name': 'ABC'},
                     **self.general_fields
                 ),
                 mock.call(
                     summary='Caption for action 2',
                     description='Caption for action 2',
+                    assignee={'name': 'ZZZ'},
                     **self.general_fields
                 ),
             ])
@@ -158,12 +160,6 @@ class TestJiraInteraction(TestCase):
 
         # attendees added for action1 since it is linked with depends_on to parent item with ``attendees`` attribute
         self.assertEqual(jira_mock.add_watcher.call_args_list,
-                         [
-                             mock.call(issue, 'ABC'),
-                             mock.call(issue, 'ZZZ'),
-                         ])
-
-        self.assertEqual(jira_mock.assign_issue.call_args_list,
                          [
                              mock.call(issue, 'ABC'),
                              mock.call(issue, 'ZZZ'),
@@ -234,11 +230,13 @@ class TestJiraInteraction(TestCase):
                 mock.call(
                     summary='MEETING-12345_2: Caption for action 1',
                     description='Description for action 1',
+                    assignee={'name': 'ABC'},
                     **self.general_fields
                 ),
                 mock.call(
                     summary='Caption for action 2',
                     description='Caption for action 2',
+                    assignee={'name': 'ZZZ'},
                     **self.general_fields
                 ),
             ])

--- a/tests/test_jira_interaction.py
+++ b/tests/test_jira_interaction.py
@@ -12,16 +12,15 @@ import mlx.jira_interaction as dut
 
 @mock.patch('mlx.jira_interaction.JIRA')
 class TestJiraInteraction(TestCase):
-    general_fields = {
-        'components': [
-            {'name': '[SW]'},
-            {'name': '[HW]'},
-        ],
-        'issuetype': {'name': 'Task'},
-        'project': 'MLX12345',
-    }
-
     def setUp(self):
+        self.general_fields = {
+            'components': [
+                {'name': '[SW]'},
+                {'name': '[HW]'},
+            ],
+            'issuetype': {'name': 'Task'},
+            'project': 'MLX12345',
+        }
         self.settings = {
             'api_endpoint': 'https://jira.atlassian.com/rest/api/latest/',
             'username': 'my_username',
@@ -36,6 +35,7 @@ class TestJiraInteraction(TestCase):
             'relationship_to_parent': 'depends_on',
             'components': '[SW],[HW]',
             'catch_errors': False,
+            'notify_watchers': False,
         }
         self.coll = TraceableCollection()
         parent = TraceableItem('MEETING-12345_2')
@@ -160,6 +160,45 @@ class TestJiraInteraction(TestCase):
 
         # attendees added for action1 since it is linked with depends_on to parent item with ``attendees`` attribute
         self.assertEqual(jira_mock.add_watcher.call_args_list,
+                         [
+                             mock.call(issue, 'ABC'),
+                             mock.call(issue, 'ZZZ'),
+                         ])
+
+        self.assertEqual(jira_mock.assign_issue.call_args_list, [])
+
+    def test_notify_watchers(self, jira):
+        """ Test effect of setting `notify_watchers` to True
+
+        By default, watchers are added as the last step. When setting `notify_watchers` is set to a truthy value,
+        the assignee should be set in an additional call to Jira after the watchers have been added.
+        """
+        jira_mock = jira.return_value
+        jira_mock.search_issues.return_value = []
+        self.settings['notify_watchers'] = True
+
+        with self.assertLogs(level=WARNING) as cm:
+            warning('Dummy log')
+            dut.create_jira_issues(self.settings, self.coll)
+
+        # No kwarg 'assignee' should be passed
+        self.assertEqual(
+            jira_mock.create_issue.call_args_list,
+            [
+                mock.call(
+                    description='Description for action 1',
+                    summary='MEETING-12345_2: Caption for action 1',
+                    **self.general_fields
+                ),
+                mock.call(
+                    description='Caption for action 2',
+                    summary='Caption for action 2',
+                    **self.general_fields
+                ),
+            ])
+        # Additional call to set assignee should be made after the issue has been created
+        issue = jira_mock.create_issue.return_value
+        self.assertEqual(jira_mock.assign_issue.call_args_list,
                          [
                              mock.call(issue, 'ABC'),
                              mock.call(issue, 'ZZZ'),

--- a/tests/test_jira_interaction.py
+++ b/tests/test_jira_interaction.py
@@ -142,13 +142,11 @@ class TestJiraInteraction(TestCase):
                 mock.call(
                     summary='MEETING-12345_2: Caption for action 1',
                     description='Description for action 1',
-                    assignee={'name': 'ABC'},
                     **self.general_fields
                 ),
                 mock.call(
                     summary='Caption for action 2',
                     description='Caption for action 2',
-                    assignee={'name': 'ZZZ'},
                     **self.general_fields
                 ),
             ])
@@ -160,6 +158,12 @@ class TestJiraInteraction(TestCase):
 
         # attendees added for action1 since it is linked with depends_on to parent item with ``attendees`` attribute
         self.assertEqual(jira_mock.add_watcher.call_args_list,
+                         [
+                             mock.call(issue, 'ABC'),
+                             mock.call(issue, 'ZZZ'),
+                         ])
+
+        self.assertEqual(jira_mock.assign_issue.call_args_list,
                          [
                              mock.call(issue, 'ABC'),
                              mock.call(issue, 'ZZZ'),
@@ -230,13 +234,11 @@ class TestJiraInteraction(TestCase):
                 mock.call(
                     summary='MEETING-12345_2: Caption for action 1',
                     description='Description for action 1',
-                    assignee={'name': 'ABC'},
                     **self.general_fields
                 ),
                 mock.call(
                     summary='Caption for action 2',
                     description='Caption for action 2',
-                    assignee={'name': 'ZZZ'},
                     **self.general_fields
                 ),
             ])

--- a/tests/test_jira_interaction.py
+++ b/tests/test_jira_interaction.py
@@ -177,7 +177,7 @@ class TestJiraInteraction(TestCase):
         jira_mock.search_issues.return_value = []
         self.settings['notify_watchers'] = True
 
-        with self.assertLogs(level=WARNING) as cm:
+        with self.assertLogs(level=WARNING):
             warning('Dummy log')
             dut.create_jira_issues(self.settings, self.coll)
 


### PR DESCRIPTION
Add an optional setting `traceability_jira_automation['notify_watchers']`, which is set to `False` by default, to let Jira notify a ticket's watchers of its creation by setting the assignee field of the ticket after the watchers have been added instead of during the ticket's creation.

Note that a notification is only triggered when a change in the ticket occurs. Explicitly setting the default assignee - after the Jira ticket has been already been created while resorting to the default assignee - will not trigger a notification.

This is essentially a workaround because Jira can't be configured to notify a watcher when they are added as a watcher.