### PR TITLE
Prioritize :onlycovered: option of item-matrix over :group:

### DIFF
--- a/doc/integration_test_report.rst
+++ b/doc/integration_test_report.rst
@@ -315,6 +315,7 @@ Traceability from SSS to SRS
     :sourcetitle: system requirement
     :type: fulfilled_by
     :stats:
+    :group: top
     :onlycovered:
 
 Another matrix that should spawn a warning as the relation in *type* does not exist

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -328,7 +328,7 @@ limitations in doing so:
 :onlycovered: *optional*, *flag*
 
     By default, all source items are included. By providing the *onlycovered* flag, only covered items are shown in the
-    output.
+    output. This option takes precedence over the ``:group:`` option.
 
 :nocaptions: *optional*, *flag*
 

--- a/mlx/directives/item_matrix_directive.py
+++ b/mlx/directives/item_matrix_directive.py
@@ -105,7 +105,7 @@ class ItemMatrix(TraceableBaseNode):
                     covered = self._fill_target_cells(app, rights, target_ids)
                     self._store_row(rows, left, rights, covered, self['onlycovered'])
 
-        tgroup += self._build_table_body(rows, self['group'])
+        tgroup += self._build_table_body(rows, self['group'], self['onlycovered'])
 
         count_total = len(rows.covered) + len(rows.uncovered) - duplicate_source_count
         count_covered = len(rows.covered) - duplicate_source_count
@@ -128,18 +128,21 @@ class ItemMatrix(TraceableBaseNode):
         self.replace_self(top_node)
 
     @staticmethod
-    def _build_table_body(rows, group):
-        """ Creates the table body and fills it with rows, grouping when desired
+    def _build_table_body(rows, group, onlycovered):
+        """ Creates the table body and fills it with rows, grouping and excluding uncovered source items when desired
 
         Args:
             rows (Rows): Rows namedtuple object
             group (str): Group option, falsy to disable grouping, 'top' or 'bottom' otherwise
+            onlycovered (bool): True to only include source items that are covered; False to include all
 
         Returns:
             nodes.tbody: Filled table body
         """
         tbody = nodes.tbody()
-        if not group:
+        if onlycovered:
+            tbody += rows.covered
+        elif not group:
             tbody += rows.sorted
         elif group == 'top':
             tbody += rows.uncovered


### PR DESCRIPTION
Prioritize `:onlycovered:` option of `item-matrix` directive over `:group:` option.

I was surprised that this wasn't the case already, so I'm classifying this as a bug.

Closes #234 