### PR TITLE
Matplotlib will deprecate normalize=None and default to normalize=True

### DIFF
--- a/mlx/directives/item_pie_chart_directive.py
+++ b/mlx/directives/item_pie_chart_directive.py
@@ -224,7 +224,7 @@ class ItemPieChart(TraceableBaseNode):
 
         fig, axes = plt.subplots()
         colors = self['colors'] if self['colors'] else None
-        axes.pie(sizes, explode=explode, labels=labels, autopct=pct_wrapper(sizes), startangle=90, colors=colors)
+        axes.pie(sizes, explode=explode, labels=labels, autopct=pct_wrapper(sizes), startangle=90, normalize=False, colors=colors)
         axes.axis('equal')
         folder_name = path.join(env.app.srcdir, '_images')
         if not path.exists(folder_name):


### PR DESCRIPTION
Since we do not specify this argument to the pie function, I would like
to just keep the current default.

Error reported:

```
/usr/local/lib/python3.9/dist-packages/mlx/directives/item_pie_chart_directive.py:227: MatplotlibDeprecationWarning: normalize=None does not normalize if the sum is less than 1 but this behavior is deprecated since 3.3 until two minor releases later. After the deprecation period the default value will be normalize=True. To prevent normalization pass normalize=False 
  axes.pie(sizes, explode=explode, labels=labels, autopct=pct_wrapper(sizes), startangle=90, colors=colors)
```