### PR TITLE
Sort source column of item-matrix when external items are used

### DIFF
--- a/doc/integration_test_report.rst
+++ b/doc/integration_test_report.rst
@@ -69,6 +69,7 @@ This text is not part of any item
 .. item:: r005 Another (does not show captions on the related items)
     :aspice: 2
     :asil: C
+    :ext_toolname: namespace:group:another
     :class: terciary
     :trace: r002 r002 r003
     :nocaptions:

--- a/mlx/directives/item_matrix_directive.py
+++ b/mlx/directives/item_matrix_directive.py
@@ -1,8 +1,9 @@
 import re
-from collections import namedtuple
+from collections import namedtuple, OrderedDict
 
 from docutils import nodes
 from docutils.parsers.rst import directives
+from natsort import natsorted
 
 from mlx.traceability_exception import report_warning
 from mlx.traceable_base_directive import TraceableBaseDirective
@@ -89,7 +90,9 @@ class ItemMatrix(TraceableBaseNode):
         if not source_ids:
             # try to use external targets as source
             for ext_rel in external_relationships:
-                for ext_source, target_ids in collection.get_external_targets(self['source'], ext_rel).items():
+                external_targets = collection.get_external_targets(self['source'], ext_rel)
+                # natural sorting on source
+                for ext_source, target_ids in OrderedDict(natsorted(external_targets.items())).items():
                     covered = False
                     left = nodes.entry()
                     left += self.make_external_item_ref(app, ext_source, ext_rel)


### PR DESCRIPTION
The source column of the item-matrix should always be sorted naturally, also when external items are used. The sorting was missing in the [v7.0.0](https://github.com/melexis/sphinx-traceability-extension/releases/tag/v7.0.0) release.