### PR TITLE
Add filtertarget flag to item-matrix directive

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -355,8 +355,12 @@ limitations in doing so:
 :<<attribute>>: *optional*, *single argument*
 
     Python-style regular expression used to filter the source items (left column) based on their attributes.
-    The attribute value is **not** used to filter target items.
+    The attribute value is **not** used to filter target items, unless the optional ``:filtertarget:`` flag is set.
     When omitted, no filtering is done on the source item attributes.
+
+:filtertarget: *optional*, *flag*
+
+    When enabled, ``:<<attribute>>:`` filtering is done on target instead of source items.
 
 :sourcecolumns: *optional*, *multiple arguments (space-separated)*
 

--- a/mlx/directives/item_matrix_directive.py
+++ b/mlx/directives/item_matrix_directive.py
@@ -35,10 +35,15 @@ class ItemMatrix(TraceableBaseNode):
             collection (TraceableCollection): Collection for which to generate the nodes.
         """
         Rows = namedtuple('Rows', "sorted covered uncovered counters")
-        source_ids = collection.get_items(self['source'], attributes=self['filter-attributes'])
+        filters = {x: None for x in ['source', 'target']}
+        if self['filtertarget']:
+            filters['target'] = self['filter-attributes']
+        else:
+            filters['source'] = self['filter-attributes']
+        source_ids = collection.get_items(self['source'], attributes=filters['source'])
         targets_with_ids = []
         for target_regex in self['target']:
-            targets_with_ids.append(collection.get_items(target_regex))
+            targets_with_ids.append(collection.get_items(target_regex, attributes=filters['target']))
         top_node = self.create_top_node(self['title'], hide_title=self['hidetitle'])
         table = nodes.table()
         if self.get('classes'):
@@ -629,6 +634,7 @@ class ItemMatrixDirective(TraceableBaseDirective):
          :nocaptions:
          :onlycaptions:
          :hidetitle:
+         :filtertarget:
     """
     # Optional argument: title (whitespace allowed)
     optional_arguments = 1
@@ -660,6 +666,7 @@ class ItemMatrixDirective(TraceableBaseDirective):
         'nocaptions': directives.flag,
         'onlycaptions': directives.flag,
         'hidetitle': directives.flag,
+        'filtertarget': directives.flag,
     }
     # Content disallowed
     has_content = False
@@ -745,6 +752,7 @@ class ItemMatrixDirective(TraceableBaseDirective):
         self.check_option_presence(node, 'coveredintermediates')
         self.check_option_presence(node, 'stats')
         self.check_option_presence(node, 'hidetitle')
+        self.check_option_presence(node, 'filtertarget')
 
         if node['onlycovered'] and node['onlyuncovered']:
             raise TraceabilityException(


### PR DESCRIPTION
A `filtertarget` flag is available for the `item-2d-matrix` directive, allowing the `<<attribute>>` filter to operate on target instead of source items.

This PR aims to provide the same functionality to the `item-matrix` directive, using the same approach as d3f25dcd21c9fb965cefcbf1d32c3ce22dbfc180.

A trivial use case would be being able to verify the coverage of requirements that are validated by a passing testcase:
```
.. item-matrix:: Testcase traceability matrix
    :source: RQT
    :target: TC
    :sourcetitle: Requirement
    :targettitle: Testcase
    :type: validated_by
    :filtertarget:
    :status: PASS
```
