### PR TITLE
Add flexibility to traceability_jira_automation['relationship_to_parent']

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -526,8 +526,8 @@ A warning gets reported when a Jira ticket already exists. These warnings can be
 crash your build, you can set ``errors_to_warnings`` to a falsy value.
 
 The item ID of a linked item can be added to the summary of the Jira ticket to create by specifying the relationship
-to this item in the value for setting ``relationship_to_parent``. The value can be a sequence with the relationship as
-the first element and the regular expression to match the linked item's ID as the second element.
+to this item in the value for setting ``relationship_to_parent``. The value can be a list or tuple with the relationship
+as the first element and the regular expression to match the linked item's ID as the second element.
 This feature makes it possible to create a query link in advance to list all Jira tickets that are related to this
 linked item.
 

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -507,7 +507,7 @@ Configuration
         'project_key_regex': r'ACTION-(?P<project>\d{5})_',
         'project_key_prefix': 'MLX',
         'default_project': 'SWCC',
-        'relationship_to_parent': 'depends_on',
+        'relationship_to_parent': ('depends_on', r'MEETING-[\w_]+'),
         'components': '[SW],[HW]',
         'description_head': 'Action raised in meeting.\n\n',
         'warn_if_exists': False,
@@ -526,8 +526,10 @@ A warning gets reported when a Jira ticket already exists. These warnings can be
 crash your build, you can set ``errors_to_warnings`` to a falsy value.
 
 The item ID of a linked item can be added to the summary of the Jira ticket to create by specifying the relationship
-to this item with ``relationship_to_parent``. This makes it possible to create a query link in advance to list all
-related Jira tickets.
+to this item in the value for setting ``relationship_to_parent``. The value can be a sequence with the relationship as
+the first element and the regular expression to match the linked item's ID as the second element.
+This feature makes it possible to create a query link in advance to list all Jira tickets that are related to this
+linked item.
 
 A string can be added to the start of a ticket's description by configuring ``description_head``. If the item to create
 a ticket for does not have a body, its caption will be used to build the ticket's description.

--- a/mlx/jira_interaction.py
+++ b/mlx/jira_interaction.py
@@ -175,5 +175,7 @@ def get_info_from_relationship(item, config_for_parent, traceability_collection)
         if parent_id:
             parent = traceability_collection.get_item(parent_id)
             jira_field = "{id}: {field}".format(id=parent_id, field=jira_field)  # prepend item ID of parent
-            attendees = parent.get_attribute('attendees').split(',')
+            attr_value = parent.get_attribute('attendees')
+            if attr_value:
+                attendees = attr_value.split(',')
     return attendees, jira_field

--- a/mlx/jira_interaction.py
+++ b/mlx/jira_interaction.py
@@ -1,5 +1,4 @@
 """Functionality to interact with Jira"""
-from collections.abc import Sequence
 from re import match, search
 
 from jira import JIRA, JIRAError
@@ -150,7 +149,7 @@ def get_info_from_relationship(item, config_for_parent, traceability_collection)
 
     Args:
         item (TraceableItem): Traceable item to create the Jira ticket for
-        config_for_parent (str/Sequence): Relationship to the item to extract info from / sequence with
+        config_for_parent (str/tuple/list): Relationship to the item to extract info from / tuple or list with
             relationship as the first element and regex to match ID of parent item as the second element
         traceability_collection (TraceableCollection): Collection of all traceability items
 
@@ -161,12 +160,12 @@ def get_info_from_relationship(item, config_for_parent, traceability_collection)
     attendees = []
     jira_field = item.caption
     if config_for_parent:
-        if isinstance(config_for_parent, Sequence):
+        if isinstance(config_for_parent, (tuple, list)):
             relationship = config_for_parent[0]
             parent_regex = config_for_parent[1]
         else:
             relationship = config_for_parent
-            parent_regex = '.*'
+            parent_regex = '.+'
         parent_ids = item.iter_targets(relationship)
         parent_id = None
         for id_ in parent_ids:

