### PR TITLE
Fix bugs in item-link and item-relink directives

### DIFF
--- a/doc/unit_test.rst
+++ b/doc/unit_test.rst
@@ -22,6 +22,13 @@ Unit Tests for mlx.traceability
     :targets: UTEST_TRACEABLE_COLLECTION-GET_ITEMS_ATTRIBUTE
     :type: validated_by
 
+.. duplicate item-link shall only result in a warning
+
+.. item-link::
+    :sources: RQT-ATTRIBUTES_FAKE
+    :targets: UTEST_TRACEABLE_COLLECTION-GET_ITEMS_ATTRIBUTE
+    :type: validated_by
+
 .. item:: UTEST_TRACEABLE_ITEM-INIT
     :validates: RQT-DOCUMENTATION_ID
 
@@ -63,11 +70,33 @@ Unit Tests for mlx.traceability
 .. test item-relink defined after item-link and item definitions: item-link shall always be processed first
 
 .. item-link::
-    :sources: nonexistent_item
+    :sources: item_to_relink
     :targets: RQT-CAPTION
     :type: validates
 
 .. item-relink::
-    :remap: nonexistent_item
+    :remap: item_to_relink
     :target: UTEST_ITEM_DIRECTIVE-MAKE_INTERNAL_ITEM_REF_SHOW_CAPTION
     :type: validated_by
+
+.. duplicate item-relink shall NOT result in a warning
+
+.. item-relink::
+    :remap: item_to_relink
+    :target: UTEST_ITEM_DIRECTIVE-MAKE_INTERNAL_ITEM_REF_SHOW_CAPTION
+    :type: validated_by
+
+.. the placeholder item_to_relink shall not be removed from the collection:
+   2 warnings shall be produced (1 per target)
+
+.. item-link::
+    :sources: item_to_relink
+    :target: UTEST_TRACEABLE_ITEM-REMOVE_
+    :type: trace
+
+.. warn about invalid relation
+
+.. item-relink::
+    :remap: item_to_relink
+    :target: UTEST_ITEM_DIRECTIVE-MAKE_INTERNAL_ITEM_REF_SHOW_CAPTION
+    :type: non_existing_relation

--- a/mlx/directives/item_link_directive.py
+++ b/mlx/directives/item_link_directive.py
@@ -40,7 +40,7 @@ class ItemLink(TraceableBaseNode):
                 try:
                     collection.add_relation(source, self['type'], target)
                 except TraceabilityException as err:
-                    report_warning(err, self['docname'], self['line'])
+                    report_warning(err, self['document'], self['line'])
 
 
 class ItemLinkDirective(TraceableBaseDirective):

--- a/mlx/directives/item_relink_directive.py
+++ b/mlx/directives/item_relink_directive.py
@@ -64,7 +64,7 @@ class ItemRelink(TraceableBaseNode):
         """
         for source_id in ItemRelink.source_ids:
             source = collection.get_item(source_id)
-            if source.is_placeholder and not [targets for _,targets in source.all_relations if targets]:
+            if source.is_placeholder and not [targets for _, targets in source.all_relations if targets]:
                 print(f'poppingg {source_id}')
                 collection.items.pop(source_id)
 

--- a/mlx/directives/item_relink_directive.py
+++ b/mlx/directives/item_relink_directive.py
@@ -32,11 +32,12 @@ class ItemRelink(TraceableBaseNode):
         reverse_type = collection.get_reverse_relation(forward_type)
 
         if source is None:
-            report_warning("Could not find item {!r} specified in item-relink directive".format(source_id))
+            report_warning("Could not find item {!r} specified in item-relink directive".format(source_id),
+                           self['document'], self['line'])
             return
         if not reverse_type:
             report_warning("Could not find reverse relationship type for type {!r} specified in item-relink directive"
-                           .format(forward_type))
+                           .format(forward_type), self['document'], self['line'])
             return
 
         affected_items = set()

--- a/mlx/traceability.py
+++ b/mlx/traceability.py
@@ -469,9 +469,7 @@ def _parse_description(description, attr_values, merge_request_id, regex):
 # Extension setup
 def setup(app):
     """Extension setup"""
-
     # Javascript and stylesheet for the tree-view
-    # app.add_js_file('jquery.js') #note: can only be included once
     app.add_js_file('https://cdn.rawgit.com/aexmachina/jquery-bonsai/master/jquery.bonsai.js')
     app.add_css_file('https://cdn.rawgit.com/aexmachina/jquery-bonsai/master/jquery.bonsai.css')
     app.add_js_file('traceability.js')

--- a/mlx/traceability.py
+++ b/mlx/traceability.py
@@ -192,10 +192,9 @@ class PendingItemXref(TraceableBaseNode):
 # -----------------------------------------------------------------------------
 # Event handlers
 def perform_consistency_check(app, env):
-    """
-    New in sphinx 1.6: consistency checker callback
+    """Called once in between Sphinx' read stage and write stage.
 
-    Used to perform the self-test on the collection of items
+    Used to perform (re)linking of item-link and item-relink and perform the self-test on the collection of items.
 
     If the ``checklist_item_regex`` is configured, a warning is reported
     for each item ID that matches it and is not defined as a checklist-item.

--- a/mlx/traceability.py
+++ b/mlx/traceability.py
@@ -201,6 +201,7 @@ def perform_consistency_check(app, env):
     for each item ID that matches it and is not defined as a checklist-item.
     """
     env.traceability_collection.process_intermediate_nodes()
+    ItemRelink.remove_placeholders(env.traceability_collection)
     try:
         env.traceability_collection.self_test(app.config.traceability_notifications.get('undefined-reference'))
     except TraceabilityException as err:

--- a/tools/doc-warnings.json
+++ b/tools/doc-warnings.json
@@ -1,8 +1,8 @@
 {
     "sphinx": {
         "enabled": true,
-        "min": 24,
-        "max": 24,
+        "min": 29,
+        "max": 29,
         "exclude": [
             "WARNING: the mlx.traceability extension is not safe for parallel reading",
             "WARNING: doing serial read"


### PR DESCRIPTION
Fixed:
- prevent bug introduced in 9.3.1 that causes a crash when duplicating a link/relationship with `item-link`
- `item-relink` can now be used more than once with the same `:remap:` value
- fix crash that occurred when a placeholder item in `item-relink`'s `:remap:` option did not have all of its targets transferred/relinked (to a valid item)