### PR TITLE
Avoid crash when linking via intermediate is done incorrectly

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -422,7 +422,7 @@ linked via the ``:intermediate:`` RQT-items:
     the righthand side are used to link the *intermediate* items to the *target* items.
     External relationships are not compatible with this feature (yet).
 
-:intermediate: *optional*, *single argument*
+:intermediate: *required*, *single argument*
 
     Python-style regular expression used to select intermediate items, meaning items that have to be linked to both
     the source and target items.

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -422,7 +422,7 @@ linked via the ``:intermediate:`` RQT-items:
     the righthand side are used to link the *intermediate* items to the *target* items.
     External relationships are not compatible with this feature (yet).
 
-:intermediate: *required*, *single argument*
+:intermediate: *optional* (*required* when type includes ``|``), *single argument*
 
     Python-style regular expression used to select intermediate items, meaning items that have to be linked to both
     the source and target items.

--- a/mlx/directives/item_matrix_directive.py
+++ b/mlx/directives/item_matrix_directive.py
@@ -653,7 +653,7 @@ class ItemMatrixDirective(TraceableBaseDirective):
             raise TraceabilityException("The :intermediate: option is used, expected at least two relationships "
                                         "separated by ' | ' in the :type: option; got {!r}".format(node['type']),
                                         docname=env.docname)
-        elif ' | ' in node['type'] and not node['intermediate']:
+        if ' | ' in node['type'] and not node['intermediate']:
             raise TraceabilityException("The value of the :type: option contains the '|' character,  but the option "
                                         ":intermediate: is missing for item-matrix {!r}".format(node['title']),
                                         docname=env.docname)

--- a/mlx/directives/item_matrix_directive.py
+++ b/mlx/directives/item_matrix_directive.py
@@ -653,6 +653,10 @@ class ItemMatrixDirective(TraceableBaseDirective):
             raise TraceabilityException("The :intermediate: option is used, expected at least two relationships "
                                         "separated by ' | ' in the :type: option; got {!r}".format(node['type']),
                                         docname=env.docname)
+        elif ' | ' in node['type'] and not node['intermediate']:
+            raise TraceabilityException("The value of the :type: option contains the '|' character,  but the option "
+                                        ":intermediate: is missing for item-matrix {!r}".format(node['title']),
+                                        docname=env.docname)
 
         # Process ``group`` option, given as a string that is either top or bottom or empty ().
         node['group'] = self.options.get('group', '')


### PR DESCRIPTION
When the value of the `:type:` option contains a `|` character and the `:intermediate:` option is missing, the Sphinx build crashes with the following error message: 

```
sphinx.errors.ExtensionError: Handler <function process_item_nodes at 0x7f73b7487158> for event 'doctree-resolved' threw an exception (exception: list index out of range)
Extension error:
Handler <function process_item_nodes at 0x7f73b7487158> for event 'doctree-resolved' threw an exception (exception: list index out of range)
```

Let's raise a descriptive error instead.