### PR TITLE
Support filtering and labeling by relationship type for item-piechart

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -322,6 +322,9 @@ traceability_relationships = {
     'fulfills': 'fulfilled_by',
     'implements': 'implemented_by',
     'validates': 'validated_by',
+    'passes': 'passed_by',
+    'fails': 'failed_by',
+    'skipped': 'skipped_by',
     'ext_toolname': ''
 }
 
@@ -338,6 +341,12 @@ traceability_relationship_to_string = {
     'implemented_by': 'Implemented by',
     'validates': 'Validates',
     'validated_by': 'Validated by',
+    'passes': 'Passes',
+    'passed_by': 'Passed by',
+    'fails': 'Fails',
+    'failed_by': 'Failed by',
+    'skipped': 'Skipped',
+    'skipped_by': 'Skipped by',
     'ext_toolname': 'Reference to toolname'
 }
 

--- a/doc/integration_test_report.rst
+++ b/doc/integration_test_report.rst
@@ -160,27 +160,27 @@ Integration test reports
 ========================
 
 .. item:: ITEST_REP-CAPTION Report with attribute missing from priority list
-    :depends_on: ITEST-CAPTION
-    :result: RUNNING
+    :skipped: ITEST-CAPTION
+    :result: skip
 
 .. item:: ITEST_REP-AUTO_REVERSE
-    :depends_on: ITEST-AUTO_REVERSE
+    :passes: ITEST-AUTO_REVERSE
     :result: pass
 
 .. item:: ITEST_REP-COVERAGE
-    :depends_on: ITEST-COVERAGE
+    :fails: ITEST-COVERAGE
     :result: error
 
 .. item:: ITEST_REP-MATRIX
-    :depends_on: ITEST-MATRIX
+    :passes: ITEST-MATRIX
     :result: pass
 
 .. item:: ITEST_REP-TREE
-    :depends_on: ITEST-TREE
+    :passes: ITEST-TREE
     :result: PASS
 
 .. item:: ITEST_REP-TREE_SCOPE
-    :depends_on: ITEST-TREE_SCOPE
+    :fails: ITEST-TREE_SCOPE
     :result: ERROR
 
 .. item:: ITEST_REP-ATTRIBUTES_MATRIX
@@ -188,6 +188,10 @@ Integration test reports
 
 .. item:: ITEST_REP-r100
     :depends_on: ITEST-r100
+
+.. item:: ITEST_REP-LIST
+    :skipped: ITEST-LIST
+    :result: skip
 
 Attribute details
 =================
@@ -499,7 +503,7 @@ Source and target columns
     :intermediate: ITEST-
     :target: ITEST_REP-
     :hidetarget:
-    :type: validated_by | impacts_on
+    :type: validated_by | passes fails skipped
     :sourcetitle: requirements
     :intermediatetitle: integration tests
     :targettitle: integration tests results

--- a/doc/requirements.rst
+++ b/doc/requirements.rst
@@ -149,7 +149,7 @@ Test coverage
     :id_set: RQT [IU]TEST [IU]TEST_REP
     :sourcetype: validated_by
     :targettype: passed_by skipped_by failed_by
-    :label_set: uncovered, covered, ran test
+    :label_set: uncovered, covered, has report
     :result: ERROR, fail, pass
     :colors: orange c b darkred #FF0000 g pink
 

--- a/doc/requirements.rst
+++ b/doc/requirements.rst
@@ -138,17 +138,40 @@ Test coverage
     :nocaptions:
     :stats:
 
+.. item-matrix:: Trace requirements to test case reports
+    :source: RQT
+    :intermediate: [IU]TEST
+    :target: [IU]TEST_REP
+    :targetcolumns: result
+    :type: validated_by | passed_by skipped_by failed_by
+    :splitintermediates:
+    :sourcetitle: Requirement
+    :intermediatetitle: Test case
+    :targettitle: Test case report
+    :nocaptions:
+    :stats:
+
 .. item-piechart:: Chart fetching third label from defaults
     :id_set: RQT [IU]TEST [IU]TEST_REP
     :label_set: not covered, covered
