### PR TITLE
Warn about circular relationships via child of child

### DIFF
--- a/mlx/directives/item_tree_directive.py
+++ b/mlx/directives/item_tree_directive.py
@@ -60,7 +60,7 @@ class ItemTree(TraceableBaseNode):
                         childcontent.append(self._generate_bullet_list_tree(app, collection, target))
                     except RecursionError as err:
                         msg = ("Could not process item-tree {!r} because of a circular relationship: {} -{}-> {}"
-                            .format(self['title'], item_id, relation, target))
+                               .format(self['title'], item_id, relation, target))
                         raise TraceabilityException(msg) from err
         bullet_list_item.append(childcontent)
         return bullet_list_item

--- a/mlx/directives/item_tree_directive.py
+++ b/mlx/directives/item_tree_directive.py
@@ -59,7 +59,7 @@ class ItemTree(TraceableBaseNode):
                     try:
                         childcontent.append(self._generate_bullet_list_tree(app, collection, target))
                     except RecursionError as err:
-                        msg = ("Could not process item-tree {!r} because of a circular relationship: {} -{}-> {}"
+                        msg = ("Could not process item-tree {!r} because of a circular relationship: {} {} {}"
                                .format(self['title'], item_id, relation, target))
                         raise TraceabilityException(msg) from err
         bullet_list_item.append(childcontent)

--- a/mlx/directives/item_tree_directive.py
+++ b/mlx/directives/item_tree_directive.py
@@ -2,7 +2,7 @@ from docutils import nodes
 from docutils.parsers.rst import directives
 from sphinx.builders.latex import LaTeXBuilder
 
-from mlx.traceability import report_warning
+from mlx.traceability import report_warning, TraceabilityException
 from mlx.traceable_base_directive import TraceableBaseDirective
 from mlx.traceable_base_node import TraceableBaseNode
 
@@ -56,7 +56,12 @@ class ItemTree(TraceableBaseNode):
             for target in tgts:
                 # print('%s has child %s for relation %s' % (item_id, target, relation))
                 if collection.get_item(target).attributes_match(self['filter-attributes']):
-                    childcontent.append(self._generate_bullet_list_tree(app, collection, target))
+                    try:
+                        childcontent.append(self._generate_bullet_list_tree(app, collection, target))
+                    except RecursionError as err:
+                        msg = ("Could not process item-tree {!r} because of a circular relationship: {} -{}-> {}"
+                            .format(self['title'], item_id, relation, target))
+                        raise TraceabilityException(msg) from err
         bullet_list_item.append(childcontent)
         return bullet_list_item
 

--- a/mlx/traceability.py
+++ b/mlx/traceability.py
@@ -611,9 +611,9 @@ def setup(app):
     app.add_directive('attribute-link', AttributeLinkDirective)
     app.add_directive('attribute-sort', AttributeSortDirective)
 
-    app.connect('doctree-resolved', process_item_nodes)
-    app.connect('env-check-consistency', perform_consistency_check)
     app.connect('builder-inited', initialize_environment)
+    app.connect('env-check-consistency', perform_consistency_check)
+    app.connect('doctree-resolved', process_item_nodes)
 
     app.add_role('item', XRefRole(nodeclass=PendingItemXref,
                                   innernodeclass=nodes.emphasis,

--- a/mlx/traceable_collection.py
+++ b/mlx/traceable_collection.py
@@ -234,6 +234,13 @@ class TraceableCollection:
                                                                               relation=rev_relation,
                                                                               target=itemid),
                                                             item.get_document()))
+                    # Circular relation exists?
+                    for target_of_target in target.iter_targets(relation, sort=False):
+                        if target_of_target in item.iter_targets(rev_relation, sort=False):
+                            errors.append(TraceabilityException(
+                                "Circular relationship found: {} {} {} {} {} {} {}"
+                                .format(itemid, relation, tgt, relation, target_of_target, relation, itemid),
+                                item.get_document()))
         if errors:
             raise MultipleTraceabilityExceptions(errors)
 


### PR DESCRIPTION
- Report warning when circular relationship is found via child of child
- Catch the `RecursionError` that got raised when processing an item-tree with a circular relationship. Let's raise a clear error message instead of `exception: maximum recursion depth exceeded while calling a Python object`.