### PR TITLE
Support changes to item body in callback function

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -346,6 +346,15 @@ traceability_external_relationship_to_url = {
 
 traceability_json_export_path = '_build/exported_items.json'
 
+def traceability_callback_per_item(name, collection):
+    if name == 'r001':
+        item = collection.get_item(name)
+        content_str = item.get_content()
+        content_str += '\n\nThis line was added by ``traceability_callback_per_item`` and is parsed as |RST| syntax.'
+        item.set_content(content_str)
+
+rst_epilog = ".. |RST|   replace:: :abbr:`RST (reStructuredText)`"
+
 # OrderedDict([('regex', (default, :hover+:active, :visited)), ...])
 # OrderedDict generates a dict with a deterministic order, used to prioritize the regexes, top to bottom
 traceability_hyperlink_colors = OrderedDict([

--- a/doc/integration_test_report.rst
+++ b/doc/integration_test_report.rst
@@ -40,7 +40,7 @@ Other requirements
     Title
     ~~~~~
 
-    - More contentt
+    - More content
     - More again
 
         - And nested content

--- a/mlx/traceable_base_class.py
+++ b/mlx/traceable_base_class.py
@@ -22,7 +22,7 @@ class TraceableBaseClass:
 
         Args:
             name (str): Base class object identification
-            state: The state of the state machine which controls the parsing
+            state: The state of the state machine, which controls the parsing
         '''
         self.id = self.to_id(name)
         self.name = name

--- a/mlx/traceable_item.py
+++ b/mlx/traceable_item.py
@@ -17,21 +17,19 @@ class TraceableItem(TraceableBaseClass):
 
     defined_attributes = {}
 
-    def __init__(self, item_id, placeholder=False, state=None):
+    def __init__(self, item_id, placeholder=False, **kwargs):
         ''' Initializes a new traceable item
 
         Args:
             item_id (str): Item identifier.
             placeholder (bool): Internal use only.
-            state: The state of the state machine which controls the parsing
         '''
-        super().__init__(item_id, state=state)
+        super().__init__(item_id, **kwargs)
         self.explicit_relations = {}
         self.implicit_relations = {}
         self.attributes = {}
         self.attribute_order = []
         self._placeholder = placeholder
-        self._state = state
 
     def update(self, other):
         ''' Updates item with other object. Stores the sum of both objects.

--- a/mlx/traceable_item.py
+++ b/mlx/traceable_item.py
@@ -17,19 +17,21 @@ class TraceableItem(TraceableBaseClass):
 
     defined_attributes = {}
 
-    def __init__(self, item_id, placeholder=False):
+    def __init__(self, item_id, placeholder=False, state=None):
         ''' Initializes a new traceable item
 
         Args:
             item_id (str): Item identifier.
             placeholder (bool): Internal use only.
+            state: The state of the state machine which controls the parsing
         '''
-        super(TraceableItem, self).__init__(item_id)
+        super().__init__(item_id, state=state)
         self.explicit_relations = {}
         self.implicit_relations = {}
         self.attributes = {}
         self.attribute_order = []
         self._placeholder = placeholder
+        self._state = state
 
     def update(self, other):
         ''' Updates item with other object. Stores the sum of both objects.


### PR DESCRIPTION
Support changes to item body in [callback function](https://melexis.github.io/sphinx-traceability-extension/configuration.html#callback-per-item-advanced). 

Simply use `TraceableItem.get_content()` and `TraceableItem.set_content()` to get and set the content as `str`.