### PR TITLE
Fix broken links in HTML output

### DIFF
--- a/mlx/traceable_base_node.py
+++ b/mlx/traceable_base_node.py
@@ -86,11 +86,7 @@ class TraceableBaseNode(nodes.General, nodes.Element, ABC):
         if notification_item:
             item_info = notification_item
         try:
-            if self['document'] == item_info.docname and hasattr(app.builder, 'link_suffix'):
-                relative_path = item_info.docname + app.builder.link_suffix
-            else:
-                relative_path = app.builder.get_relative_uri(self['document'], item_info.docname)
-            newnode['refuri'] = relative_path
+            newnode['refuri'] = app.builder.get_relative_uri(self['document'], item_info.docname)
             newnode['refuri'] += '#' + item_info.identifier
             newnode['refdocname'] = item_info.docname
         except NoUri:

--- a/mlx/traceable_base_node.py
+++ b/mlx/traceable_base_node.py
@@ -78,6 +78,7 @@ class TraceableBaseNode(nodes.General, nodes.Element, ABC):
             item_info = notification_item
         try:
             if self['document'] == item_info.docname and hasattr(app.builder, 'link_suffix'):
+                # include filename so that the returned node can be reused on every page in the same directory
                 relative_path = item_info.docname.split(SEP)[-1] + app.builder.link_suffix
             else:
                 relative_path = app.builder.get_relative_uri(self['document'], item_info.docname)

--- a/mlx/traceable_base_node.py
+++ b/mlx/traceable_base_node.py
@@ -86,7 +86,11 @@ class TraceableBaseNode(nodes.General, nodes.Element, ABC):
         if notification_item:
             item_info = notification_item
         try:
-            newnode['refuri'] = app.builder.get_relative_uri(self['document'], item_info.docname)
+            if self['document'] == item_info.docname and hasattr(app.builder, 'link_suffix'):
+                relative_path = item_info.docname + app.builder.link_suffix
+            else:
+                relative_path = app.builder.get_relative_uri(self['document'], item_info.docname)
+            newnode['refuri'] = relative_path
             newnode['refuri'] += '#' + item_info.identifier
             newnode['refdocname'] = item_info.docname
         except NoUri:

--- a/mlx/traceable_base_node.py
+++ b/mlx/traceable_base_node.py
@@ -83,15 +83,12 @@ class TraceableBaseNode(nodes.General, nodes.Element, ABC):
 
         newnode = nodes.reference('', '')
         innernode = nodes.emphasis(display_text, display_text)
+        if notification_item:
+            item_info = notification_item
         try:
-            if not notification_item:
-                newnode['refuri'] = app.builder.get_relative_uri(self['document'], item_info.docname)
-                newnode['refuri'] += '#' + item_id
-                newnode['refdocname'] = item_info.docname
-            else:
-                newnode['refuri'] = app.builder.get_relative_uri(self['document'], notification_item.docname)
-                newnode['refuri'] += '#' + notification_item_id
-                newnode['refdocname'] = notification_item.docname
+            newnode['refuri'] = app.builder.get_relative_uri(self['document'], item_info.docname)
+            newnode['refuri'] += '#' + item_info.identifier
+            newnode['refdocname'] = item_info.docname
         except NoUri:
             # ignore if no URI can be determined, e.g. for LaTeX output :(
             pass

--- a/mlx/traceable_base_node.py
+++ b/mlx/traceable_base_node.py
@@ -63,6 +63,7 @@ class TraceableBaseNode(nodes.General, nodes.Element, ABC):
             display_option = option
             break
         item_info = env.traceability_collection.get_item(item_id)
+        link_item = item_info
         notification_item = None
         p_node = nodes.paragraph()
 
@@ -75,13 +76,13 @@ class TraceableBaseNode(nodes.General, nodes.Element, ABC):
                 txt = nodes.Text('%s not defined, broken link' % item_id)
                 p_node.append(txt)
                 return p_node
-            item_info = notification_item
+            link_item = notification_item
         try:
-            if self['document'] == item_info.docname and hasattr(app.builder, 'link_suffix'):
+            if self['document'] == link_item.docname and hasattr(app.builder, 'link_suffix'):
                 # include filename so that the returned node can be reused on every page in the same directory
-                relative_path = item_info.docname.split(SEP)[-1] + app.builder.link_suffix
+                relative_path = link_item.docname.split(SEP)[-1] + app.builder.link_suffix
             else:
-                relative_path = app.builder.get_relative_uri(self['document'], item_info.docname)
+                relative_path = app.builder.get_relative_uri(self['document'], link_item.docname)
         except NoUri:
             # ignore if no URI can be determined, e.g. for LaTeX output
             relative_path = ''
@@ -93,11 +94,11 @@ class TraceableBaseNode(nodes.General, nodes.Element, ABC):
         if relative_path in ref_nodes[item_id][display_option]:
             return ref_nodes[item_id][display_option][relative_path]  # cached paragraph node
 
-        display_text, text_on_hover_node = self._get_caption_info(item_info)
+        display_text, text_on_hover_node = self._get_caption_info(item_info)  # display original item
         newnode = nodes.reference('', '')
         innernode = nodes.emphasis(display_text, display_text)
-        newnode['refuri'] = f"{relative_path}#{item_info.identifier}"
-        newnode['refdocname'] = item_info.docname
+        newnode['refuri'] = f"{relative_path}#{link_item.identifier}"
+        newnode['refdocname'] = link_item.docname
 
         # change text color if item_id matches a regex in traceability_hyperlink_colors
         colors = self._find_colors_for_class(app.config.traceability_hyperlink_colors, item_id)

--- a/tests/directives/test_item_directive.py
+++ b/tests/directives/test_item_directive.py
@@ -5,12 +5,17 @@ from sphinx.application import Sphinx
 from sphinx.builders.latex import LaTeXBuilder
 from sphinx.builders.html import StandaloneHTMLBuilder
 from sphinx.environment import BuildEnvironment
+from sphinx.errors import NoUri
 
 from mlx.directives.item_directive import Item as dut
 from mlx.traceable_collection import TraceableCollection
 from mlx.traceable_item import TraceableItem
 
 from parameterized import parameterized
+
+
+def raise_no_uri(*args, **kwargs):
+    raise NoUri
 
 
 class TestItemDirective(TestCase):
@@ -22,13 +27,14 @@ class TestItemDirective(TestCase):
         self.node['id'] = 'some_id'
         self.node['line'] = 1
         self.item = TraceableItem(self.node['id'])
-        self.item.set_document(self.node['document'], self.node['line'])
-        self.item.bind_node(self.node)
+        self.item.set_location(self.node['document'], self.node['line'])
+        self.item.node = self.node
         self.app.config = Mock()
         self.app.config.traceability_hyperlink_colors = {}
 
     def test_make_internal_item_ref_no_caption(self):
         mock_builder = MagicMock(spec=StandaloneHTMLBuilder)
+        mock_builder.link_suffix = '.html'
         mock_builder.env = BuildEnvironment()
         self.app.builder = mock_builder
         self.app.builder.env.traceability_collection = TraceableCollection()
@@ -42,12 +48,13 @@ class TestItemDirective(TestCase):
         self.assertEqual(ref_node.tagname, 'reference')
         self.assertEqual(em_node.rawsource, 'some_id')
         self.assertEqual(str(em_node.children[0]), 'some_id')
-        self.assertEqual(p_node, self.app.builder.env.traceability_ref_nodes[self.node['id']]['default'])
+        self.assertEqual(p_node, self.app.builder.env.traceability_ref_nodes[self.node['id']]['default'][f'{self.node["document"]}.html'])
         self.assertNotIn('nocaptions', self.app.builder.env.traceability_ref_nodes[self.node['id']])
         self.assertNotIn('onlycaptions', self.app.builder.env.traceability_ref_nodes[self.node['id']])
 
     def test_make_internal_item_ref_show_caption(self):
         mock_builder = MagicMock(spec=StandaloneHTMLBuilder)