+    :colors: orange c b
+
+.. item-piechart:: Test coverage chart targeting UTEST and ITEST
+    :id_set: RQT [IU]TEST [IU]TEST_REP
+    :label_set: not covered, covered
     :colors: orange c b darkred green yellow
-    :sourcetype: validated_by
+    :targettype: failed_by passed_by skipped_by
+
+.. item-piechart:: Test coverage chart targeting ITEST only
+    :id_set: RQT ITEST ITEST_REP
+    :label_set: not covered, covered
+    :colors: orange c b darkred green yellow
     :targettype: failed_by passed_by skipped_by
 
 .. item-piechart:: Test coverage chart with test results, based on the :result: attribute
     :id_set: RQT [IU]TEST [IU]TEST_REP
     :sourcetype: validated_by
-    :targettype: passed_by skipped_by failed_by
+    :targettype: failed_by passed_by skipped_by
     :label_set: uncovered, covered, has report
     :result: ERROR, fail, pass
     :colors: orange c b darkred #FF0000 g pink
@@ -164,8 +187,16 @@ Test coverage
 .. item-piechart:: Test coverage chart with test results, based on the :targettype: option
     :id_set: RQT [IU]TEST [IU]TEST_REP
     :label_set: uncovered, covered, ran test
+    :sourcetype: validated_by
     :targettype: failed_by passed_by skipped_by
     :colors: orange c b r g y
+
+.. item-piechart:: Test coverage chart with test results, based on the :targettype: option (in bad order)
+    :id_set: RQT [IU]TEST [IU]TEST_REP
+    :label_set: uncovered, covered, ran test
+    :sourcetype: validated_by
+    :targettype: skipped_by passed_by failed_by
+    :colors: orange c b y g r
 
 .. item-piechart:: All uncovered as the bad sourcetype results in 0 links
     :id_set: RQT [IU]TEST

--- a/doc/requirements.rst
+++ b/doc/requirements.rst
@@ -125,6 +125,7 @@ Design coverage
     :id_set: RQT DESIGN
     :label_set: uncovered, covered
     :functional: .*
+    :sourcetype: fulfilled_by
 
 Test coverage
 =============
@@ -140,10 +141,14 @@ Test coverage
 .. item-piechart:: Chart fetching third label from defaults
     :id_set: RQT [IU]TEST [IU]TEST_REP
     :label_set: not covered, covered
-    :colors: orange c b
+    :colors: orange c b darkred green yellow
+    :sourcetype: validated_by
+    :targettype: failed_by passed_by skipped_by
 
-.. item-piechart:: Test coverage chart with test results
+.. item-piechart:: Test coverage chart with test results, based on the :result: attribute
     :id_set: RQT [IU]TEST [IU]TEST_REP
+    :sourcetype: validated_by
+    :targettype: passed_by skipped_by failed_by
     :label_set: uncovered, covered, ran test
     :result: ERROR, fail, pass
     :colors: orange c b darkred #FF0000 g pink
@@ -155,6 +160,16 @@ Test coverage
     ERROR: darkred (dark red)
     fail: #FF0000 (red)
     pass: g (green)
+
+.. item-piechart:: Test coverage chart with test results, based on the :targettype: option
+    :id_set: RQT [IU]TEST [IU]TEST_REP
+    :label_set: uncovered, covered, ran test
+    :targettype: failed_by passed_by skipped_by
+    :colors: orange c b r g y
+
+.. item-piechart:: All uncovered as the bad sourcetype results in 0 links
+    :id_set: RQT [IU]TEST
+    :sourcetype: impacts_on
 
 .. item-piechart:: All uncovered as there is no direct relationship
     :id_set: [IU]TEST_REP RQT

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -584,6 +584,8 @@ A pie chart of documentation items can be generated using:
     .. item-piechart:: Test coverage of requirements with report results
         :id_set: RQT TEST TEST_REP
         :label_set: uncovered, covered, executed
+        :sourcetype: validated_by covered_by
+        :targettype: failed_by passed_by skipped_by
         :result: error, fail, pass
         :functional: .*
         :colors: orange c b darkred #FF0000 g
@@ -604,12 +606,29 @@ are comma-separated lists.
     ID, the second label is used. The third label (optional) is used for items with both relationships covered.
     The labels in the example are the default values.
 
