### PR TITLE
item-piechart: support hidden titles and render long labels

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -16,7 +16,6 @@ import os
 import subprocess
 import sys
 
-import matplotlib
 import mlx.traceability
 from mlx.traceability import report_warning
 from pkg_resources import get_distribution
@@ -450,10 +449,6 @@ else:
         print("Can't find 'plantuml.jar' file.")
         print("You need to add path to 'plantuml.jar' file to your PATH variable.")
         sys.exit(os.strerror(errno.EPERM))
-
-# Configure Matplotlib to use Lato font
-matplotlib.rcParams['font.sans-serif'] = 'Lato'
-
 
 def setup(app):
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -16,6 +16,7 @@ import os
 import subprocess
 import sys
 
+import matplotlib
 import mlx.traceability
 from mlx.traceability import report_warning
 from pkg_resources import get_distribution
@@ -449,6 +450,10 @@ else:
         print("Can't find 'plantuml.jar' file.")
         print("You need to add path to 'plantuml.jar' file to your PATH variable.")
         sys.exit(os.strerror(errno.EPERM))
+
+# Configure Matplotlib to use Lato font
+matplotlib.rcParams['font.sans-serif'] = 'Lato'
+
 
 def setup(app):
 

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -596,6 +596,7 @@ A pie chart of documentation items can be generated using:
         :result: error, fail, pass
         :functional: .*
         :colors: orange c b darkred #FF0000 g
+        :hidetitle:
 
 where the *id_set* arguments can be replaced by any Python regular expression. The *label_set* and *result* arguments
 are comma-separated lists.
@@ -650,6 +651,10 @@ are comma-separated lists.
     a color for each label in *label_set*, followed by as many colors as possible attribute values that you've listed
     in the *:<<attribute>>:* option (*:result:* in the example). Matplotlib supports many formats, explained in their
     demo_.
+
+:hidetitle: *optional*, *flag*
+
+    By providing the *hidetitle* flag, the title will be hidden.
 
 .. note::
 

--- a/mlx/directives/item_pie_chart_directive.py
+++ b/mlx/directives/item_pie_chart_directive.py
@@ -344,6 +344,7 @@ class ItemPieChartDirective(TraceableBaseDirective):
          :colors: <<color>> ...
          :sourcetype: <<relationship>> ...
          :targettype: <<relationship>> ...
+         :hidetitle:
     """
     # Optional argument: title (whitespace allowed)
     optional_arguments = 1
@@ -355,6 +356,7 @@ class ItemPieChartDirective(TraceableBaseDirective):
         'colors': directives.unchanged,
         'sourcetype': directives.unchanged,
         'targettype': directives.unchanged,
+        'hidetitle': directives.flag,
     }
     # Content disallowed
     has_content = False
@@ -382,6 +384,7 @@ class ItemPieChartDirective(TraceableBaseDirective):
         )
         self.check_relationships(node['sourcetype'], env)
         self.check_relationships(node['targettype'], env)
+        self.check_option_presence(node, 'hidetitle')
 
         return [node]
 

--- a/mlx/directives/item_pie_chart_directive.py
+++ b/mlx/directives/item_pie_chart_directive.py
@@ -290,10 +290,9 @@ class ItemPieChart(TraceableBaseNode):
         explode = self._get_explode_values(labels, self['label_set'])
         if not colors:
             colors = None
-        fig, axes = plt.subplots()
+        fig, axes = plt.subplots(subplot_kw=dict(aspect="equal"))
         _, texts, autotexts = axes.pie(sizes, explode=explode, labels=labels, autopct=pct_wrapper(sizes),
                                        startangle=90, colors=colors)
-        axes.axis('equal')
         folder_name = path.join(env.app.srcdir, '_images')
         if not path.exists(folder_name):
             mkdir(folder_name)
@@ -301,10 +300,11 @@ class ItemPieChart(TraceableBaseNode):
         hash_value = sha256(hash_string.encode()).hexdigest()  # create hash value based on chart parameters
         rel_file_path = path.join('_images', 'piechart-{}.png'.format(hash_value))
         if rel_file_path not in env.images:
-            fig.savefig(path.join(env.app.srcdir, rel_file_path), format='png')
+            fig.savefig(path.join(env.app.srcdir, rel_file_path), format='png', bbox_inches='tight')
             env.images[rel_file_path] = ['_images', path.split(rel_file_path)[-1]]  # store file name in build env
 
         image_node = nodes.image()
+        image_node['classes'].append('pie-chart')
         image_node['uri'] = rel_file_path
         image_node['candidates'] = '*'  # look at uri value for source path, relative to the srcdir folder
         return image_node

--- a/mlx/directives/item_pie_chart_directive.py
+++ b/mlx/directives/item_pie_chart_directive.py
@@ -287,6 +287,7 @@ class ItemPieChart(TraceableBaseNode):
         Returns:
             (nodes.image) Image node containing the pie chart image.
         """
+        mpl.rcParams['font.sans-serif'] = 'Lato'
         explode = self._get_explode_values(labels, self['label_set'])
         if not colors:
             colors = None

--- a/mlx/directives/item_pie_chart_directive.py
+++ b/mlx/directives/item_pie_chart_directive.py
@@ -51,7 +51,7 @@ class ItemPieChart(TraceableBaseNode):
             collection (TraceableCollection): Collection for which to generate the nodes.
         """
         env = app.builder.env
-        top_node = self.create_top_node(self['title'])
+        top_node = self.create_top_node(self['title'], hide_title=self['hidetitle'])
         self.collection = collection
         self.source_relationships = self['sourcetype'] if self['sourcetype'] else self.collection.iter_relations()
         self.target_relationships = self['targettype'] if self['targettype'] else self.collection.iter_relations()

--- a/mlx/directives/item_pie_chart_directive.py
+++ b/mlx/directives/item_pie_chart_directive.py
@@ -8,6 +8,7 @@ import matplotlib as mpl
 if not environ.get('DISPLAY'):
     mpl.use('Agg')
 import matplotlib.pyplot as plt  # pylint: disable=wrong-import-order
+from sphinx.builders.latex import LaTeXBuilder
 
 from mlx.traceability_exception import report_warning
 from mlx.traceable_base_directive import TraceableBaseDirective
@@ -299,9 +300,10 @@ class ItemPieChart(TraceableBaseNode):
             mkdir(folder_name)
         hash_string = str(colors) + str(texts) + str(autotexts)
         hash_value = sha256(hash_string.encode()).hexdigest()  # create hash value based on chart parameters
-        rel_file_path = path.join('_images', 'piechart-{}.png'.format(hash_value))
+        image_format = 'pdf' if isinstance(env.app.builder, LaTeXBuilder) else 'svg'
+        rel_file_path = path.join('_images', 'piechart-{}.{}'.format(hash_value, image_format))
         if rel_file_path not in env.images:
-            fig.savefig(path.join(env.app.srcdir, rel_file_path), format='png', bbox_inches='tight')
+            fig.savefig(path.join(env.app.srcdir, rel_file_path), format=image_format, bbox_inches='tight')
             env.images[rel_file_path] = ['_images', path.split(rel_file_path)[-1]]  # store file name in build env
 
         image_node = nodes.image()


### PR DESCRIPTION
Added:
- The title can be hidden with the flag `:hidetitle:`.
- The generated images have the class `pie-chart` for easier manipulation with CSS.
- Use svg for HTML and pdf for PDF output instead of png.

Fixed:
- Long labels were not fully rendered. The width of the images will now adapt to the length of the labels instead of being fixed.