--- a/mlx/jira_interaction.py
+++ b/mlx/jira_interaction.py
@@ -1,4 +1,5 @@
 """Functionality to interact with Jira"""
+from collections.abc import Sequence
 from re import match, search
 
 from jira import JIRA, JIRAError
@@ -149,7 +150,7 @@ def get_info_from_relationship(item, config_for_parent, traceability_collection)
 
     Args:
         item (TraceableItem): Traceable item to create the Jira ticket for
-        config_for_parent (str/tuple): Relationship to the item to extract info from or tuple with
+        config_for_parent (str/Sequence): Relationship to the item to extract info from / sequence with
             relationship as the first element and regex to match ID of parent item as the second element
         traceability_collection (TraceableCollection): Collection of all traceability items
 
@@ -160,7 +161,7 @@ def get_info_from_relationship(item, config_for_parent, traceability_collection)
     attendees = []
     jira_field = item.caption
     if config_for_parent:
-        if isinstance(config_for_parent, tuple):
+        if isinstance(config_for_parent, Sequence):
             relationship = config_for_parent[0]
             parent_regex = config_for_parent[1]
         else:

--- a/mlx/jira_interaction.py
+++ b/mlx/jira_interaction.py
@@ -1,5 +1,5 @@
 """Functionality to interact with Jira"""
-from re import search
+from re import match, search
 
 from jira import JIRA, JIRAError
 
@@ -142,14 +142,15 @@ def determine_jira_project(key_regex, key_prefix, default_project, item_id):
         return default_project
 
 
-def get_info_from_relationship(item, relationship, traceability_collection):
+def get_info_from_relationship(item, config_for_parent, traceability_collection):
     """ Gets info from the first item with the given relationship.
 
     Its id is added to the jira field and if it has the 'attendees' attribute, its value is returned as a list.
 
     Args:
         item (TraceableItem): Traceable item to create the Jira ticket for
-        relationship_to_parent (str): Relationship to the item to extract info from
+        config_for_parent (str/tuple): Relationship to the item to extract info from or tuple with
+            relationship as the first element and regex to match ID of parent item as the second element
         traceability_collection (TraceableCollection): Collection of all traceability items
 
     Returns:
@@ -158,10 +159,20 @@ def get_info_from_relationship(item, relationship, traceability_collection):
     """
     attendees = []
     jira_field = item.caption
-    if relationship:
+    if config_for_parent:
+        if isinstance(config_for_parent, tuple):
+            relationship = config_for_parent[0]
+            parent_regex = config_for_parent[1]
+        else:
+            relationship = config_for_parent
+            parent_regex = '.*'
         parent_ids = item.iter_targets(relationship)
-        if parent_ids:
-            parent_id = parent_ids[0]
+        parent_id = None
+        for id_ in parent_ids:
+            if match(parent_regex, id_):
+                parent_id = id_
+                break
+        if parent_id:
             parent = traceability_collection.get_item(parent_id)
             jira_field = "{id}: {field}".format(id=parent_id, field=jira_field)  # prepend item ID of parent
             attendees = parent.get_attribute('attendees').split(',')

--- a/mlx/traceable_item.py
+++ b/mlx/traceable_item.py
@@ -160,14 +160,14 @@ class TraceableItem(TraceableBaseClass):
         Returns:
             (list) List of targets to other traceable item(s), naturally sorted by default
         '''
-        relations = []
+        targets = []
         if explicit and relation in self.explicit_relations:
-            relations.extend(self.explicit_relations[relation])
+            targets.extend(self.explicit_relations[relation])
         if implicit and relation in self.implicit_relations:
-            relations.extend(self.implicit_relations[relation])
+            targets.extend(self.implicit_relations[relation])
         if sort:
-            return natsorted(relations)
-        return relations
+            return natsorted(targets)
+        return targets
 
     def iter_relations(self, sort=True):
         ''' Iterates over available relations: naturally sorted by default.

