### PR TITLE
Support markup for checklist item ID in MR description

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -509,6 +509,13 @@ functionality of the regular *item* directive.
 
     .. checklist-item:: PLAN-UNIT_TESTS Have you added unit tests for regression detection?
 
+.. note::
+
+    The IDs of these checklist-items should not start with an underscore or an asterisk to support markup in the PR/MR
+    description. More details in `PR #203`_.
+
+.. _`PR #203`: https://github.com/melexis/sphinx-traceability-extension/pull/203
+
 
 Setting the additional attribute's value
 ========================================

--- a/mlx/traceability.py
+++ b/mlx/traceability.py
@@ -446,7 +446,7 @@ def _parse_description(description, attr_values, merge_request_id, regex):
     query_results = {}
     for line in description.split('\n'):
         # catch the content of checkbox and the item ID after the checkbox
-        cli_match = match(r"\s*[\*\-]\s+\[(?P<checkbox>[\sx])\]\s+(?P<target_id>{})".format(regex), line)
+        cli_match = match(r"\s*[\*\-]\s+[*_`~]*\[(?P<checkbox>[\sx])\]\s+(?P<target_id>{})".format(regex), line)
         if cli_match:
             if cli_match.group('checkbox') == 'x':
                 item_info = ItemInfo(attr_values[0], merge_request_id)


### PR DESCRIPTION
Support markup of `checklist-item` ID in description of merge/pull request.

Example of a checklist item that the plugin ignored because of the markup:

- [x] **~CL-BUMP_VERSION: Bump the version number~**

I've updated the description of https://github.com/melexis/sphinx-traceability-extension/pull/121 to show that this is supported.