+        mock_builder.link_suffix = '.html'
         mock_builder.env = BuildEnvironment()
         self.app.builder = mock_builder
         self.app.builder.env.traceability_collection = TraceableCollection()
@@ -63,10 +70,11 @@ class TestItemDirective(TestCase):
         self.assertEqual(str(em_node), '<emphasis>some_id : caption text</emphasis>')
         self.assertEqual(ref_node.tagname, 'reference')
         self.assertEqual(em_node.rawsource, 'some_id : caption text')
-        self.assertEqual(p_node, self.app.builder.env.traceability_ref_nodes[self.node['id']]['default'])
+        self.assertEqual(p_node, self.app.builder.env.traceability_ref_nodes[self.node['id']]['default'][f'{self.node["document"]}.html'])
 
     def test_make_internal_item_ref_only_caption(self):
         mock_builder = MagicMock(spec=StandaloneHTMLBuilder)
+        mock_builder.link_suffix = '.html'
         mock_builder.env = BuildEnvironment()
         self.app.builder = mock_builder
         self.app.builder.env.traceability_collection = TraceableCollection()
@@ -86,10 +94,11 @@ class TestItemDirective(TestCase):
             '</emphasis>')
         self.assertEqual(ref_node.tagname, 'reference')
         self.assertEqual(em_node.rawsource, 'caption text')
-        self.assertEqual(p_node, self.app.builder.env.traceability_ref_nodes[self.node['id']]['onlycaptions'])
+        self.assertEqual(p_node, self.app.builder.env.traceability_ref_nodes[self.node['id']]['onlycaptions'][f'{self.node["document"]}.html'])
 
-    def test_make_internal_item_ref_hide_caption(self):
+    def test_make_internal_item_ref_hide_caption_html(self):
         mock_builder = MagicMock(spec=StandaloneHTMLBuilder)
+        mock_builder.link_suffix = '.html'
         mock_builder.env = BuildEnvironment()
         self.app.builder = mock_builder
         self.app.builder.env.traceability_collection = TraceableCollection()
@@ -108,10 +117,11 @@ class TestItemDirective(TestCase):
                          '</emphasis>')
         self.assertEqual(ref_node.tagname, 'reference')
         self.assertEqual(em_node.rawsource, 'some_id')
-        self.assertEqual(p_node, self.app.builder.env.traceability_ref_nodes[self.node['id']]['nocaptions'])
+        self.assertEqual(p_node, self.app.builder.env.traceability_ref_nodes[self.node['id']]['nocaptions'][f'{self.node["document"]}.html'])
 
     def test_make_internal_item_ref_hide_caption_latex(self):
         mock_builder = MagicMock(spec=LaTeXBuilder)
+        mock_builder.get_relative_uri = Mock(side_effect=raise_no_uri)
         mock_builder.env = BuildEnvironment()
         self.app.builder = mock_builder
         self.app.builder.env.traceability_collection = TraceableCollection()
@@ -127,7 +137,7 @@ class TestItemDirective(TestCase):
         self.assertEqual(str(em_node), '<emphasis>some_id</emphasis>')
         self.assertEqual(ref_node.tagname, 'reference')
         self.assertEqual(em_node.rawsource, 'some_id')
