### PR TITLE
Added condition for git in query_checklist

### DIFF
--- a/mlx/traceability.py
+++ b/mlx/traceability.py
@@ -407,7 +407,7 @@ def query_checklist(settings, attr_values):
         base_url = "{}/repos/{}/pulls/".format(settings['api_host_name'].rstrip('/'),
                                                settings['project_id'],)
         key = 'body'
-    elif 'gitlab' in settings['api_host_name']:
+    elif ('gitlab' in settings['api_host_name']) or ('git' in settings['api_host_name']):
         headers['PRIVATE-TOKEN'] = settings['private_token']
         base_url = "{}/projects/{}/merge_requests/".format(settings['api_host_name'].rstrip('/'),
                                                            settings['project_id'],)


### PR DESCRIPTION
Some URLs use the `git` instead of `gitlab`. An extra `else-if` condition was added to support cases where the URL starts with `git` 

Issue-ID: 272