### PR TITLE
Ensure visibility of arrow button to collapse traceability

### DIFF
--- a/mlx/assets/traceability.js
+++ b/mlx/assets/traceability.js
@@ -6,6 +6,7 @@ jQuery(function () {
 $(document).ready(function () {
     $('div.collapsible_links div.admonition:first-child').each(function (i) {
         $(this).siblings('dl').first().addCollapseButton($(this));
+        $(this).css('clear', 'left');  // sphinx-rtd-theme==0.5.0 sets `clear: both` which pushes button out of bar
     });
 
     // show an item's hidden caption on hover

--- a/mlx/assets/traceability.js
+++ b/mlx/assets/traceability.js
@@ -4,7 +4,7 @@ jQuery(function () {
 });
 
 $(document).ready(function () {
-    $('div.collapsible_links div.admonition:first-child').each(function (i) {
+    $('div.collapsible_links div.admonition.item').each(function (i) {
         $(this).siblings('dl').first().addCollapseButton($(this));
         $(this).css('clear', 'left');  // sphinx-rtd-theme==0.5.0 sets `clear: both` which pushes button out of bar
     });


### PR DESCRIPTION
Closes https://github.com/melexis/sphinx-traceability-extension/issues/191

This is a patch for the following issues:

- external themes may set the CSS style `clear: both` on the admonition div, causing the arrow button to be pushed out of the admonition bar and become invisible (white arrow on white background)
- if an item-directive is preceded by an internal reference definition, e.g. `.. _sw_requirements:`, the arrow button didn't appear

FYI @bwi-mlx @bavovanachte 