### PR TITLE
CI/CD: Fix conditional to trigger deploy job

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -35,9 +35,9 @@ jobs:
 
   deploy:
 
+    if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
     needs: test
     runs-on: ubuntu-latest
-    if: ${{ github.event.release.created }}
     steps:
     - name: Disable jekyll
       run: |

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,9 +1,6 @@
 name: Python package
 
-on:
-  push:
-  release:
-    types: [created]
+on: push
 
 jobs:
   test:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -10,7 +10,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
-
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
I found the solution [here](https://github.community/t/trigger-job-on-tag-push-only/18076/2). It seems that `${{ github.event.release.created }}` doesn't exist or do what we want as seen [here](https://github.com/melexis/sphinx-traceability-extension/actions/runs/894066055).