-        self.assertEqual(p_node, self.app.builder.env.traceability_ref_nodes[self.node['id']]['nocaptions'])
+        self.assertEqual(p_node, self.app.builder.env.traceability_ref_nodes[self.node['id']]['nocaptions'][''])
 
     @parameterized.expand([
         ("ext_toolname", True),

--- a/tests/directives/test_item_directive.py
+++ b/tests/directives/test_item_directive.py
@@ -48,9 +48,10 @@ class TestItemDirective(TestCase):
         self.assertEqual(ref_node.tagname, 'reference')
         self.assertEqual(em_node.rawsource, 'some_id')
         self.assertEqual(str(em_node.children[0]), 'some_id')
-        self.assertEqual(p_node, self.app.builder.env.traceability_ref_nodes[self.node['id']]['default'][f'{self.node["document"]}.html'])
-        self.assertNotIn('nocaptions', self.app.builder.env.traceability_ref_nodes[self.node['id']])
-        self.assertNotIn('onlycaptions', self.app.builder.env.traceability_ref_nodes[self.node['id']])
+        cache = self.app.builder.env.traceability_ref_nodes[self.node['id']]
+        self.assertEqual(p_node, cache['default'][f'{self.node["document"]}.html'])
+        self.assertNotIn('nocaptions', cache)
+        self.assertNotIn('onlycaptions', cache)
 
     def test_make_internal_item_ref_show_caption(self):
         mock_builder = MagicMock(spec=StandaloneHTMLBuilder)
@@ -70,7 +71,8 @@ class TestItemDirective(TestCase):
         self.assertEqual(str(em_node), '<emphasis>some_id : caption text</emphasis>')
         self.assertEqual(ref_node.tagname, 'reference')
         self.assertEqual(em_node.rawsource, 'some_id : caption text')
-        self.assertEqual(p_node, self.app.builder.env.traceability_ref_nodes[self.node['id']]['default'][f'{self.node["document"]}.html'])
+        cache = self.app.builder.env.traceability_ref_nodes[self.node['id']]
+        self.assertEqual(p_node, cache['default'][f'{self.node["document"]}.html'])
 
     def test_make_internal_item_ref_only_caption(self):
         mock_builder = MagicMock(spec=StandaloneHTMLBuilder)
@@ -94,7 +96,8 @@ class TestItemDirective(TestCase):
             '</emphasis>')
         self.assertEqual(ref_node.tagname, 'reference')
         self.assertEqual(em_node.rawsource, 'caption text')
-        self.assertEqual(p_node, self.app.builder.env.traceability_ref_nodes[self.node['id']]['onlycaptions'][f'{self.node["document"]}.html'])
+        cache = self.app.builder.env.traceability_ref_nodes[self.node['id']]
+        self.assertEqual(p_node, cache['onlycaptions'][f'{self.node["document"]}.html'])
 
     def test_make_internal_item_ref_hide_caption_html(self):
         mock_builder = MagicMock(spec=StandaloneHTMLBuilder)
@@ -117,7 +120,8 @@ class TestItemDirective(TestCase):
                          '</emphasis>')
         self.assertEqual(ref_node.tagname, 'reference')
         self.assertEqual(em_node.rawsource, 'some_id')
-        self.assertEqual(p_node, self.app.builder.env.traceability_ref_nodes[self.node['id']]['nocaptions'][f'{self.node["document"]}.html'])
+        cache = self.app.builder.env.traceability_ref_nodes[self.node['id']]
+        self.assertEqual(p_node, cache['nocaptions'][f'{self.node["document"]}.html'])
 
     def test_make_internal_item_ref_hide_caption_latex(self):
         mock_builder = MagicMock(spec=LaTeXBuilder)
@@ -137,7 +141,8 @@ class TestItemDirective(TestCase):
         self.assertEqual(str(em_node), '<emphasis>some_id</emphasis>')
         self.assertEqual(ref_node.tagname, 'reference')
         self.assertEqual(em_node.rawsource, 'some_id')
-        self.assertEqual(p_node, self.app.builder.env.traceability_ref_nodes[self.node['id']]['nocaptions'][''])
+        cache = self.app.builder.env.traceability_ref_nodes[self.node['id']]
+        self.assertEqual(p_node, cache['nocaptions'][''])
 
     @parameterized.expand([
         ("ext_toolname", True),


### PR DESCRIPTION
When multiple HTML pages try to link to the same traceable item, it's possible some links are broken since [v9.0.0](https://github.com/melexis/sphinx-traceability-extension/releases/tag/v9.0.0). This PR fixes this bug.

Instead of caching the reference node with `href="#RQT-CAPTION"` in `env.traceability_ref_nodes` when the item `RQT-CAPTION` is located on the same HTML page, this PR changes it into `href="requirements.html#RQT-CAPTION"`. When the relative URI is different, a different reference node needs to be cached additionally.