### PR TITLE
Display uncovered intermediates by default in item matrix

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -479,19 +479,20 @@ linked via the ``:intermediate:`` RQT-items:
 :intermediatetitle: *optional*, *single argument*
 
     When given, an extra column that lists the intermediate item(s) per source item will be added between the columns
-    that list sources and the linked targets. The argument will be used as title for this new column.
+    that list sources and the linked targets. The argument will be used as title for this new column. Intermediates will
+    only be listed if both themselves and their source are covered, unless the *splitintermediates* flag is set.
 
 :coveredintermediates: *optional*, *flag*
 
     When enabled, all sources that have one or more intermediates that are uncovered will be treated as uncovered even
-    when the source has another intermediate that *is* covered, i.e. **all**
-    intermediates must be covered for the linked source to be covered.
+    when the source has another intermediate that *is* covered, i.e. **all** intermediates must be covered for the
+    linked source to be covered.
 
 :splitintermediates: *optional*, *flag*
 
-    When enabled, a row will be created for every intermediate item instead of grouping them together in the same
-    row for the source item. This can be useful if you want to group target items per intermediate item *instead of
-    per source item*.
+    When enabled, a row will be created for every intermediate item instead of grouping them together in the same row
+    as the source item. In addition, all intermediates will be listed, regardless of their coverage status. This can be
+    useful if you want to group target items per intermediate item *instead of per source item*.
 
 .. _traceability_usage_2d_matrix:
 

--- a/mlx/directives/item_matrix_directive.py
+++ b/mlx/directives/item_matrix_directive.py
@@ -115,7 +115,7 @@ class ItemMatrix(TraceableBaseNode):
                 if self['splitintermediates']:
                     for intermediate, target_sets in intermediates.items():
                         self._store_row_with_intermediate({intermediate: target_sets},
-                                                           rows, source_item, rights, covered, app)
+                                                          rows, source_item, rights, covered, app)
                     duplicate_count_for_source = len(intermediates) - 1
                     duplicate_count_total += duplicate_count_for_source
                     duplicate_count_covered += duplicate_count_for_source if covered else 0
