### PR TITLE
Include the plugin's version in Sphinx' error log

### DIFF
--- a/mlx/traceability.py
+++ b/mlx/traceability.py
@@ -18,6 +18,7 @@ from sphinx.errors import NoUri
 from docutils import nodes
 from docutils.parsers.rst import directives
 
+from mlx.__traceability_version__ import version
 from mlx.traceable_attribute import TraceableAttribute
 from mlx.traceable_base_node import TraceableBaseNode
 from mlx.traceable_item import TraceableItem
@@ -613,3 +614,5 @@ def setup(app):
     app.add_role('item', XRefRole(nodeclass=PendingItemXref,
                                   innernodeclass=nodes.emphasis,
                                   warn_dangling=True))
+
+    return {'version': version}


### PR DESCRIPTION
Currently the version shown for mlx.traceability in Sphinx' error log is `unknown version` like so:
`mlx.traceability (unknown version) from /usr/local/lib/python3.7/dist-packages/mlx/traceability.py`

This PR will display the version number of the installed plugin instead:
`mlx.traceability (7.3.0) from /usr/local/lib/python3.7/dist-packages/mlx/traceability.py`