### PR TITLE
Indicate support for Sphinx parallel-write

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -12,6 +12,7 @@ exclude .pylintrc
 include LICENSE.txt
 include NOTICE
 include tox.ini
+include tools/doc-warnings.json
 include doc/.env.example
 recursive-include doc *.bat
 recursive-include doc *.py

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    = -j auto
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build

--- a/mlx/traceability.py
+++ b/mlx/traceability.py
@@ -626,4 +626,8 @@ def setup(app):
                                   innernodeclass=nodes.emphasis,
                                   warn_dangling=True))
 
-    return {'version': version}
+    return {
+        'version': version,
+        'parallel_read_safe': True,
+        'parallel_write_safe': True,
+    }

--- a/mlx/traceability.py
+++ b/mlx/traceability.py
@@ -628,6 +628,6 @@ def setup(app):
 
     return {
         'version': version,
-        'parallel_read_safe': True,
+        'parallel_read_safe': False,
         'parallel_write_safe': True,
     }

--- a/tools/doc-warnings.json
+++ b/tools/doc-warnings.json
@@ -1,0 +1,26 @@
+{
+    "sphinx": {
+        "enabled": true,
+        "min": 24,
+        "max": 24,
+        "exclude": [
+            "WARNING: the mlx.traceability extension is not safe for parallel reading",
+            "WARNING: doing serial read"
+        ]
+    },
+    "doxygen": {
+        "enabled": false
+    },
+    "junit": {
+        "enabled": false
+    },
+    "xmlrunner": {
+        "enabled": false
+    },
+    "coverity": {
+        "enabled": false
+    },
+    "robot": {
+        "enabled": false
+    }
+}

--- a/tox.ini
+++ b/tox.ini
@@ -73,8 +73,8 @@ whitelist_externals =
     tee
     mlx-warnings
 commands=
-    mlx-warnings --sphinx --exact-warnings 24 --command make -C doc html
-    mlx-warnings --sphinx --exact-warnings 24 --command make -C doc latexpdf
+    mlx-warnings --config doc-warnings.json --command make -C doc html
+    mlx-warnings --config doc-warnings.json --command make -C doc latexpdf
 
 [testenv:sphinx-latest]
 deps=
@@ -87,8 +87,8 @@ whitelist_externals =
     tee
     mlx-warnings
 commands=
-    mlx-warnings --sphinx --exact-warnings 24 --command make -C doc html
-    mlx-warnings --sphinx --exact-warnings 24 --command make -C doc latexpdf
+    mlx-warnings --config doc-warnings.json --command make -C doc html
+    mlx-warnings --config doc-warnings.json --command make -C doc latexpdf
 
 [testenv:coveralls]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -73,8 +73,8 @@ whitelist_externals =
     tee
     mlx-warnings
 commands=
-    mlx-warnings --config doc-warnings.json --command make -C doc html
-    mlx-warnings --config doc-warnings.json --command make -C doc latexpdf
+    mlx-warnings --config tools/doc-warnings.json --command make -C doc html
+    mlx-warnings --config tools/doc-warnings.json --command make -C doc latexpdf
 
 [testenv:sphinx-latest]
 deps=
@@ -87,8 +87,8 @@ whitelist_externals =
     tee
     mlx-warnings
 commands=
-    mlx-warnings --config doc-warnings.json --command make -C doc html
-    mlx-warnings --config doc-warnings.json --command make -C doc latexpdf
+    mlx-warnings --config tools/doc-warnings.json --command make -C doc html
+    mlx-warnings --config tools/doc-warnings.json --command make -C doc latexpdf
 
 [testenv:coveralls]
 deps =


### PR DESCRIPTION
Added support for sphinx parallel build to avoid the following warnings:
```
WARNING: the mlx.traceability extension does not declare if it is safe for parallel reading, assuming it isn't - please ask the extension author to check and make it explicit
WARNING: doing serial read
```

I'm not sure if there would be any problem with allowing parallel builds in the traceability plugin.