### PR TITLE
Use lower case to link to a TraceableAttribute

### DIFF
--- a/mlx/directives/item_attribute_directive.py
+++ b/mlx/directives/item_attribute_directive.py
@@ -52,12 +52,12 @@ class ItemAttributeDirective(TraceableBaseDirective):
 
         # Convert to lower-case as sphinx only allows lowercase arguments (attribute to item directive)
         attribute_id = self.arguments[0]
-        target_node = nodes.target('', '', ids=[attribute_id])
         attribute_node = ItemAttribute('')
         attribute_node['document'] = env.docname
         attribute_node['line'] = self.lineno
 
         stored_id = TraceableAttribute.to_id(attribute_id)
+        target_node = nodes.target('', '', ids=[stored_id])
         if stored_id not in TraceableItem.defined_attributes:
             report_warning('Found attribute description which is not defined in configuration ({})'
                            .format(attribute_id),

--- a/mlx/traceable_base_node.py
+++ b/mlx/traceable_base_node.py
@@ -162,7 +162,7 @@ class TraceableBaseNode(nodes.General, nodes.Element, ABC):
                 newnode['refdocname'] = attr_info.docname
                 try:
                     newnode['refuri'] = app.builder.get_relative_uri(self['document'], attr_info.docname)
-                    newnode['refuri'] += '#' + attr_name
+                    newnode['refuri'] += '#' + attr_info.identifier
                 except NoUri:
                     # ignore if no URI can be determined, e.g. for LaTeX output :(
                     pass


### PR DESCRIPTION
When you specify the attribute identifier (the key in `traceability_attribute_to_string`) instead of the attribute name (the value in `traceability_attribute_to_string`) as the first argument for the `item-attribute` directive, links to this attribute definition don't work. This PR addresses this issue. Links to the attribute are produced by the `item` and `item-attributes-matrix` directives, for example.