### PR TITLE
item-piechart: support labeling using relationships of sourcetype

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    ?= -j auto
+SPHINXOPTS    ?= -j auto -T
 SPHINXBUILD   ?= sphinx-build
 PYTHONWARNINGS?= default::DeprecationWarning
 PAPER         ?=

--- a/doc/integration_test_report.rst
+++ b/doc/integration_test_report.rst
@@ -193,6 +193,16 @@ Integration test reports
     :skipped: ITEST-LIST
     :result: skip
 
+Waivers
+=======
+
+.. item:: WAIVER-NOT_IMPLEMENTED The test case has not been implemented yet.
+    :validates: ITEST_REP-COVERAGE
+    :status: not implemented
+
+.. item:: WAIVER-EXPECTED_FAILURE The failure of the test case was expected.
+    :validates: ITEST_REP-TREE_SCOPE
+
 Attribute details
 =================
 

--- a/doc/requirements.rst
+++ b/doc/requirements.rst
@@ -123,7 +123,7 @@ Design coverage
 
 .. item-piechart:: Design coverage chart of functional requirements
     :id_set: RQT DESIGN
-    :label_set: uncovered, covered
+    :label_set: Uncovered, Covered
     :functional: .*
     :sourcetype: fulfilled_by
 

--- a/doc/requirements.rst
+++ b/doc/requirements.rst
@@ -198,6 +198,14 @@ Test coverage
     :targettype: skipped_by passed_by failed_by
     :colors: orange c b y g r
 
+.. item-piechart:: Test cases as source using sourcetype to label with the :splitsourcetype: flag
+    :id_set: [IU]TEST [IU]TEST_REP WAIVER
+    :label_set: not executed, unused, expected failure
+    :sourcetype: failed_by passed_by skipped_by
+    :status: not implemented,
+    :colors: orange black cyan r g y slategrey
+    :splitsourcetype:
+
 .. item-piechart:: All uncovered as the bad sourcetype results in 0 links
     :id_set: RQT [IU]TEST
     :sourcetype: impacts_on

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -595,6 +595,7 @@ A pie chart of documentation items can be generated using:
         :targettype: failed_by passed_by skipped_by
         :result: error, fail, pass
         :functional: .*
+        :splitsourcetype:
         :colors: orange c b darkred #FF0000 g
         :hidetitle:
 
@@ -645,12 +646,18 @@ are comma-separated lists.
     The attribute value is **not** used to filter target items.
     When omitted, no filtering is done on the source item attributes.
 
+:splitsourcetype: *optional*, *flag*
+
+    Enable this flag in combination with the *sourcetype* option to split the slice with the second label in *label_set*
+    into a slice for each relationship between sources and targets. Then, the second label in *label_set* will not
+    be used (but you'll still need to specify a color for it in the *colors* option, if you want custom colors).
+
 :colors: *optional*, *multiple arguments (space-separated)*
 
     By default, matplotlib will choose the colors. This option allows you to define custom colors. You should specify
-    a color for each label in *label_set*, followed by as many colors as possible attribute values that you've listed
-    in the *:<<attribute>>:* option (*:result:* in the example). Matplotlib supports many formats, explained in their
-    demo_.
+    a color for each regex in *id_set*, followed by as many relationships/colors given for *sourcetype* option, if
+    the *splitsourcetype* flag is used, and the *targettype* option or the *<<attribute>>* option (*:result:* in the
+    example). Matplotlib supports many formats, explained in their demo_.
 
 :hidetitle: *optional*, *flag*
 


### PR DESCRIPTION
This MR only affects the `item-piechart` directive.

Added:
- `:splitsourcetype:` flag as requested in issue #305

Fixed:
- fixed crash that occurred when a label in `:label_set:` contained a capital letter

Closes #305 