### PR TITLE
Support linking with item-link directive using regular expressions

### DIFF
--- a/doc/integration_test_report.rst
+++ b/doc/integration_test_report.rst
@@ -748,11 +748,11 @@ This is a subtitle that has a ``item-link`` item under it. You shouldn't see any
 .. test: link to later (bottom of this page) defined source, should not warn
 
 .. item-link::
-    :source: late\d
+    :source: r003|late001|CL
     :type: trace
     :targets: r001
 
-.. warning on next 2 item-links due to the use of all or none of the mutually exclusive options:
+.. warnings on next 2 item-links due to the use of all or none of the mutually exclusive options:
 
 .. item-link::
     :source: late001

--- a/doc/integration_test_report.rst
+++ b/doc/integration_test_report.rst
@@ -742,26 +742,26 @@ This is a subtitle that has a ``item-link`` item under it. You shouldn't see any
 
 .. item-link::
     :sources: r001
-    :targets: r002
+    :target: r\d+2
     :type: trace
 
 .. test: link to later (bottom of this page) defined source, should not warn
 
 .. item-link::
-    :sources: late001
+    :source: late\d
     :type: trace
     :targets: r001
 
-.. warning on next item-link due to missing sources:
+.. warning on next 2 item-links due to the use of all or none of the mutually exclusive options:
 
 .. item-link::
+    :source: late001
+    :sources: late001
+    :target: r001
+    :targets: r001
     :type: trace
-    :targets: r100
-
-.. warning on next item-link due to missing targets:
 
 .. item-link::
-    :sources: r100
     :type: trace
 
 .. warning on next item-link due to missing relation type:

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -122,7 +122,8 @@ involved. In that case, you can use the ``item-link`` directive as follows:
 
 .. note::
 
-    The options ``sources`` and ``targets`` *can* be combined with the options ``target`` and ``source`` respectively.
+    Exactly **1** of the options ``sources`` *or* ``source`` shall be used with exactly **1** of the options ``targets``
+    *or* ``target``.
 
 This directive has no representation in the documentation build output.
 

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -161,6 +161,11 @@ Example usage of the ``item-relink`` directive:
 
 This directive has no representation in the documentation build output.
 
+.. note::
+
+    This ``item-relink`` directive is processed *after* the ``item-link`` directive. Thus, the ``item-link`` directive
+    *can* use the item given to the ``remap`` option.
+
 -------------------------------------------------
 Adding attributes outside of the item definitions
 -------------------------------------------------

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -97,20 +97,20 @@ involved. In that case, you can use the ``item-link`` directive as follows:
         :target: TST[345]
         :type: validates
 
-:sources: *multiple arguments*, *mutually exclusive with ``source``*
+:sources: *multiple arguments*, *mutually exclusive with* ``source``
 
     List of item IDs to add the given forward relationship type to, linking them to every target item.
 
-:source: *single argument*, *mutually exclusive with ``sources``*
+:source: *single argument*, *mutually exclusive with* ``sources``
 
     Regular expression to filter items from the traceable collection and add the given forward relationship type to,
     linking them to every target item.
 
-:targets: *multiple arguments*, *mutually exclusive with ``target``*
+:targets: *multiple arguments*, *mutually exclusive with* ``target``
 
     List of item IDs to add the reverse of the given relationship type to, linking them to every source item.
 
-:target: *single argument*, *mutually exclusive with ``targets``*
+:target: *single argument*, *mutually exclusive with* ``targets``
 
     Regular expression to filter items from the traceable collection and add the reverse of the given relationship type
     to, linking them to every source item.

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -92,9 +92,40 @@ involved. In that case, you can use the ``item-link`` directive as follows:
         :targets: TST3 TST4 TST5
         :type: validates
 
+    .. item-link::
+        :source: RQT1\d
+        :target: TST1\d
+        :type: validates
+
 This directive has no representation in the documentation build output. It will
