### PR TITLE
Fix sorting behavior of targets via intermediates in item-matrix

### DIFF
--- a/doc/integration_test_report.rst
+++ b/doc/integration_test_report.rst
@@ -61,15 +61,6 @@ Other requirements
 
 This text is not part of any item
 
-.. item:: r003 The great
-    :class: secondary
-    :trace: r002
-    :ext_toolname: namespace:group:document
-    :asil: A
-    :status: Approved
-
-    Clean up all this.
-
 .. item:: r005 Another (does not show captions on the related items)
     :aspice: 2
     :asil: C
@@ -95,6 +86,15 @@ This text is not part of any item
         r005
 
     To demonstrate that bug #2 is solved
+
+.. item:: r003 Item defined after r006 and before r007
+    :class: secondary
+    :trace: r002
+    :ext_toolname: namespace:group:document
+    :asil: A
+    :status: Approved
+
+    Clean up all this.
 
 .. item:: r007 Depends on all with stereotypes
     :asil: X

--- a/mlx/directives/item_matrix_directive.py
+++ b/mlx/directives/item_matrix_directive.py
@@ -453,6 +453,7 @@ class ItemMatrix(TraceableBaseNode):
                     items = target_items
                 elif row_idx < len(target_items):
                     items = [target_items[row_idx]]
+                items = natsorted(items, key=lambda item: getattr(item, 'id', ''))
                 row += self._create_cell_for_items(items, app)
             # target columns: attributes and extra relations
             target_attribute_cells = []


### PR DESCRIPTION
Targets that are linked via intermediates in an `item-matrix` will now be sorted naturally (excluding external targets) so that the same sorting behavior is used whether the `:intermediate:` option is used or not.

Closes #246 