--- a/tests/test_jira_interaction.py
+++ b/tests/test_jira_interaction.py
@@ -306,7 +306,8 @@ class TestJiraInteraction(TestCase):
         """
         self.settings['relationship_to_parent'] = ('depends_on', r'ZZZ-[\w_]+')
         alternative_parent = TraceableItem('ZZZ-TO_BE_PRIORITIZED')
-        self.coll.add_relation('ACTION-12345_ACTION_1', 'depends_on', alternative_parent.id)  # to be prioritized over MEETING-12345_2
+        # to be prioritized over MEETING-12345_2
+        self.coll.add_relation('ACTION-12345_ACTION_1', 'depends_on', alternative_parent.id)
 
         jira_mock = jira.return_value
         jira_mock.search_issues.return_value = []
@@ -325,7 +326,6 @@ class TestJiraInteraction(TestCase):
                              mock.call("project=MLX12345 and summary ~ 'Caption for action 2'"),
                          ])
 
-        issue = jira_mock.create_issue.return_value
         self.assertEqual(
             jira_mock.create_issue.call_args_list,
             [
@@ -347,7 +347,8 @@ class TestJiraInteraction(TestCase):
         """ Tests dut.get_info_from_relationship with a config_for_parent parameter as tuple """
         relationship_to_parent = ('depends_on', r'ZZZ-[\w_]+')
         alternative_parent = TraceableItem('ZZZ-TO_BE_PRIORITIZED')
-        self.coll.add_relation('ACTION-12345_ACTION_1', 'depends_on', alternative_parent.id)  # to be prioritized over MEETING-12345_2
+        # to be prioritized over MEETING-12345_2
+        self.coll.add_relation('ACTION-12345_ACTION_1', 'depends_on', alternative_parent.id)
         action1 = self.coll.get_item('ACTION-12345_ACTION_1')
 
         attendees, jira_field = dut.get_info_from_relationship(action1, relationship_to_parent, self.coll)
@@ -359,7 +360,8 @@ class TestJiraInteraction(TestCase):
         """ Tests dut.get_info_from_relationship with a config_for_parent parameter as str """
         relationship_to_parent = 'depends_on'
         alternative_parent = TraceableItem('ZZZ-TO_BE_IGNORED')
-        self.coll.add_relation('ACTION-12345_ACTION_1', 'depends_on', alternative_parent.id)  # not to be prioritized over MEETING-12345_2 (natural sorting)
+        # not to be prioritized over MEETING-12345_2 (natural sorting)
+        self.coll.add_relation('ACTION-12345_ACTION_1', 'depends_on', alternative_parent.id)
         action1 = self.coll.get_item('ACTION-12345_ACTION_1')
 
         attendees, jira_field = dut.get_info_from_relationship(action1, relationship_to_parent, self.coll)

--- a/tests/test_jira_interaction.py
+++ b/tests/test_jira_interaction.py
@@ -304,7 +304,7 @@ class TestJiraInteraction(TestCase):
         Tests that the linked item, added in this test case, is selected by configured tuple for
         ``relationship_to_parent``
         """
-        self.settings['relationship_to_parent'] = ('depends_on', 'ZZZ-[\w_]+')
+        self.settings['relationship_to_parent'] = ('depends_on', r'ZZZ-[\w_]+')
         alternative_parent = TraceableItem('ZZZ-TO_BE_PRIORITIZED')
         self.coll.add_relation('ACTION-12345_ACTION_1', 'depends_on', alternative_parent.id)  # to be prioritized over MEETING-12345_2
 


### PR DESCRIPTION
Add flexibility to `traceability_jira_automation['relationship_to_parent']`. Currently only a string is allowed to define the relation to look for parent items. The first parent item from that list is used. This behavior is not deterministic enough when the item to generate a Jira ticket for has multiple items linked to it with the same relationship.

This PR adds support for a sequence (e.g. a tuple, a list) as configured value. This sequence should have the relationship as the first element and a regex to match the ID of the desired parent item as the second element. Backward compatibility is ensured by keeping for support for the string as value.