### PR TITLE
No longer generate a blank image for an empty item-piechart

### DIFF
--- a/doc/requirements.rst
+++ b/doc/requirements.rst
@@ -165,3 +165,6 @@ Test coverage
     :id_set: RQT [IU]TEST [IU]TEST_REP
     :label_set: not covered, covered
     :colors: slategrey
+
+.. item-piechart:: Chart without any items to trigger warning
+    :id_set: NONEXISTENT [IU]TEST

--- a/doc/requirements.rst
+++ b/doc/requirements.rst
@@ -166,5 +166,5 @@ Test coverage
     :label_set: not covered, covered
     :colors: slategrey
 
-.. item-piechart:: Chart without any items to trigger warning
+.. item-piechart:: Chart without any items: no image or warning shall be generated
     :id_set: NONEXISTENT [IU]TEST

--- a/mlx/directives/item_pie_chart_directive.py
+++ b/mlx/directives/item_pie_chart_directive.py
@@ -225,7 +225,8 @@ class ItemPieChart(TraceableBaseNode):
 
         fig, axes = plt.subplots()
         colors = self['colors'] if self['colors'] else None
-        _, texts, autotexts = axes.pie(sizes, explode=explode, labels=labels, autopct=pct_wrapper(sizes), startangle=90, colors=colors)
+        _, texts, autotexts = axes.pie(sizes, explode=explode, labels=labels, autopct=pct_wrapper(sizes),
+                                       startangle=90, colors=colors)
         axes.axis('equal')
         folder_name = path.join(env.app.srcdir, '_images')
         if not path.exists(folder_name):

--- a/mlx/directives/item_pie_chart_directive.py
+++ b/mlx/directives/item_pie_chart_directive.py
@@ -74,9 +74,8 @@ class ItemPieChart(TraceableBaseNode):
         p_node += nodes.Text(statistics)
         if chart_labels:
             top_node += self.build_pie_chart(chart_labels, env)
