### PR TITLE
Add flag to item-matrix to hide the title

### DIFF
--- a/doc/integration_test_report.rst
+++ b/doc/integration_test_report.rst
@@ -271,6 +271,7 @@ No relationships
     :targettitle: nothing
     :sourcetitle: more of nothing
     :stats:
+    :hidetitle:
 
 All relationships
 -----------------

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -268,6 +268,7 @@ A traceability matrix of documentation items can be generated using:
         :group: bottom
         :nocaptions:
         :stats:
+        :hidetitle:
 
 Documentation items matching their ID to the given *source* regular expression end up in the leftmost column of the
 generated table. Documentation items matching their ID to the given *target* regular expression(s) with a matching
@@ -371,6 +372,10 @@ limitations in doing so:
     and the number of items having no target in the target-column(s) (=not covered or allocated). And calculates a
     coverage/allocation percentage from these counts.
     When omitted this percentage is not displayed.
+
+:hidetitle: *optional*, *flag*
+
+    By providing the *stats* flag, the title will be hidden.
 
 :class: *optional*, *single argument*
 

--- a/mlx/directives/item_matrix_directive.py
+++ b/mlx/directives/item_matrix_directive.py
@@ -33,7 +33,7 @@ class ItemMatrix(TraceableBaseNode):
         targets_with_ids = []
         for target_regex in self['target']:
             targets_with_ids.append(collection.get_items(target_regex))
-        top_node = self.create_top_node(self['title'])
+        top_node = self.create_top_node(self['title'], hide_title=self['hidetitle'])
         table = nodes.table()
         if self.get('classes'):
             table.get('classes').extend(self.get('classes'))
@@ -560,6 +560,7 @@ class ItemMatrixDirective(TraceableBaseDirective):
          :stats:
          :nocaptions:
          :onlycaptions:
+         :hidetitle:
     """
     # Optional argument: title (whitespace allowed)
     optional_arguments = 1
@@ -586,6 +587,7 @@ class ItemMatrixDirective(TraceableBaseDirective):
         'stats': directives.flag,
         'nocaptions': directives.flag,
         'onlycaptions': directives.flag,
+        'hidetitle': directives.flag,
     }
     # Content disallowed
     has_content = False
@@ -656,6 +658,7 @@ class ItemMatrixDirective(TraceableBaseDirective):
         self.check_option_presence(node, 'onlycovered')
         self.check_option_presence(node, 'coveredintermediates')
         self.check_option_presence(node, 'stats')
+        self.check_option_presence(node, 'hidetitle')
 
         if node['targetattributes']:
             node['splittargets'] = True

--- a/mlx/traceable_base_node.py
+++ b/mlx/traceable_base_node.py
@@ -23,6 +23,7 @@ class TraceableBaseNode(nodes.General, nodes.Element, ABC):
         Args:
             title (str): Title or item ID of the top node
             app (sphinx.application.Sphinx): Optional application object, needed when item ID is given to create link
+            hide_title (bool): True to add the title in an admonition node; False to return an empty container node
 
         Returns:
             nodes.container: Top level replacement node to which other nodes can be appended

--- a/mlx/traceable_base_node.py
+++ b/mlx/traceable_base_node.py
@@ -15,26 +15,29 @@ EXTERNAL_LINK_FIELDNAME = 'field'
 class TraceableBaseNode(nodes.General, nodes.Element, ABC):
     """ Base class for all Traceability node classes. """
 
-    def create_top_node(self, title, app=None):
-        ''' Creates the top node for the Element node. An admonition object with given title is created and returns.
+    def create_top_node(self, title, app=None, hide_title=False):
+        ''' Creates the top node for the Element node.
+
+        When the title should be shown, an admonition object with given title is added.
 
         Args:
             title (str): Title or item ID of the top node
             app (sphinx.application.Sphinx): Optional application object, needed when item ID is given to create link
 
         Returns:
-            Top level replacement node to which other nodes can be appended
+            nodes.container: Top level replacement node to which other nodes can be appended
         '''
         top_node = nodes.container()
-        admon_node = nodes.admonition()
-        admon_node['classes'].append('item')
-        title_node = nodes.title()
-        if app:
-            title_node += self.make_internal_item_ref(app, title).children[0]
-        else:
-            title_node += nodes.Text(title)
-        admon_node += title_node
-        top_node += admon_node
+        if not hide_title:
+            admon_node = nodes.admonition()
+            admon_node['classes'].append('item')
+            title_node = nodes.title()
+            if app:
+                title_node += self.make_internal_item_ref(app, title).children[0]
+            else:
+                title_node += nodes.Text(title)
+            admon_node += title_node
+            top_node += admon_node
         return top_node
 
     @abstractmethod


### PR DESCRIPTION
Add flag `:hidetitle:` to the `item-matrix` directive to hide the title.