+:sourcetype: *optional*, *multiple arguments (space-separated)*
+
+    The list of relationships that should be used to filter the target. The relationships considered for
+    filtering are from the "Source" items to the "Target" items. In this example, if an RQT-item
+    is not linked to a TEST-item with *validated_by* and/or *covered_by*, this source item will be labeled as
+    *uncovered*.
+
+:targettype: *optional*, *multiple arguments (space-separated)*
+
+    The list of relationships that should be used to filter the nested target. The relationships considered for
+    filtering are from the "Target" items to the "Target-of-target" items. These relationhips will also be used to label
+    additional slices if the *<<attribute>>* option that accepts multiple arguments is unused.
+    In this example, if a TEST-item is not linked to a TEST_REP-item with one or more of
+    *passed_by/skipped_by/failed_by*, the source item will be labeled as *covered* instead of
+    *passes*, *skipped* or *fails*, which are the human readable and reversed
+    forms of the arguments for this option. If an RQT-item with multiple TEST-items, one linked to
+
 :<<attribute>>: *optional*, *multiple arguments (comma-separated)*
 
     The optional *result* can be replaced by any configured attribute of the third item ID. Its arguments are possible
     values of this attribute, ordered in priority from high to low. Using this option splits up the slice with the third
-    label. In this example an RQT item with multiple TEST items, one with a *fail* and others a *pass* as *result* value
-    in the TEST_REP item, will be added to the *fail* slice of the pie chart.
+    label. In this example an RQT-item with multiple TEST-items, one with a *fail* and others a *pass* as *result* value
+    in the TEST_REP-item, will be added to the *fail* slice of the pie chart.
 
 :<<attribute>>: *optional*, *single argument*
 

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -615,13 +615,14 @@ are comma-separated lists.
 
 :targettype: *optional*, *multiple arguments (space-separated)*
 
-    The list of relationships that should be used to filter the nested target. The relationships considered for
-    filtering are from the "Target" items to the "Target-of-target" items. These relationhips will also be used to label
-    additional slices if the *<<attribute>>* option that accepts multiple arguments is unused.
-    In this example, if a TEST-item is not linked to a TEST_REP-item with one or more of
-    *passed_by/skipped_by/failed_by*, the source item will be labeled as *covered* instead of
+    The list of relationships that should be used to filter the nested target, ordered in priority from high to low.
+    The relationships considered for
+    filtering are from the "Target" items to the "Target-of-target" items. These relationships will also be used to
+    label additional slices if the *<<attribute>>* option that accepts multiple arguments is unused.
+    In this example, excluding the `:result:` option, if a TEST-item is not linked to a TEST_REP-item with one or more
+    of *passed_by/skipped_by/failed_by*, the source item will be labeled as *covered* instead of
     *passes*, *skipped* or *fails*, which are the human readable and reversed
-    forms of the arguments for this option. If an RQT-item with multiple TEST-items, one linked to
+    forms of the arguments for this option.
 
 :<<attribute>>: *optional*, *multiple arguments (comma-separated)*
 

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -624,6 +624,11 @@ are comma-separated lists.
     in the *:<<attribute>>:* option (*:result:* in the example). Matplotlib supports many formats, explained in their
     demo_.
 
+.. note::
+
+    In this example, if an RQT-item is linked to one or more TEST-items and at least one TEST-item is not linked
+    to a TEST_REP-item, the RQT-item will be labeled as *covered* instead of *executed*.
+
 .. _demo: https://matplotlib.org/stable/gallery/color/color_demo.html#color-demo
 
 .. _traceability_checklist:

--- a/mlx/directives/item_pie_chart_directive.py
+++ b/mlx/directives/item_pie_chart_directive.py
@@ -156,7 +156,7 @@ class ItemPieChart(TraceableBaseNode):
                 self.linked_labels[top_source_id] = label
 
     def _match_target_types(self, top_source_id, nested_target_item, relationship):
-        """ L
+        """ Links the reverse of the highest priority relationship of nested relations to the top source id.
 
         Args:
             top_source_id (str): Identifier of the top source item, e.g. requirement identifier.