@@ -123,7 +123,7 @@ class ItemMatrix(TraceableBaseNode):
                     self._store_row_with_intermediate({intermediate: target_sets for intermediate, target_sets
                                                        in intermediates.items()
                                                        if covered and covered_intermediates[intermediate]},
-                                                       rows, source_item, rights, covered, app)
+                                                      rows, source_item, rights, covered, app)
             else:
                 has_external_target = self.add_external_targets(rights, source_item, external_relationships, app)
                 has_internal_target = self.add_internal_targets(rights, source_id, targets_with_ids, relationships,

--- a/mlx/directives/item_matrix_directive.py
+++ b/mlx/directives/item_matrix_directive.py
@@ -388,7 +388,7 @@ class ItemMatrix(TraceableBaseNode):
                 source_to_links_map[source_id] = {}
             source_to_links_map[source_id][intermediate_item] = targets
 
-    def _store_row_with_intermediate(self, linked_items, rows, source, empty_right_cells, covered, app):
+    def _store_row_with_intermediate(self, linked_items, rows, source, empty_right_cells, *args):
         """ Stores a row for a source, linking targets via one or all intermediates
 
         Args:
@@ -396,11 +396,10 @@ class ItemMatrix(TraceableBaseNode):
             rows (Rows): Rows namedtuple object to extend
             source (TraceableItem): Source item
             empty_right_cells (list): List of empty lists to fill with intermediates items, followed by target items
-            app (sphinx.application.Sphinx): Sphinx application object
         """
         right_cells = deepcopy(empty_right_cells)
         self.add_all_targets(right_cells, linked_items)
-        self._store_data(rows, source, right_cells, covered, app)
+        self._store_data(rows, source, right_cells, *args)
 
     def _store_data(self, rows, source, right_cells, covered, app):
         """ Stores the data in one or more rows in the given Rows object.


### PR DESCRIPTION
This PR builds on #284, but I figured the additional changes might elicit enough discussion to warrant a separate PR.

At its core, this PR changes the internal plumbing of the `item-matrix` directive to allow rendering uncovered intermediates. At the same time (and this is probably where the discussion comes in), it changes the default behavior to display uncovered intermediates, as I figure it's the more useful alternative (more on that later). An `onlycoveredintermediates` flag, analogous to the existing `onlycovered` and `onlyuncovered` flags, is added to bring back the old behavior (to a point).

The goal of this PR is to support a workflow that I believe should be relatively common: verifying the coverage of requirements that are validated by a testcase who have themselves a test record object attesting to their pass/fail status. Structuring the information in that manner allows to decouple the requirements and testcases (which, as source objects, are version-controlled) from the test records (which, as products of some automated non-regression test suite, are not).

Picture, if you will, the following directive:
```
.. item-matrix:: Testcase traceability matrix
    :source: RQT
    :intermediate: TC
    :target: TR
    :sourcetitle: Requirement
    :intermediatetitle: Testcase
    :targettitle: Test record
    :type: validated_by | tested_by
    :targetcolumns: status
    :splitintermediates:
    :stats:
    :nocaptions:
```

Which would render as:
```
Statistics: 1 out of 1 covered: 100%
+-------------+----------+-------------+--------+
| Requirement | Testcase | Test record | Status |
+-------------+----------+-------------+--------+
| RQT-1       | TC-1     | TR-1        | PASS   |
|             +----------+-------------+--------+
|             | TC-2     | TR-2        | FAIL   |
|             +----------+-------------+--------+
|             | TC-3     | TR-3        | PASS   |
+-------------+----------+-------------+--------+
```

Now, because we'd like to filter the records based on their status without having to parse the table by hand, we can use #284 and modify the directive as follows:
```
.. item-matrix:: Testcase traceability matrix
    :source: RQT
    :intermediate: TC
    :target: TR
    :sourcetitle: Requirement
    :intermediatetitle: Testcase
    :targettitle: Test record
    :type: validated_by | tested_by
    :filtertarget:
    :status: PASS
    :splitintermediates:
    :stats:
    :nocaptions:
```

Producing, before this PR:
```
Statistics: 1 out of 1 covered: 100%
+-------------+----------+-------------+
| Requirement | Testcase | Test record |
+-------------+----------+-------------+
| RQT-1       | TC-1     | TR-1        |
|             +----------+-------------+
|             | TC-3     | TR-3        |
+-------------+----------+-------------+
```

And because we'd also like a failing test record to invalidate the corresponding requirement, we add the `coveredintermediates` flag, resulting in:
```
Statistics: 0 out of 1 covered: 0%
+-------------+----------+-------------+
| Requirement | Testcase | Test record |
+-------------+----------+-------------+
| RQT-1       |          |             |
+-------------+----------+-------------+
```

Giving us correct statistics, but an entirely useless table. In order to know why `RQT-1` is not covered, we would need to split the item matrix into two, mostly negating the point of having an `intermediate` attribute in the first place.

As we can see, `coveredintermediates` (which should probably be renamed to `allintermediatescovered`, `intermediatereductionand`, or something to that effect) actually has two effects, although only the first is documented: requiring all intermediates to be covered in order to cover the source (i.e. reduction AND instead of reduction OR), and hiding all intermediates of an uncovered source. I consider this last effect to be undesirable, which is why I took the liberty of modifying it.

Thus, this PR modifies Table 2 (without the `coveredintermediates` flag) as follows:
```
Statistics: 1 out of 1 covered: 100%
+-------------+----------+-------------+
| Requirement | Testcase | Test record |
+-------------+----------+-------------+
| RQT-1       | TC-1     | TR-1        |
|             +----------+-------------+
|             | TC-2     |             |
|             +----------+-------------+
|             | TC-3     | TR-3        |
+-------------+----------+-------------+
```

And Table 3 (with the `coveredintermediates` flag) as follows:
```
Statistics: 0 out of 1 covered: 0%
+-------------+----------+-------------+
| Requirement | Testcase | Test record |
+-------------+----------+-------------+
| RQT-1       | TC-1     | TR-1        |
|             +----------+-------------+
|             | TC-2     |             |
|             +----------+-------------+
|             | TC-3     | TR-3        |
+-------------+----------+-------------+
```

By adding the `onlycoveredintermediates` flag, Table 2 (without the `coveredintermediates` flag) becomes:
```
Statistics: 1 out of 1 covered: 100%
+-------------+----------+-------------+
| Requirement | Testcase | Test record |
+-------------+----------+-------------+
| RQT-1       | TC-1     | TR-1        |
|             +----------+-------------+
|             | TC-3     | TR-3        |
+-------------+----------+-------------+
```

And Table 3 (with the `coveredintermediates` flag) becomes:
```
Statistics: 0 out of 1 covered: 0%
+-------------+----------+-------------+
| Requirement | Testcase | Test record |
+-------------+----------+-------------+
| RQT-1       | TC-1     | TR-1        |
|             +----------+-------------+
|             | TC-3     | TR-3        |
+-------------+----------+-------------+
```

Which results in a clean split between the coverage (controlled by `coveredintermediates`) and the rendering (controlled by `onlycoveredintermediates`).
