### PR TITLE
Bugfix for multiple item-piecharts

### DIFF
--- a/doc/requirements.rst
+++ b/doc/requirements.rst
@@ -144,3 +144,7 @@ Test coverage
     :id_set: RQT [IU]TEST [IU]TEST_REP
     :label_set: uncovered, covered, ran test
     :result: ERROR, fail, pass
+
+.. item-piechart:: All uncovered as there is no direct relationship
+    :id_set: [IU]TEST_REP RQT
+    :label_set: uncovered, covered

--- a/mlx/directives/item_pie_chart_directive.py
+++ b/mlx/directives/item_pie_chart_directive.py
@@ -52,14 +52,13 @@ class ItemPieChart(TraceableBaseNode):
         self._set_priorities()
         self._set_attribute_id()
 
-        for source_id in self.collection.get_items(''):
+        for source_id in self.collection.get_items(self['id_set'][0]):
             source_item = self.collection.get_item(source_id)
             # placeholders don't end up in any item-piechart (less duplicate warnings for missing items)
             if source_item.is_placeholder():
                 continue
-            if re.match(self['id_set'][0], source_id):
-                self.linked_attributes[source_id] = self['label_set'][0].lower()  # default is "uncovered"
-                self.loop_relationships(source_id, source_item, self['id_set'][1], self._match_covered)
+            self.linked_attributes[source_id] = self['label_set'][0].lower()  # default is "uncovered"
+            self.loop_relationships(source_id, source_item, self['id_set'][1], self._match_covered)
 
         chart_labels, statistics = self._prepare_labels_and_values(list(self.priorities),
                                                                    list(self.linked_attributes.values()))

--- a/mlx/directives/item_pie_chart_directive.py
+++ b/mlx/directives/item_pie_chart_directive.py
@@ -29,11 +29,14 @@ def pct_wrapper(sizes):
 
 class ItemPieChart(TraceableBaseNode):
     '''Pie chart on documentation items'''
-    collection = None
-    relationships = []
-    priorities = {}  # default priority order is 'uncovered', 'covered', 'executed', 'pass', 'fail', 'error'
-    attribute_id = ''
-    linked_attributes = {}  # source_id (str): attr_value (str)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.collection = None
+        self.relationships = []
+        self.priorities = {}  # default priority order is 'uncovered', 'covered', 'executed', 'pass', 'fail', 'error'
+        self.attribute_id = ''
+        self.linked_attributes = {}  # source_id (str): attr_value (str)
 
     def perform_replacement(self, app, collection):
         """


### PR DESCRIPTION
Squash bug that caused the `item-piechart` directive to start off with the statistics of previously defined `item-piechart`s.