-        elif not self['allowempty']:
-            report_warning("item-piechart does not contain any items: no image will be generated. "
-                           "If this was your goal, add the :allowempty: flag to hide this warning.",
+        else:
+            report_warning("item-piechart does not contain any items: no image will be generated",
                            self['document'], self['line'])
         top_node += p_node
         self.replace_self(top_node)
@@ -281,7 +280,7 @@ class ItemPieChartDirective(TraceableBaseDirective):
          :<<attribute>>: error, fail, pass ...
          :<<attribute>>: regexp
          :colors: <<color>> ...
-         :allowempty:
+
     """
     # Optional argument: title (whitespace allowed)
     optional_arguments = 1
@@ -291,7 +290,6 @@ class ItemPieChartDirective(TraceableBaseDirective):
         'id_set': directives.unchanged,
         'label_set': directives.unchanged,
         'colors': directives.unchanged,
-        'allowempty': directives.flag,
     }
     # Content disallowed
     has_content = False
@@ -300,19 +298,23 @@ class ItemPieChartDirective(TraceableBaseDirective):
         """ Processes the contents of the directive. """
         env = self.state.document.settings.env
 
-        node = ItemPieChart('')
-        node['document'] = env.docname
-        node['line'] = self.lineno
+        item_chart_node = ItemPieChart('')
+        item_chart_node['document'] = env.docname
+        item_chart_node['line'] = self.lineno
 
-        self.process_title(node)
-        self._process_id_set(node)
-        self._process_label_set(node)
-        self._process_attribute(node)
-        self.add_found_attributes(node)
-        self.process_options(node, {'colors': {'default': []}})
-        self.check_option_presence(node, 'allowempty')
+        self.process_title(item_chart_node)
 
-        return [node]
+        self._process_id_set(item_chart_node)
+
+        self._process_label_set(item_chart_node)
+
+        self._process_attribute(item_chart_node)
+
+        self.add_found_attributes(item_chart_node)
+
+        self.process_options(item_chart_node, {'colors': {'default': []}})
+
+        return [item_chart_node]
 
     def _process_id_set(self, node):
         """ Processes id_set option. At least two arguments are required. Otherwise, a warning is reported. """

--- a/mlx/directives/item_pie_chart_directive.py
+++ b/mlx/directives/item_pie_chart_directive.py
@@ -228,14 +228,12 @@ class ItemPieChart(TraceableBaseNode):
 
         fig, axes = plt.subplots()
         colors = self['colors'] if self['colors'] else None
-        axes.pie(sizes, explode=explode, labels=labels, autopct=pct_wrapper(sizes), startangle=90, colors=colors)
+        _, texts, autotexts = axes.pie(sizes, explode=explode, labels=labels, autopct=pct_wrapper(sizes), startangle=90, colors=colors)
         axes.axis('equal')
         folder_name = path.join(env.app.srcdir, '_images')
         if not path.exists(folder_name):
             mkdir(folder_name)
-        hash_string = str(self['colors'])
-        for pie_slice in axes.__dict__['texts']:
-            hash_string += str(pie_slice)
+        hash_string = str(self['colors']) + str(texts) + str(autotexts)
         hash_value = sha256(hash_string.encode()).hexdigest()  # create hash value based on chart parameters
         rel_file_path = path.join('_images', 'piechart-{}.png'.format(hash_value))
         if rel_file_path not in env.images:

--- a/mlx/directives/item_pie_chart_directive.py
+++ b/mlx/directives/item_pie_chart_directive.py
@@ -74,9 +74,6 @@ class ItemPieChart(TraceableBaseNode):
         p_node += nodes.Text(statistics)
         if chart_labels:
             top_node += self.build_pie_chart(chart_labels, env)
-        else:
-            report_warning("item-piechart does not contain any items: no image will be generated",
-                           self['document'], self['line'])
         top_node += p_node
         self.replace_self(top_node)
 

--- a/mlx/directives/item_pie_chart_directive.py
+++ b/mlx/directives/item_pie_chart_directive.py
@@ -72,7 +72,11 @@ class ItemPieChart(TraceableBaseNode):
                            self['document'], self['line'])
         p_node = nodes.paragraph()
         p_node += nodes.Text(statistics)
-        top_node += self.build_pie_chart(chart_labels, env)
+        if chart_labels:
+            top_node += self.build_pie_chart(chart_labels, env)
+        else:
+            report_warning("item-piechart does not contain any items: no image will be generated",
+                           self['document'], self['line'])
         top_node += p_node
         self.replace_self(top_node)
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,14 @@ from setuptools import setup, find_packages
 
 project_url = 'https://github.com/melexis/sphinx-traceability-extension'
 
-requires = ['Sphinx>=2.1,<6.*', 'docutils', 'matplotlib<4.*', 'natsort', 'python-decouple', 'requests']
+requires = [
+    'Sphinx>=2.1,<6.*',
+    'docutils',
+    'matplotlib<4.*',
+    'natsort',
+    'python-decouple',
+    'requests',
+]
 
 setup(
     name='mlx.traceability',

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 project_url = 'https://github.com/melexis/sphinx-traceability-extension'
 
-requires = ['Sphinx>=2.1', 'docutils', 'matplotlib<=3.4.3', 'natsort', 'python-decouple', 'requests']
+requires = ['Sphinx>=2.1', 'docutils', 'matplotlib<4.*', 'natsort', 'python-decouple', 'requests']
 
 setup(
     name='mlx.traceability',

--- a/tools/doc-warnings.json
+++ b/tools/doc-warnings.json
@@ -1,8 +1,8 @@
 {
     "sphinx": {
         "enabled": true,
-        "min": 24,
-        "max": 24,
+        "min": 25,
+        "max": 25,
         "exclude": [
             "WARNING: the mlx.traceability extension is not safe for parallel reading",
             "WARNING: doing serial read"

--- a/tools/doc-warnings.json
+++ b/tools/doc-warnings.json
@@ -1,8 +1,8 @@
 {
     "sphinx": {
         "enabled": true,
-        "min": 25,
-        "max": 25,
+        "min": 24,
+        "max": 24,
         "exclude": [
             "WARNING: the mlx.traceability extension is not safe for parallel reading",
             "WARNING: doing serial read"


### PR DESCRIPTION
- Fix: avoid that matplotlib generates a blank image when the item-piechart doesn't contain any documentation items
- Fix: add support for matplotlib==3.5.0

Resolves #271, resolves #249

Closes #275