### PR TITLE
Add overwrite flag to attribute-link directive

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -180,16 +180,25 @@ involved. In that case, you can use the ``attribute-link`` directive as follows:
         :asil: D
         :status: Approved
 
-This directive has no representation in the documentation build output. It will
-just add an additional attribute(s) to the items of which their ID.
-
 In the above example, the *asil* and *status* attributes with given values get
 added to all items that have an ID that starts with *RQT-*. If your documentation defines
 items *RQT-1* and *RQT-11*, but you only want to add an attribute to item *RQT-1*, you
 should use the ``filter`` option with value *RQT-1$*. If the ``filter`` option is missing,
 all items will be affected. Newline characters in the ``filter`` regex get removed.
 
-.. note:: This directive overwrites any attribute values configured in the ``item`` directive.
+:filter: *required*, *single argument*
+
+    Regular expression to filter items from the traceable collection and give them the provided attributes.
+
+:<<attribute>>: *optional*, *single argument*
+
+    Value of ``<<attribute>>`` to give to the matching items.
+
+:overwrite: *optional*, *flag*
+
+    When enabled, overwrite existing values of ``<<attribute>>``.
+
+This directive has no representation in the documentation build output.
 
 --------------------------------
 Adding description to attributes

--- a/mlx/directives/attribute_link_directive.py
+++ b/mlx/directives/attribute_link_directive.py
@@ -20,10 +20,11 @@ class AttributeLink(TraceableBaseNode):
         filtered_items = collection.get_item_objects(self['filter'])
         for attribute, value in self['filter-attributes'].items():
             for item in filtered_items:
-                try:
-                    item.add_attribute(attribute, value)
-                except TraceabilityException as err:
-                    report_warning(err, self['document'], self['line'])
+                if self['overwrite'] or not item.get_attribute(attribute):
+                    try:
+                        item.add_attribute(attribute, value)
+                    except TraceabilityException as err:
+                        report_warning(err, self['document'], self['line'])
         self.replace_self([])
 
 
@@ -37,10 +38,12 @@ class AttributeLinkDirective(TraceableBaseDirective):
       .. attribute-link::
          :filter: regex
          :<<attribute>>: attribute_value
+         :overwrite:
     """
     # Options
     option_spec = {
         'filter': directives.unchanged,
+        'overwrite': directives.flag,
     }
     # Content disallowed
     has_content = False
@@ -60,5 +63,6 @@ class AttributeLinkDirective(TraceableBaseDirective):
             },
         )
         self.add_found_attributes(node)
+        self.check_option_presence(node, 'overwrite')
 
         return [node]


### PR DESCRIPTION
This PR adds an explicit `overwrite` flag to the `attribute-link` directive, so that existing values are not clobbered by default.

A non-overwriting `attribute-link` directive can be used to give attributes default values:

```
.. attribute-link::
    :filter: RQT-
    :status: UNKNOWN
```

I had trouble deciding whether changing the current behavior was worse than overwriting user input by default, so I also implemented this feature with a `nooverwrite` flag on another branch. If you prefer that one, just tell me so I can push it.