### PR TITLE
Make :class: option work for item-directive

### DIFF
--- a/mlx/directives/item_directive.py
+++ b/mlx/directives/item_directive.py
@@ -149,6 +149,8 @@ class ItemDirective(TraceableBaseDirective):
         item_node['classes'].append('collapsible_links')  # traceability.js adds the arrowhead button
         if app.config.traceability_collapse_links:
             item_node['classes'].append('collapse')
+        if 'class' in self.options:
+            item_node['classes'].extend(self.options.get('class'))
         item = self._store_item_info(target_id, env)
 
         # Custom callback for modifying items

--- a/tox.ini
+++ b/tox.ini
@@ -63,7 +63,7 @@ commands =
 [testenv:sphinx2.1]
 deps=
     {[testenv]deps}
-    jinja2 < 3.*
+    jinja2 == 3.0.3
     sphinx <= 2.1.9999  # rq.filter: <=2.1.9999
     sphinxcontrib-plantuml
     mlx.warnings >= 1.3.0

--- a/tox.ini
+++ b/tox.ini
@@ -63,7 +63,7 @@ commands =
 [testenv:sphinx2.1]
 deps=
     {[testenv]deps}
-    jinja2<3.*
+    jinja2 < 3.*
     sphinx <= 2.1.9999  # rq.filter: <=2.1.9999
     sphinxcontrib-plantuml
     mlx.warnings >= 1.3.0

--- a/tox.ini
+++ b/tox.ini
@@ -63,7 +63,8 @@ commands =
 [testenv:sphinx2.1]
 deps=
     {[testenv]deps}
-    jinja2 == 3.0.3
+    jinja2 == 2.11.3
+    markupsafe == 1.1.0
     sphinx <= 2.1.9999  # rq.filter: <=2.1.9999
     sphinxcontrib-plantuml
     mlx.warnings >= 1.3.0

--- a/tox.ini
+++ b/tox.ini
@@ -63,6 +63,7 @@ commands =
 [testenv:sphinx2.1]
 deps=
     {[testenv]deps}
+    jinja2<3.*
     sphinx <= 2.1.9999  # rq.filter: <=2.1.9999
     sphinxcontrib-plantuml
     mlx.warnings >= 1.3.0


### PR DESCRIPTION
The `:class:` option may be useful to modify the lay-out of a traceable item in HTML format.