### PR TITLE
Remove the use of OrderedDictt

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -15,7 +15,6 @@ import errno
 import os
 import subprocess
 import sys
-from collections import OrderedDict
 
 import mlx.traceability
 from mlx.traceability import report_warning
@@ -397,15 +396,15 @@ def traceability_inspect_item(name, collection):
 
 rst_epilog = ".. |RST|   replace:: :abbr:`RST (reStructuredText)`"
 
-# OrderedDict([('regex', (default, :hover+:active, :visited)), ...])
-# OrderedDict generates a dict with a deterministic order, used to prioritize the regexes, top to bottom
-traceability_hyperlink_colors = OrderedDict([
-    (r'RQT|r[\d]+', ('#7F00FF', '#b369ff')),
-    (r'[IU]TEST_REP', ('rgba(255, 0, 0, 1)', 'rgba(255, 0, 0, 0.7)', 'rgb(200, 0, 0)')),
-    (r'[IU]TEST', ('goldenrod', 'hsl(43, 62%, 58%)', 'darkgoldenrod')),
-    (r'SYS_', ('', 'springgreen', '')),
-    (r'SRS_', ('', 'orange', '')),
-])
+# {'regex': (default, :hover+:active, :visited)), ...}
+# A dictionary with deterministic order, used to prioritize the regexes, top to bottom
+traceability_hyperlink_colors = {
+    r'RQT|r[\d]+': ('#7F00FF', '#b369ff'),
+    r'[IU]TEST_REP': ('rgba(255, 0, 0, 1)', 'rgba(255, 0, 0, 0.7)', 'rgb(200, 0, 0)'),
+    r'[IU]TEST': ('goldenrod', 'hsl(43, 62%, 58%)', 'darkgoldenrod'),
+    r'SYS_': ('', 'springgreen', ''),
+    r'SRS_': ('', 'orange', ''),
+}
 
 # traceability_item_no_captions = True
 # traceability_list_no_captions = True

--- a/mlx/directives/item_matrix_directive.py
+++ b/mlx/directives/item_matrix_directive.py
@@ -1,5 +1,5 @@
 import re
-from collections import OrderedDict, namedtuple
+from collections import namedtuple
 from copy import copy, deepcopy
 
 from docutils import nodes
@@ -133,7 +133,7 @@ class ItemMatrix(TraceableBaseNode):
             for ext_rel in external_relationships:
                 external_targets = collection.get_external_targets(self['source'], ext_rel)
                 # natural sorting on source
-                for ext_source, target_ids in OrderedDict(natsorted(external_targets.items())).items():
+                for ext_source, target_ids in natsorted(external_targets.items()):
                     covered = False
                     source_link = self.make_external_item_ref(app, ext_source, ext_rel)
                     rights = [[] for _ in range(len(self['target']))]

--- a/mlx/directives/item_pie_chart_directive.py
+++ b/mlx/directives/item_pie_chart_directive.py
@@ -1,6 +1,5 @@
 import re
 from hashlib import sha256
-from collections import OrderedDict
 from os import environ, mkdir, path
 
 from docutils import nodes
@@ -37,7 +36,7 @@ class ItemPieChart(TraceableBaseNode):
         self.source_relationships = []
         self.target_relationships = []
         self.relationship_to_string = {}
-        self.priorities = OrderedDict()  # default priority order is 'uncovered', 'covered', 'executed'
+        self.priorities = {}  # default priority order is 'uncovered', 'covered', 'executed'
         self.nested_target_regex = ''
         self.linked_labels = {}  # source_id (str): attr_value/relationship_str (str)
 

--- a/mlx/traceability.py
+++ b/mlx/traceability.py
@@ -7,7 +7,7 @@ Sphinx extension for reStructuredText that added traceable documentation items.
 See readme for more details.
 """
 import warnings
-from collections import OrderedDict, namedtuple
+from collections import namedtuple
 from re import fullmatch, match
 from os import path
 
@@ -47,7 +47,7 @@ def generate_color_css(app, hyperlink_colors):
 
     Args:
         app: Sphinx application object to use.
-        hyperlink_colors (OrderedDict): Ordered dict with regex strings as keys and list/tuple of strings as values.
+        hyperlink_colors: Dictionary with regex strings as keys and list/tuple of strings as values.
     """
     class_names = app.config.traceability_class_names
     with open(path.join(path.dirname(__file__), 'assets', 'hyperlink_colors.css'), 'w') as css_file:
@@ -590,7 +590,7 @@ def setup(app):
     app.add_config_value('traceability_tree_no_captions', False, 'env')
 
     # Configuration for customizing the color of hyperlinked items
-    app.add_config_value('traceability_hyperlink_colors', OrderedDict([]), 'env')
+    app.add_config_value('traceability_hyperlink_colors', {}, 'env')
     # Dictionary used by plugin to pass class names via application object
     app.add_config_value('traceability_class_names', {}, 'env')
 

--- a/mlx/traceable_base_node.py
+++ b/mlx/traceable_base_node.py
@@ -173,7 +173,7 @@ class TraceableBaseNode(nodes.General, nodes.Element, ABC):
         The regexp of the first item in the ordered dictionary has the highest priority.
 
         Args:
-            hyperlink_colors (OrderedDict): Ordered dict with regex strings as keys and list/tuple of strings as values.
+            hyperlink_colors (dict): Dictionary with regex strings as keys and list/tuple of strings as values.
             item_id (str): A traceability item ID.
 
         Returns:

--- a/mlx/traceable_collection.py
+++ b/mlx/traceable_collection.py
@@ -340,11 +340,8 @@ class TraceableCollection:
         '''
         external_targets_to_item_ids = {}
         for item_id, item in self.items.items():
-            for target in item.yield_targets_sorted(relation):
+            for target in item.yield_targets(relation):
                 if not re.match(regex, target):
                     continue
-                if target not in external_targets_to_item_ids:
-                    external_targets_to_item_ids[target] = [item_id]
-                else:
-                    external_targets_to_item_ids[target].append(item_id)
+                external_targets_to_item_ids.setdefault(target, []).append(item_id)
         return external_targets_to_item_ids


### PR DESCRIPTION
Remove the use of `collections.OrderedDict` and rely on the order-preserving functionality of dictionaries in Python>=3.7. Depends on #294.

Sphinx reports a warning when you keep using `OrderedDict` in your *conf.py*.

`WARNING: The config value 'traceability_hyperlink_colors' has type 'OrderedDict', defaults to 'dict'.`
