### PR TITLE
Fix HTML layout of contents directive

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -40,7 +40,7 @@ deps=
     matplotlib
     sphinx-testing >= 0.5.2
     sphinx_selective_exclude>=1.0.3
-    sphinx_rtd_theme==0.5.0
+    sphinx_rtd_theme==0.5.2
     parameterized
 commands=
     {posargs:py.test --cov=mlx --cov-report=term-missing -vv tests/}


### PR DESCRIPTION
The changes to `docutils/writers/html5_polyglot/__init__.py` in [docutils>=0.17](https://docutils.sourceforge.io/HISTORY.html#release-0-17-2021-04-03) are incompatible with [sphinx-rtd-theme](https://pypi.org/project/sphinx-rtd-theme/). Support for docutils==0.17 has been added in Sphinx==4.x in [this PR](https://github.com/sphinx-doc/sphinx/pull/9125).