### PR TITLE
Fix broken (re)linking from version 9.3.0

### DIFF
--- a/doc/unit_test.rst
+++ b/doc/unit_test.rst
@@ -10,6 +10,8 @@ Unit Tests
 Unit Tests for mlx.traceability
 -------------------------------
 
+.. test item-link defined before item-relink and item definitions: item-link shall always be processed first
+
 .. item-relink::
     :remap: RQT-ATTRIBUTES_FAKE
     :target: RQT-ATTRIBUTES
@@ -57,4 +59,15 @@ Unit Tests for mlx.traceability
     :validates: RQT-MATRIX
 
 .. item:: UTEST_ITEM_DIRECTIVE-MAKE_INTERNAL_ITEM_REF_SHOW_CAPTION
-    :validates: RQT-CAPTION
+
+.. test item-relink defined after item-link and item definitions: item-link shall always be processed first
+
+.. item-link::
+    :sources: nonexistent_item
+    :targets: RQT-CAPTION
+    :type: validates
+
+.. item-relink::
+    :remap: nonexistent_item
+    :target: UTEST_ITEM_DIRECTIVE-MAKE_INTERNAL_ITEM_REF_SHOW_CAPTION
+    :type: validated_by

--- a/mlx/traceable_item.py
+++ b/mlx/traceable_item.py
@@ -60,7 +60,8 @@ class TraceableItem(TraceableBaseClass):
                 targets.update(self.explicit_relations[relation])
             if relation in self.implicit_relations:
                 targets.update(self.implicit_relations[relation])
-            yield relation, natsorted(targets)
+            if targets:
+                yield relation, natsorted(targets)
 
     @staticmethod
     def _add_relations(relations_of_self, relations_of_other):

--- a/tools/doc-warnings.json
+++ b/tools/doc-warnings.json
@@ -1,8 +1,8 @@
 {
     "sphinx": {
         "enabled": true,
-        "min": 23,
-        "max": 23,
+        "min": 24,
+        "max": 24,
         "exclude": [
             "WARNING: the mlx.traceability extension is not safe for parallel reading",
             "WARNING: doing serial read"


### PR DESCRIPTION
PR #308 (v9.3.0) introduced a bug that caused the `item-link` and `item-relink` directives to only take effect from the moment they were processed during Sphinx' write stage. The linking must be done before any other directives are rendered, however, for the (re)linking to affect the entire output instead of from the point the document  they are defined in is rendered.

I've committed the fix to master branch already:

- https://github.com/melexis/sphinx-traceability-extension/commit/ab784f9a43e73bce35a827b2986a8a8dc77d8036
- 3b67a97bbac54fb0179505614eb27febe6a6a43c
- 18df53c723eb2a79452156e49d367ddb23efddb5

Fixed in this PR:
- Adjusting warning limit to account for the valid warning of `TraceableBaseNode.self_test` again, which was gone during v9.3.0: `WARNING: Item 'non_existing_requirement' has no reference to source document.`
- Don't list relationship type if there are no targets after relinking.