### PR TITLE
Fix some quality-of-life issues with item-piechart

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -634,6 +634,7 @@ A pie chart of documentation items can be generated using:
         :splitsourcetype:
         :colors: orange c b darkred #FF0000 g
         :hidetitle:
+        :stats:
 
 where the *id_set* arguments can be replaced by any Python regular expression. The *label_set* and *result* arguments
 are comma-separated lists.
@@ -698,6 +699,11 @@ are comma-separated lists.
 :hidetitle: *optional*, *flag*
 
     By providing the *hidetitle* flag, the title will be hidden.
+
+:stats: *optional*, *flag*
+
+    By providing the *stats* flag, some statistics (coverage percentage) are calculated and displayed below the
+    pie chart.
 
 .. note::
 

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -643,6 +643,10 @@ Pie chart of documentation items
 
 A pie chart of documentation items can be generated using:
 
+.. warning::
+
+    Starting from version 10.0.0, pie chart statistics will be hidden unless the *stats* flag is provided.
+
 .. code-block:: rest
 
     .. item-piechart:: Test coverage of requirements with report results

--- a/mlx/directives/item_pie_chart_directive.py
+++ b/mlx/directives/item_pie_chart_directive.py
@@ -77,7 +77,8 @@ class ItemPieChart(TraceableBaseNode):
                            .format(len(data['labels']), len(data['labels']) - len(data['colors'])),
                            self['document'], self['line'])
         p_node = nodes.paragraph()
-        p_node += nodes.Text(statistics)
+        if self['stats']:
+            p_node += nodes.Text(statistics)
         if data['labels']:
             top_node += self.build_pie_chart(data['sizes'], data['labels'], data['colors'], env)
         top_node += p_node
@@ -370,6 +371,7 @@ class ItemPieChartDirective(TraceableBaseDirective):
          :targettype: <<relationship>> ...
          :splitsourcetype:
          :hidetitle:
