### PR TITLE
Use `re.match` for regexes in `traceability_hyperlink_colors`

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -354,25 +354,20 @@ Custom colors for linked items
 ------------------------------
 
 The plugin allows customization of the colors of traceable items in order to easily recognize the type of item which is
-linked to. A dictionary in the configuration file defines the regexp, which is used to search_ item IDs, as key and a
+linked to. A dictionary in the configuration file defines the regexp, which is used to match_ item IDs, as key and a
 tuple of 1-3 color defining strings as value. The first color is used for the default hyperlink state, the second color
 is used for the hover and active states, and the third color is used to override the default color of the visited state.
 Leaving a color empty results in the use of the default html style. The top regexp has the highest priority. To support
 Python versions lower than 3.7, we use an :code:`OrderedDict` to have a deterministic order for prioritizing regexes.
 
-.. warning::
-
-    In version 9.0.0, the regular expressions in `traceability_hyperlink_colors` will be used to match_ item IDs
-    instead of search_. This way, all regexes will be handled the same way by this plugin.
-
 .. code-block:: python
 
     traceability_hyperlink_colors = OrderedDict([
-        (r'^(RQT|r[\d]+', ('#7F00FF', '#b369ff')),
-        (r'^[IU]TEST_REP', ('rgba(255, 0, 0, 1)', 'rgba(255, 0, 0, 0.7)', 'rgb(200, 0, 0)')),
-        (r'^[IU]TEST', ('goldenrod', 'hsl(43, 62%, 58%)', 'darkgoldenrod')),
-        (r'^SYS_', ('', 'springgreen', '')),
-        (r'^SRS_', ('', 'orange', '')),
+        (r'(RQT|r[\d]+', ('#7F00FF', '#b369ff')),
+        (r'[IU]TEST_REP', ('rgba(255, 0, 0, 1)', 'rgba(255, 0, 0, 0.7)', 'rgb(200, 0, 0)')),
+        (r'[IU]TEST', ('goldenrod', 'hsl(43, 62%, 58%)', 'darkgoldenrod')),
+        (r'SYS_', ('', 'springgreen', '')),
+        (r'SRS_', ('', 'orange', '')),
     ])
 
 .. _traceability_notifications:
@@ -475,4 +470,3 @@ per documentation object:
     traceability_render_relationship_per_item = False
 
 .. _match: https://docs.python.org/3/library/re.html#re.match
-.. _search: https://docs.python.org/3/library/re.html#re.search

--- a/mlx/traceability.py
+++ b/mlx/traceability.py
@@ -6,7 +6,6 @@ Traceability plugin
 Sphinx extension for reStructuredText that added traceable documentation items.
 See readme for more details.
 """
-import warnings
 from collections import namedtuple
 from re import fullmatch, match
 from os import path

--- a/mlx/traceability.py
+++ b/mlx/traceability.py
@@ -216,9 +216,6 @@ def perform_consistency_check(app, env):
     if app.config.traceability_hyperlink_colors:
         app.add_css_file('hyperlink_colors.css')
         generate_color_css(app, app.config.traceability_hyperlink_colors)
-        if [regex for regex in app.config.traceability_hyperlink_colors if not regex.startswith('^')]:
-            warnings.warn('Regexes in traceability_hyperlink_colors will be handled by re.match instead of re.search '
-                          'in mlx.traceability>=9', DeprecationWarning)
 
     regex = app.config.traceability_checklist.get('checklist_item_regex')
     if regex is not None and app.config.traceability_checklist['has_checklist_items']:

--- a/mlx/traceable_base_node.py
+++ b/mlx/traceable_base_node.py
@@ -194,7 +194,7 @@ class TraceableBaseNode(nodes.General, nodes.Element, ABC):
         """
         for regex, colors in hyperlink_colors.items():
             colors = tuple(colors)
-            if re.search(regex, item_id):
+            if re.match(regex, item_id):
                 return tuple(colors)
         return None
 


### PR DESCRIPTION
Finally address the `DeprecationWarning` and use `re.match` instead of `re.search` for regexes in `traceability_hyperlink_colors`