### PR TITLE
Fix LaTeX crash when hiding item-matrix table

### DIFF
--- a/doc/integration_test_report.rst
+++ b/doc/integration_test_report.rst
@@ -300,6 +300,13 @@ All relationships with items having ASIL-C/D attribute
     :group: bottom
     :stats:
 
+.. item-matrix:: Only statistics (hidden table)
+    :asil: [CD]
+    :hidesource:
+    :hidetarget:
+    :group: bottom
+    :stats:
+
 Traceability from SRS to SSS
 ----------------------------
 

--- a/mlx/directives/item_matrix_directive.py
+++ b/mlx/directives/item_matrix_directive.py
@@ -533,7 +533,7 @@ class ItemMatrix(TraceableBaseNode):
 
     @staticmethod
     def _create_cell_for_attribute(item, attribute):
-        """ Creates a cell with the item's attribute value the given attribute.
+        """ Creates a cell with the item's attribute value for the given attribute.
 
         Args:
             item (TraceableItem): TraceableItem instance

--- a/mlx/directives/item_matrix_directive.py
+++ b/mlx/directives/item_matrix_directive.py
@@ -138,7 +138,8 @@ class ItemMatrix(TraceableBaseNode):
             p_node += txt
             top_node += p_node
 
-        top_node += table
+        if number_of_columns:
+            top_node += table
         self.replace_self(top_node)
 
     def _build_table_body(self, rows, group, onlycovered, onlyuncovered):

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 project_url = 'https://github.com/melexis/sphinx-traceability-extension'
 
-requires = ['Sphinx>=2.1', 'docutils', 'matplotlib', 'natsort', 'python-decouple', 'requests']
+requires = ['Sphinx>=2.1', 'docutils', 'matplotlib<=3.4.3', 'natsort', 'python-decouple', 'requests']
 
 setup(
     name='mlx.traceability',


### PR DESCRIPTION
- Prevent installation of matplotlib==3.5.0
- Fix LaTeX crash when the table of the item-matrix is supposed to be hidden like so:

```
.. item-matrix::
    :hidesource:
    :hidetarget:
```