### PR TITLE
Add an option to item-matrix to filter source items on relationships

### DIFF
--- a/doc/integration_test_report.rst
+++ b/doc/integration_test_report.rst
@@ -325,6 +325,24 @@ Traceability from external sources
     :targettitle: internal items
     :type: ext_toolname
 
+Traceability from integration tests to requirements
+---------------------------------------------------
+
+.. item-matrix:: All integration tests
+    :source: ITEST-
+    :sourcetitle: integration tests
+    :targettitle: requirements
+    :type: validates
+    :stats:
+
+.. item-matrix:: All integration tests that have a report
+    :source: ITEST-
+    :sourcetitle: integration tests
+    :targettitle: requirements
+    :type: validates
+    :sourcetype: impacts_on
+    :stats:
+
 Item attribute matrix
 =====================
 

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -256,6 +256,7 @@ A traceability matrix of documentation items can be generated using:
         :sourcetitle: Software requirements
         :targettitle: Integration and unit test cases
         :type: validated_by
+        :sourcetype: fulfilled_by
         :status: Appr
         :group: bottom
         :onlycovered:
@@ -301,6 +302,11 @@ limitations in doing so:
     When multiple arguments are provided the target column will show items that match *any* of the given relationships
     provided. The same filtering is applied to all "Target" columns in the matrix.
     When omitted all possible relations are considered **except for external relations**.
+
+:sourcetype: *optional*, *multiple arguments (space-separated)*
+
+    The list of relationships that should all source items should have. This option is unrelated to the *target* option
+    and is solely used to filter source items - in addition to the *source* filter.
 
 :status: *optional*, *multiple arguments (space-separated)*
 

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -305,7 +305,7 @@ limitations in doing so:
 
 :sourcetype: *optional*, *multiple arguments (space-separated)*
 
-    The list of relationships that should all source items should have. This option is unrelated to the *target* option
+    The list of relationships that all source items should have. This option is unrelated to the *target* option
     and is solely used to filter source items - in addition to the *source* filter.
 
 :status: *optional*, *multiple arguments (space-separated)*

--- a/mlx/directives/item_matrix_directive.py
+++ b/mlx/directives/item_matrix_directive.py
@@ -70,6 +70,8 @@ class ItemMatrix(TraceableBaseNode):
         rows = Rows([], [], [])
         for source_id in source_ids:
             source_item = collection.get_item(source_id)
+            if self['sourcetype'] and not source_item.has_relations(self['sourcetype']):
+                continue
             covered = False
             left = nodes.entry()
             left += self.make_internal_item_ref(app, source_id)
@@ -189,6 +191,7 @@ class ItemMatrixDirective(TraceableBaseDirective):
          :targettitle: Target column header
          :sourcetitle: Source column header
          :type: <<relationship>> ...
+         :sourcetype: <<relationship>> ...
          :group: top | bottom
          :onlycovered:
          :stats:
@@ -204,6 +207,7 @@ class ItemMatrixDirective(TraceableBaseDirective):
         'targettitle': directives.unchanged,
         'sourcetitle': directives.unchanged,
         'type': directives.unchanged,  # a string with relationship types separated by space
+        'sourcetype': directives.unchanged,  # a string with relationship types separated by space
         'group': group,
         'onlycovered': directives.flag,
         'stats': directives.flag,
@@ -235,6 +239,7 @@ class ItemMatrixDirective(TraceableBaseDirective):
                 'targettitle': {'default': ['Target'], 'delimiter': ','},
                 'sourcetitle': {'default': 'Source'},
                 'type':        {'default': []},
+                'sourcetype':  {'default': []},
             },
         )
 
@@ -250,6 +255,7 @@ class ItemMatrixDirective(TraceableBaseDirective):
                            env.docname, self.lineno)
 
         self.check_relationships(item_matrix_node['type'], env)
+        self.check_relationships(item_matrix_node['sourcetype'], env)
 
         self.check_option_presence(item_matrix_node, 'onlycovered')
         self.check_option_presence(item_matrix_node, 'stats')