--- a/mlx/directives/item_pie_chart_directive.py
+++ b/mlx/directives/item_pie_chart_directive.py
@@ -90,7 +90,7 @@ class ItemPieChart(TraceableBaseNode):
         if self['priorities']:
             extra_labels.extend(self['priorities'])
         elif self['targettype']:
-            for relationship in reversed(self['targettype']):
+            for relationship in self['targettype']:
                 reverse_relationship = self.collection.get_reverse_relation(relationship)
                 extra_labels.append(self.relationship_to_string[reverse_relationship].lower())
 

--- a/mlx/directives/item_pie_chart_directive.py
+++ b/mlx/directives/item_pie_chart_directive.py
@@ -136,7 +136,7 @@ class ItemPieChart(TraceableBaseNode):
             nested_source_item (TraceableItem): Nested traceable item to be used as a source for looping through its
                 relationships, e.g. a test item.
         """
-        self.linked_labels[top_source_id] = self['label_set'][1].lower()  # default is "covered"
+        self._store_linked_label(top_source_id, self['label_set'][1].lower())  # default is "covered"
         if self.attribute_id:
             if self['priorities']:
                 self.loop_relationships(top_source_id, nested_source_item, self.target_relationships, self.attribute_id,

--- a/mlx/directives/item_pie_chart_directive.py
+++ b/mlx/directives/item_pie_chart_directive.py
@@ -120,7 +120,7 @@ class ItemPieChart(TraceableBaseNode):
         for relationship in relationships:
             for target_id in source_item.iter_targets(relationship, explicit=True, implicit=True):
                 target_item = self.collection.get_item(target_id)
-                # placeholders don't end up in any item-matrix (less duplicate warnings for missing items)
+                # placeholders don't end up in any item-piechart (less duplicate warnings for missing items)
                 if not target_item or target_item.is_placeholder():
                     continue
                 if re.match(pattern, target_id):

--- a/mlx/directives/item_pie_chart_directive.py
+++ b/mlx/directives/item_pie_chart_directive.py
@@ -36,6 +36,7 @@ class ItemPieChart(TraceableBaseNode):
         self.collection = None
         self.source_relationships = []
         self.target_relationships = []
+        self.relationship_to_string = {}
         self.priorities = OrderedDict()  # default priority order is 'uncovered', 'covered', 'executed', 'pass', 'fail', 'error'
         self.nested_target_regex = ''
         self.linked_labels = {}  # source_id (str): attr_value/relationship_str (str)

--- a/mlx/directives/item_pie_chart_directive.py
+++ b/mlx/directives/item_pie_chart_directive.py
@@ -146,10 +146,14 @@ class ItemPieChart(TraceableBaseNode):
                                         self._match_target_types)
 
     def _store_linked_label(self, top_source_id, label):
-        if top_source_id not in self.linked_labels:
-            self.linked_labels[top_source_id] = label
-        else:
-            # store newly encountered label if it has a higher priority
+        """ Stores the label with the given item ID as key in ``linked_labels`` if it has a higher priority.
+
+        Args:
+            top_source_id (str): Identifier of the top source item, e.g. requirement identifier.
+            label (str): Label to store if it has a higher priority than the one that has been stored.
+        """
+        if label != self.linked_labels[top_source_id]:
+            # store different label if it has a higher priority
             stored_priority = self.priorities[self.linked_labels[top_source_id]]
             latest_priority = self.priorities[label]
             if latest_priority > stored_priority:

--- a/mlx/directives/item_pie_chart_directive.py
+++ b/mlx/directives/item_pie_chart_directive.py
@@ -97,7 +97,7 @@ class ItemPieChart(TraceableBaseNode):
 
     def loop_relationships(self, top_source_id, source_item, relationships, pattern, match_function):
         """
-        Loops through the source relationships and for each relationship it loops through the matches that have been
+        Loops through the relationships and for each relationship it loops through the matches that have been
         found for the source item. If the matched item is not a placeholder and matches to the specified pattern, the
         specified function is called with the matched item as a parameter.
 
