### PR TITLE
Add flag to item-list to show contents of items

### DIFF
--- a/doc/integration_test_report.rst
+++ b/doc/integration_test_report.rst
@@ -217,11 +217,12 @@ List all items
     :nocaptions:
 
 
-List all items beginning with ``r00``
--------------------------------------
+List all items beginning with ``r00`` (show contents)
+-----------------------------------------------------
 
 .. item-list::
     :filter: ^r00
+    :showcontents:
 
 List system requirements (beginning with SYS)
 ---------------------------------------------

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -180,6 +180,7 @@ A flat list of documentation items can be generated using a Python regular expre
         :filter: SWRQT
         :status: Appr
         :nocaptions:
+        :showcontents:
 
 where *SWRQT* (*filter* argument) can be replaced by any Python regular expression. Documentation items matching
 their ID to the given regular expression end up in the list.
@@ -187,8 +188,11 @@ their ID to the given regular expression end up in the list.
 where *status* can be replaced by any configured attribute, and *Appr* can be replaced by any Python regular
 expression. Documentation items where the *status* attribute matches the given regular expression end up in the list.
 
-By default, the caption for every item in the list is shown. By providing the *nocaptions* flag, the
+By default, the caption of every item in the list is shown. By providing the *nocaptions* flag, the
 caption can be omitted. This gives a smaller list, but also less details.
+
+By default, the contents of every item in the list is hidden. By providing the *showcontents* flag, the
+contents can be shown. This can significantly lengthen the list.
 
 .. _traceability_usage_item_attributes_matrix:
 

--- a/mlx/assets/traceability.js
+++ b/mlx/assets/traceability.js
@@ -54,6 +54,12 @@ $(document).ready(function () {
         );
     });
 
+    // style item contents in item-list by rendering newlines and adding indent
+    $('.item-contents').each(function (i) {
+        $(this).css('white-space', 'pre-wrap');
+        $(this).css('padding-left', '1em');
+    });
+
     $('p.admonition-title').each(function (i) {
         $(this).children('a').first().denyPermalinkStyling($(this));
     });

--- a/mlx/directives/item_list_directive.py
+++ b/mlx/directives/item_list_directive.py
@@ -22,6 +22,12 @@ class ItemList(TraceableBaseNode):
             for i in item_ids:
                 bullet_list_item = nodes.list_item()
                 bullet_list_item.append(self.make_internal_item_ref(app, i))
+                if self['showcontents']:
+                    contents = collection.get_item(i).get_content()
+                    if contents:
+                        p_node = nodes.paragraph(text=contents)
+                        p_node['classes'].append('item-contents')
+                        bullet_list_item.append(p_node)
                 ul_node.append(bullet_list_item)
             top_node += ul_node
         self.replace_self(top_node)
@@ -37,6 +43,7 @@ class ItemListDirective(TraceableBaseDirective):
          :filter: regexp
          :<<attribute>>: regexp
          :nocaptions:
+         :showcontents:
 
     """
     # Optional argument: title (whitespace allowed)
@@ -46,6 +53,7 @@ class ItemListDirective(TraceableBaseDirective):
         'class': directives.class_option,
         'filter': directives.unchanged,
         'nocaptions': directives.flag,
+        'showcontents': directives.flag,
     }
     # Content disallowed
     has_content = False
@@ -70,6 +78,8 @@ class ItemListDirective(TraceableBaseDirective):
         )
 
         self.add_found_attributes(item_list_node)
+
+        self.check_option_presence(item_list_node, 'showcontents')
 
         self.check_caption_flags(item_list_node, app.config.traceability_list_no_captions)
 


### PR DESCRIPTION
Add new flag `:showcontents:` to `item-list` directive.

Example output:

![image](https://user-images.githubusercontent.com/28319872/122586019-6e3d1e80-d05c-11eb-944b-a29532641029.png)