--- a/mlx/traceable_item.py
+++ b/mlx/traceable_item.py
@@ -341,6 +341,21 @@ class TraceableItem(TraceableBaseClass):
                 return True
         return False
 
+    def has_relations(self, relations):
+        ''' Checks if the item has every relationship in given list.
+
+        Args:
+            relations (list): List of relations.
+
+        Returns:
+            (bool) True if the item has every relationship in given list of list is empty, False otherwise.
+        '''
+        own_relations = self.iter_relations(sort=False)
+        for relation in relations:
+            if relation not in own_relations:
+                return False
+        return True
+
     def to_dict(self):
         ''' Exports item to a dictionary.
 

--- a/tests/test_attribute_link.py
+++ b/tests/test_attribute_link.py
@@ -1,0 +1,129 @@
+from unittest import TestCase
+from unittest.mock import Mock, MagicMock
+
+from sphinx.application import Sphinx
+from sphinx.builders.latex import LaTeXBuilder
+from sphinx.builders.html import StandaloneHTMLBuilder
+from sphinx.environment import BuildEnvironment
+
+from mlx.directives.attribute_link_directive import AttributeLink as dut
+from mlx.traceable_collection import TraceableCollection
+from mlx.traceable_item import TraceableItem
+
+from parameterized import parameterized
+
+
+class TestAttributeLinkDirective(TestCase):
+
+    def setUp(self):
+        self.app = Mock(spec=Sphinx)
+        self.node = dut('')
+        self.node['document'] = 'some_doc'
+        self.node['id'] = 'some_id'
+        self.node['line'] = 1
+        self.item = TraceableItem(self.node['id'])
+        self.item.set_document(self.node['document'], self.node['line'])
+        self.item.bind_node(self.node)
+        self.app.config = Mock()
+        self.app.config.traceability_hyperlink_colors = {}
+
+    def test_make_internal_item_ref_no_caption(self):
+        mock_builder = MagicMock(spec=StandaloneHTMLBuilder)
+        mock_builder.env = BuildEnvironment()
+        self.app.builder = mock_builder
+        self.app.builder.env.traceability_collection = TraceableCollection()
+        self.app.builder.env.traceability_collection.add_item(self.item)
+        p_node = self.node.make_internal_item_ref(self.app, self.node['id'])
+        ref_node = p_node.children[0]
+        em_node = ref_node.children[0]
+        self.assertEqual(len(em_node.children), 1)
+        self.assertEqual(str(em_node), '<emphasis>some_id</emphasis>')
+        self.assertEqual(ref_node.tagname, 'reference')
+        self.assertEqual(em_node.rawsource, 'some_id')
+        self.assertEqual(str(em_node.children[0]), 'some_id')
+
+    def test_make_internal_item_ref_show_caption(self):
+        mock_builder = MagicMock(spec=StandaloneHTMLBuilder)
+        mock_builder.env = BuildEnvironment()
+        self.app.builder = mock_builder
+        self.app.builder.env.traceability_collection = TraceableCollection()
+        self.app.builder.env.traceability_collection.add_item(self.item)
+        self.item.set_caption('caption text')
+        p_node = self.node.make_internal_item_ref(self.app, self.node['id'])
+        ref_node = p_node.children[0]
+        em_node = ref_node.children[0]
+
+        self.assertEqual(len(em_node.children), 1)
+        self.assertEqual(len(em_node.children), 1)
+        self.assertEqual(str(em_node), '<emphasis>some_id : caption text</emphasis>')
+        self.assertEqual(ref_node.tagname, 'reference')
+        self.assertEqual(em_node.rawsource, 'some_id : caption text')
+
+    def test_make_internal_item_ref_only_caption(self):
+        mock_builder = MagicMock(spec=StandaloneHTMLBuilder)
+        mock_builder.env = BuildEnvironment()
+        self.app.builder = mock_builder
+        self.app.builder.env.traceability_collection = TraceableCollection()
+        self.app.builder.env.traceability_collection.add_item(self.item)
+        self.item.set_caption('caption text')
+        self.node['nocaptions'] = True
+        self.node['onlycaptions'] = True
+        p_node = self.node.make_internal_item_ref(self.app, self.node['id'])
+        ref_node = p_node.children[0]
+        em_node = ref_node.children[0]
+
+        self.assertEqual(len(em_node.children), 2)
+        self.assertEqual(
+            str(em_node),
+            '<emphasis classes="has_hidden_caption">caption text<inline classes="popup_caption">some_id</inline>'
+            '</emphasis>')
+        self.assertEqual(ref_node.tagname, 'reference')
+        self.assertEqual(em_node.rawsource, 'caption text')
+
+    def test_make_internal_item_ref_hide_caption(self):
+        mock_builder = MagicMock(spec=StandaloneHTMLBuilder)
+        mock_builder.env = BuildEnvironment()
+        self.app.builder = mock_builder
+        self.app.builder.env.traceability_collection = TraceableCollection()
+        self.app.builder.env.traceability_collection.add_item(self.item)
+        self.item.set_caption('caption text')
+        self.node['nocaptions'] = True
+        p_node = self.node.make_internal_item_ref(self.app, self.node['id'])
+        ref_node = p_node.children[0]
+        em_node = ref_node.children[0]
+
+        self.assertEqual(len(em_node.children), 2)
+        self.assertEqual(str(em_node),
+                         '<emphasis classes="has_hidden_caption">some_id'
+                         '<inline classes="popup_caption">caption text</inline>'
+                         '</emphasis>')
+        self.assertEqual(ref_node.tagname, 'reference')
+        self.assertEqual(em_node.rawsource, 'some_id')
+
+    def test_make_internal_item_ref_hide_caption_latex(self):
+        mock_builder = MagicMock(spec=LaTeXBuilder)
+        mock_builder.env = BuildEnvironment()
+        self.app.builder = mock_builder
+        self.app.builder.env.traceability_collection = TraceableCollection()
+        self.app.builder.env.traceability_collection.add_item(self.item)
+        self.item.set_caption('caption text')
+        self.node['nocaptions'] = True
+        p_node = self.node.make_internal_item_ref(self.app, self.node['id'])
+        ref_node = p_node.children[0]
+        em_node = ref_node.children[0]
+
+        self.assertEqual(len(em_node.children), 1)
+        self.assertEqual(str(em_node), '<emphasis>some_id</emphasis>')
+        self.assertEqual(ref_node.tagname, 'reference')
+        self.assertEqual(em_node.rawsource, 'some_id')
+
+    @parameterized.expand([
+       ("ext_toolname", True),
+       ("verifies", False),
+       ("is verified by", False),
+       ("prefix_ext_", False),
+       ("", False),
+    ])
+    def test_is_relation_external(self, relation_name, expected):
+        external = self.node.is_relation_external(relation_name)
+        self.assertEqual(external, expected)

--- a/tests/test_traceable_item.py
+++ b/tests/test_traceable_item.py
@@ -395,3 +395,13 @@ class TestTraceableItem(TestCase):
         # Self test should fail
         with self.assertRaises(exception.TraceabilityException):
             item.self_test()
+
+    def test_has_relations(self):
+        item = dut.TraceableItem(self.identification)
+        item.set_document(self.docname)
+        item.add_target(self.fwd_relation, self.identification_tgt)
+        self.assertEqual(item.has_relations([]), True)
+        self.assertEqual(item.has_relations([self.fwd_relation]), True)
+        self.assertEqual(item.has_relations([self.rev_relation]), False)
+        self.assertEqual(item.has_relations([self.fwd_relation, self.rev_relation]), False)
+        self.assertEqual(item.has_relations([self.rev_relation, self.fwd_relation]), False)


### PR DESCRIPTION
This PR adds the `:sourcetype:` option to the *item-matrix* directive. It is an additional filter for source items next to the `:source:` option. It filters on the relationships of the source item instead of the item's ID.

On top of #195.

Resolves #194.