### PR TITLE
Add stats flag to item-piechart directive

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -633,6 +633,10 @@ Pie chart of documentation items
 
 A pie chart of documentation items can be generated using:
 
+.. warning::
+
+    Starting from version 10.0.0, pie chart statistics will be hidden unless the *stats* flag is provided.
+
 .. code-block:: rest
 
     .. item-piechart:: Test coverage of requirements with report results
@@ -645,6 +649,7 @@ A pie chart of documentation items can be generated using:
         :splitsourcetype:
         :colors: orange c b darkred #FF0000 g
         :hidetitle:
+        :stats:
 
 where the *id_set* arguments can be replaced by any Python regular expression. The *label_set* and *result* arguments
 are comma-separated lists.
@@ -709,6 +714,11 @@ are comma-separated lists.
 :hidetitle: *optional*, *flag*
 
     By providing the *hidetitle* flag, the title will be hidden.
+
+:stats: *optional*, *flag*
+
+    By providing the *stats* flag, some statistics (coverage percentage) are calculated and displayed below the
+    pie chart.
 
 .. note::
 

--- a/mlx/directives/item_pie_chart_directive.py
+++ b/mlx/directives/item_pie_chart_directive.py
@@ -1,4 +1,5 @@
 import re
+import warnings
 from hashlib import sha256
 from os import environ, mkdir, path
 
@@ -371,6 +372,7 @@ class ItemPieChartDirective(TraceableBaseDirective):
          :targettype: <<relationship>> ...
          :splitsourcetype:
          :hidetitle:
+         :stats:
     """
     # Optional argument: title (whitespace allowed)
     optional_arguments = 1
@@ -384,6 +386,7 @@ class ItemPieChartDirective(TraceableBaseDirective):
         'targettype': directives.unchanged,
         'splitsourcetype': directives.flag,
         'hidetitle': directives.flag,
+        'stats': directives.flag,
     }
     # Content disallowed
     has_content = False
@@ -413,11 +416,16 @@ class ItemPieChartDirective(TraceableBaseDirective):
         self.check_relationships(node['targettype'], env)
         self.check_option_presence(node, 'splitsourcetype')
         self.check_option_presence(node, 'hidetitle')
+        self.check_option_presence(node, 'stats')
 
         if node['splitsourcetype'] and not node['sourcetype']:
             report_warning('item-piechart: The splitsourcetype flag must not be used when the sourcetype option is '
                            'unused; disabling splitsourcetype.', node['document'], node['line'])
             node['splitsourcetype'] = False
+
+        if not node['stats']:
+            warnings.warn('Pie chart statistics will not be displayed in mlx.traceability>=10 unless the stats flag '
+                          'is provided.', FutureWarning)
 
         return [node]
 


### PR DESCRIPTION
This PR adds a `stats` flag to the `item-piechart` directive, bringing it in line with other directives such as `item-matrix`.

For now, as requested in the discussion of #318, only a warning is produced in order to let users know of an impending change in the default behavior.

`warnings.warn` was preferred over `report_warning` to avoid outputting one warning per pie chart.