### PR TITLE
Fix empty GitHub Pages

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,4 +1,4 @@
-name: Python package
+name: Test and deploy on tag
 
 on: push
 
@@ -28,6 +28,11 @@ jobs:
       run: tox -v
       env:
         TOXENV: py,check,sphinx2.1,sphinx-latest,codecov
+    - name: Upload HTML documentation
+      uses: actions/upload-artifact@v2
+      with:
+        name: html_doc
+        path: doc/_build/html/
 
   deploy:
 
@@ -36,10 +41,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - name: Download HTML documentation from job 'test'
+      uses: actions/download-artifact@v2
+      with:
+        name: html_doc
     - name: Disable jekyll
-      run: |
-        mkdir -p doc/_build/html/
-        touch doc/_build/html/.nojekyll
+      run: touch doc/_build/html/.nojekyll
     - name: Deploy documentation
       uses: JamesIves/github-pages-deploy-action@4.1.3
       with:


### PR DESCRIPTION
The documentation on GitHub Pages has been removed after the switch to GitHub actions because the artifacts from the test job didn't get passed to the deploy job. Let's fix this and create a release to publish the documentation to https://melexis.github.io/sphinx-traceability-extension/.

Followed the following guide: https://docs.github.com/en/actions/guides/storing-workflow-data-as-artifacts#passing-data-between-jobs-in-a-workflow