@@ -120,7 +120,7 @@ class ItemPieChart(TraceableBaseNode):
     def _match_covered(self, top_source_id, nested_source_item):
         """
         Sets the appropriate label when the top-level relationship is accounted for. If the <<attribute>> option is
-        used, it loops through the source relationships again, this time with the matched item as the source.
+        used, it loops through the target relationships, this time with the matched item as the source.
 
         Args:
             top_source_id (str): Identifier of the top source item, e.g. requirement identifier.

--- a/mlx/directives/item_pie_chart_directive.py
+++ b/mlx/directives/item_pie_chart_directive.py
@@ -358,9 +358,12 @@ class ItemPieChartDirective(TraceableBaseDirective):
         if 'id_set' in self.options and len(self.options['id_set'].split()) >= 2:
             self._warn_if_comma_separated('id_set', node['document'])
             node['id_set'] = self.options['id_set'].split()
+            if len(node['id_set']) < 3 and self.options.get('targettype'):
+                report_warning('item-piechart: the targettype option is only viable with an id_set with 3 '
+                               'arguments.', node['document'], node['line'])
         else:
             node['id_set'] = []
-            report_warning('Traceability: Expected at least two arguments in id_set.',
+            report_warning('item-piechart: Expected at least two arguments in id_set.',
                            node['document'],
                            node['line'])
 
@@ -391,7 +394,7 @@ class ItemPieChartDirective(TraceableBaseDirective):
                 node['priorities'] = [x.strip(' ') for x in self.options[attr].split(',')]
                 del self.options[attr]
             else:
-                report_warning('Traceability: The <<attribute>> option is only viable with an id_set with 3 '
+                report_warning('item-piechart: The <<attribute>> option is only viable with an id_set with 3 '
                                'arguments.',
                                node['document'],
                                node['line'],)

--- a/mlx/directives/item_pie_chart_directive.py
+++ b/mlx/directives/item_pie_chart_directive.py
@@ -37,7 +37,7 @@ class ItemPieChart(TraceableBaseNode):
         self.source_relationships = []
         self.target_relationships = []
         self.relationship_to_string = {}
-        self.priorities = OrderedDict()  # default priority order is 'uncovered', 'covered', 'executed', 'pass', 'fail', 'error'
+        self.priorities = OrderedDict()  # default priority order is 'uncovered', 'covered', 'executed'
         self.nested_target_regex = ''
         self.linked_labels = {}  # source_id (str): attr_value/relationship_str (str)
 
@@ -191,7 +191,6 @@ class ItemPieChart(TraceableBaseNode):
         reverse_relationship = self.collection.get_reverse_relation(relationship)
         reverse_relationship_str = self.relationship_to_string[reverse_relationship].lower()
         self._store_linked_label(top_source_id, reverse_relationship_str)
-
 
     def _match_attribute_values(self, top_source_id, nested_target_item, *_):
         """ Links the highest priority attribute value of nested relations to the top source id.

--- a/mlx/traceability.py
+++ b/mlx/traceability.py
@@ -494,7 +494,7 @@ def setup(app):
             'asil': '^(QM|[ABCD])$',
             'aspice': '^[123]$',
             'status': '^.*$',
-            'result': '(?i)^(pass|fail|error)$',
+            'result': '(?i)^(pass|fail|error|skip)$',
             'attendees': '^([A-Z]{3}[, ]*)+$',
             'assignee': '^.*$',
             'effort': r'^([\d\.]+(mo|[wdhm]) ?)+$',

--- a/tools/doc-warnings.json
+++ b/tools/doc-warnings.json
@@ -1,8 +1,8 @@
 {
     "sphinx": {
         "enabled": true,
-        "min": 24,
-        "max": 24,
+        "min": 23,
+        "max": 23,
         "exclude": [
             "WARNING: the mlx.traceability extension is not safe for parallel reading",
             "WARNING: doing serial read"


### PR DESCRIPTION
- Added `:sourcetype:` option to the `item-piechart` directive
- Added `:targettype:` option to the `item-piechart` directive
- Fixed a bug that resulted in using the `<<attribute>>` value of the nested target item that was parsed last as label instead of respecting the order of the arguments of the `:<<attribute>>:` option, or, in case of multiple target items, discarding the effect of those defined first.

Resolves #270