### PR TITLE
Remove newline characters in filter option of attribute-link directive

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -117,7 +117,7 @@ In the above example, the *asil* and *status* attributes with given values get
 added to all items that have an ID that starts with *RQT-*. If your documentation defines
 items *RQT-1* and *RQT-11*, but you only want to add an attribute to item *RQT-1*, you
 should use the ``filter`` option with value *RQT-1$*. If the ``filter`` option is missing,
-all items will be affected.
+all items will be affected. Newline characters in the ``filter`` regex get removed.
 
 .. note:: This directive overwrites any attribute values configured in the ``item`` directive.
 

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -309,7 +309,7 @@ limitations in doing so:
     The list of relationships that all source items should have. This option is unrelated to the *target* option
     and is solely used to filter source items - in addition to the *source* filter.
 
-:status: *optional*, *multiple arguments (space-separated)*
+:<<attribute>>: *optional*, *multiple arguments (space-separated)*
 
     Python-style regular expression used to filter the source items (left column) based on their attributes.
     The attribute value is **not** used as a filter on the *target* part.

--- a/mlx/directives/attribute_link_directive.py
+++ b/mlx/directives/attribute_link_directive.py
@@ -60,6 +60,7 @@ class AttributeLinkDirective(TraceableBaseDirective):
                 'filter': {'default': r"\S+"},
             },
         )
+        node['filter'] = node['filter'].replace('\n', '').strip()
         self.add_found_attributes(node)
 
         return [node]


### PR DESCRIPTION
Remove newline characters in `filter` option of `attribute-link` directive to allow greater flexibility. Example:

```
.. attribute-link::
    :filter: 
        RQT-(
        ATTRIBUTES|
        RELATIONS|
        LIST)$
    :asil: D
```
instead of only supporting the following:
```
.. attribute-link::
    :filter: RQT-(ATTRIBUTES|RELATIONS|LIST)$
    :asil: D
```