-just add an additional relationship to the items mentioned in ``sources`` and
-``targets``.
+just add the relationship between source and target item(s).
+
+:sources: *multiple arguments*, *mutually exclusive with source*
+
+    List of item IDs to add the given forward relationship type to, linking them to every target item.
+
+:source: *single argument*, *mutually exclusive with ``sources``*
+
+    Regular expression to filter items from the traceable collection and add the given forward relationship type to,
+    linking them to every target item.
+
+:targets: *multiple arguments*, *mutually exclusive with target*
+
+    List of item IDs to add the reverse of the given relationship type to, linking them to every source item.
+
+:target: *single argument*, *mutually exclusive with ``targets``*
+
+    Regular expression to filter items from the traceable collection and add the reverse of the given relationship type
+    to, linking them to every source item.
+
+:type: *required*, *single argument*
+
+    Relationship type, used to link all source items to all target items.
+    The value must not be empty.
+
+.. note::
+
+    The options ``sources`` and ``targets`` *can* be combined with the options ``target`` and ``source`` respectively.
 
 ------------------------------------------
 Changing targets or removing relationships

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -93,14 +93,11 @@ involved. In that case, you can use the ``item-link`` directive as follows:
         :type: validates
 
     .. item-link::
-        :source: RQT1\d
-        :target: TST1\d
+        :source: RQT\d
+        :target: TST[345]
         :type: validates
 
-This directive has no representation in the documentation build output. It will
-just add the relationship between source and target item(s).
-
-:sources: *multiple arguments*, *mutually exclusive with source*
+:sources: *multiple arguments*, *mutually exclusive with ``source``*
 
     List of item IDs to add the given forward relationship type to, linking them to every target item.
 
@@ -109,7 +106,7 @@ just add the relationship between source and target item(s).
     Regular expression to filter items from the traceable collection and add the given forward relationship type to,
     linking them to every target item.
 
-:targets: *multiple arguments*, *mutually exclusive with target*
+:targets: *multiple arguments*, *mutually exclusive with ``target``*
 
     List of item IDs to add the reverse of the given relationship type to, linking them to every source item.
 
@@ -126,6 +123,8 @@ just add the relationship between source and target item(s).
 .. note::
 
     The options ``sources`` and ``targets`` *can* be combined with the options ``target`` and ``source`` respectively.
+
+This directive has no representation in the documentation build output.
 
 ------------------------------------------
 Changing targets or removing relationships

--- a/mlx/traceable_collection.py
+++ b/mlx/traceable_collection.py
@@ -23,6 +23,7 @@ class TraceableCollection:
         self.relations = {}
         self.items = {}
         self.relations_sorted = {}
+        self.placeholders_to_relink = set()
 
     def add_relation_pair(self, forward, reverse=NO_RELATION_STR):
         '''
@@ -196,6 +197,8 @@ class TraceableCollection:
             raise TraceabilityException('No relations configured', 'configuration')
         # Validate each item
         for itemid in self.items:
+            if itemid in self.placeholders_to_relink:
+                return  # This placeholder item will be removed during the processing of the ItemRelink is processed
             item = self.get_item(itemid)
             # Only for relevant items, filtered on document name
             if docname is not None and item.docname != docname and item.docname is not None:

--- a/tools/doc-warnings.json
+++ b/tools/doc-warnings.json
@@ -1,8 +1,8 @@
 {
     "sphinx": {
         "enabled": true,
-        "min": 24,
-        "max": 24,
+        "min": 23,
+        "max": 23,
         "exclude": [
             "WARNING: the mlx.traceability extension is not safe for parallel reading",
             "WARNING: doing serial read"

--- a/tools/doc-warnings.json
+++ b/tools/doc-warnings.json
@@ -1,8 +1,8 @@
 {
     "sphinx": {
         "enabled": true,
-        "min": 22,
-        "max": 22,
+        "min": 24,
+        "max": 24,
         "exclude": [
             "WARNING: the mlx.traceability extension is not safe for parallel reading",
             "WARNING: doing serial read"


### PR DESCRIPTION
Added:
- Add `source` and `target` options to `item-link` directive. They expect a regular expression.
--------------
Fixed:
- always process `item-relink` after `item-link` directive instead of using the order in which they are defined in the RST file(s)