+         :stats:
     """
     # Optional argument: title (whitespace allowed)
     optional_arguments = 1
@@ -383,6 +385,7 @@ class ItemPieChartDirective(TraceableBaseDirective):
         'targettype': directives.unchanged,
         'splitsourcetype': directives.flag,
         'hidetitle': directives.flag,
+        'stats': directives.flag,
     }
     # Content disallowed
     has_content = False
@@ -412,6 +415,7 @@ class ItemPieChartDirective(TraceableBaseDirective):
         self.check_relationships(node['targettype'], env)
         self.check_option_presence(node, 'splitsourcetype')
         self.check_option_presence(node, 'hidetitle')
+        self.check_option_presence(node, 'stats')
 
         if node['splitsourcetype'] and not node['sourcetype']:
             report_warning('item-piechart: The splitsourcetype flag must not be used when the sourcetype option is '

--- a/mlx/directives/item_pie_chart_directive.py
+++ b/mlx/directives/item_pie_chart_directive.py
@@ -1,4 +1,5 @@
 import re
+import warnings
 from hashlib import sha256
 from os import environ, mkdir, path
 
@@ -78,8 +79,7 @@ class ItemPieChart(TraceableBaseNode):
                                                            list(self.linked_labels.values()),
                                                            self['colors'])
         p_node = nodes.paragraph()
-        if self['stats']:
-            p_node += nodes.Text(statistics)
+        p_node += nodes.Text(statistics)
         if data['labels']:
             top_node += self.build_pie_chart(data['sizes'], data['labels'], data['colors'], env)
         top_node += p_node
@@ -423,6 +423,10 @@ class ItemPieChartDirective(TraceableBaseDirective):
             report_warning('item-piechart: The splitsourcetype flag must not be used when the sourcetype option is '
                            'unused; disabling splitsourcetype.', node['document'], node['line'])
             node['splitsourcetype'] = False
+
+        if not node['stats']:
+            warnings.warn('Pie chart statistics will not be displayed in mlx.traceability>=10 unless the stats flag '
+                          'is provided.', FutureWarning)
 
         return [node]
 

--- a/mlx/directives/item_pie_chart_directive.py
+++ b/mlx/directives/item_pie_chart_directive.py
@@ -58,11 +58,6 @@ class ItemPieChart(TraceableBaseNode):
         self.target_relationships = self['targettype'] if self['targettype'] else self.collection.iter_relations()
         self.relationship_to_string = app.config.traceability_relationship_to_string
         self._set_priorities()
-        if self['colors'] and len(self['colors']) < len(self.priorities):
-            report_warning("item-piechart can contain up to {} slices but only {} colors have been provided: some "
-                           "colors may be reused".format(len(self.priorities), len(self['colors'])),
-                           self['document'], self['line'])
-
         self._set_nested_target_regex()
         target_regex = re.compile(self['id_set'][1])
         for source_id in self.collection.get_items(self['id_set'][0], self['filter-attributes']):
@@ -74,15 +69,13 @@ class ItemPieChart(TraceableBaseNode):
             self.loop_relationships(source_id, source_item, self.source_relationships, target_regex,
                                     self._match_covered)
 
+        if self['colors'] and len(self['colors']) < len(self.priorities):
+            report_warning("item-piechart can contain up to {} slices but only {} colors have been provided: some "
+                           "colors may be reused".format(len(self.priorities), len(self['colors'])),
+                           self['document'], self['line'])
         data, statistics = self._prepare_labels_and_values(self.priorities,
                                                            list(self.linked_labels.values()),
                                                            self['colors'])
-
-        if data['colors'] and len(data['colors']) < len(data['labels']):
-            report_warning("item-piechart contains {} slices: {} color(s) will be reused"
-                           .format(len(data['labels']), len(data['labels']) - len(data['colors'])),
-                           self['document'], self['line'])
-
         if data['labels']:
             top_node += self.build_pie_chart(data['sizes'], data['labels'], data['colors'], env)
 

--- a/mlx/directives/item_pie_chart_directive.py
+++ b/mlx/directives/item_pie_chart_directive.py
@@ -58,6 +58,11 @@ class ItemPieChart(TraceableBaseNode):
         self.target_relationships = self['targettype'] if self['targettype'] else self.collection.iter_relations()
         self.relationship_to_string = app.config.traceability_relationship_to_string
         self._set_priorities()
+        if self['colors'] and len(self['colors']) < len(self.priorities):
+            report_warning("item-piechart contains {} slices: {} color(s) will be reused"
+                           .format(len(self.priorities), len(self.priorities) - len(self['colors'])),
+                           self['document'], self['line'])
+
         self._set_nested_target_regex()
         target_regex = re.compile(self['id_set'][1])
         for source_id in self.collection.get_items(self['id_set'][0], self['filter-attributes']):
@@ -72,10 +77,6 @@ class ItemPieChart(TraceableBaseNode):
         data, statistics = self._prepare_labels_and_values(self.priorities,
                                                            list(self.linked_labels.values()),
                                                            self['colors'])
-        if data['colors'] and len(data['colors']) < len(data['labels']):
-            report_warning("item-piechart contains {} slices: {} color(s) will be reused"
-                           .format(len(data['labels']), len(data['labels']) - len(data['colors'])),
-                           self['document'], self['line'])
         p_node = nodes.paragraph()
         if self['stats']:
             p_node += nodes.Text(statistics)


### PR DESCRIPTION
This PR fixes the following perceived shortcomings of the `item-piechart` directive:

* Fix the reported values in the error message for the wrong number of color arguments when some of the labels are empty. Fixes #321.
* Make the default behavior to hide coverage statistics unless the `stats` flag is provided (c.f. #323), as is done with other directives such as `item-matrix`.

As per the discussion below, this PR introduces breaking changes and should be scheduled for the next major release.