### PR TITLE
Completely disregard a duplicate item definition after warning about it

### DIFF
--- a/doc/integration_test_report.rst
+++ b/doc/integration_test_report.rst
@@ -72,6 +72,7 @@ This text is not part of any item
     Clean up all this again
 
 .. item:: r005 Duplicate: should trigger warning
+    :aspice: 998
 
     As this one is the second one, this should **not** appear in the generated documentation.
 

--- a/doc/integration_test_report.rst
+++ b/doc/integration_test_report.rst
@@ -73,6 +73,7 @@ This text is not part of any item
 
 .. item:: r005 Duplicate: should trigger warning
     :aspice: 998
+    :trace: non_existing_requirement
 
     As this one is the second one, this should **not** appear in the generated documentation.
 

--- a/mlx/directives/item_directive.py
+++ b/mlx/directives/item_directive.py
@@ -151,6 +151,8 @@ class ItemDirective(TraceableBaseDirective):
         if 'class' in self.options:
             item_node['classes'].extend(self.options.get('class'))
         item = self._store_item_info(target_id, env)
+        if item is None:
+            return []
 
         # Custom callback for modifying items
         if app.config.traceability_callback_per_item:
@@ -164,12 +166,14 @@ class ItemDirective(TraceableBaseDirective):
     def _store_item_info(self, target_id, env):
         """ Stores item info and adds TraceableItem to the collection.
 
+        If an item with the same identifier already exists, a warning will be reported and this item info is ignored.
+
         Args:
             target_id (str): Item identifier.
             env (sphinx.environment.BuildEnvironment): Sphinx's build environment.
 
         Returns:
-            TraceableItem: Instantiated TraceableItem.
+            TraceableItem/None: Instantiated TraceableItem; or None if an item with the same identifier already exists
         """
         target_node = nodes.target('', '', ids=[target_id])
         item = TraceableItem(target_id, state=self.state)
@@ -181,6 +185,7 @@ class ItemDirective(TraceableBaseDirective):
             env.traceability_collection.add_item(item)
         except TraceabilityException as err:
             report_warning(err, env.docname, self.lineno)
+            return None
 
         self._add_attributes(item, env.docname)
 


### PR DESCRIPTION
When an `item`-directive contains the same item identifier, a warning was generated and the directive was processed. 

I think such a directive should not be processed and rendered but this is backwards incompatible.