### PR TITLE
Let requires.io mark test version of Sphinx as green

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -63,7 +63,7 @@ commands =
 [testenv:sphinx2.1]
 deps=
     {[testenv]deps}
-    sphinx <= 2.1.9999
+    sphinx <= 2.1.9999  # rq.filter: <=2.1.9999
     sphinxcontrib-plantuml
     mlx.warnings >= 1.2.0
 whitelist_externals =


### PR DESCRIPTION
`sphinx <= 2.1.9999` should not be marked as 'outdated' by requires.io as we want to explicitly test compatibility with the old Sphinx version.