### PR TITLE
Add link type to the warning when target is missing

### DIFF
--- a/mlx/directives/item_relink_directive.py
+++ b/mlx/directives/item_relink_directive.py
@@ -39,7 +39,7 @@ class ItemRelink(TraceableBaseNode):
         if not reverse_type:
             report_warning(("Could not find reverse relationship type for type {!r} specified in "
                             "{!r} item-relink directive").format(forward_type, source_id),
-                            self['document'], self['line'])
+                           self['document'], self['line'])
             return
 
         affected_items = set()

--- a/mlx/directives/item_relink_directive.py
+++ b/mlx/directives/item_relink_directive.py
@@ -33,12 +33,12 @@ class ItemRelink(TraceableBaseNode):
         reverse_type = collection.get_reverse_relation(forward_type)
 
         if source is None:
-            report_warning("Could not find item {!r} specified in item-relink directive".format(source_id),
+            report_warning("Could not find item {!r} with type {!r} specified in item-relink directive".format(source_id, forward_type),
                            self['document'], self['line'])
             return
         if not reverse_type:
-            report_warning("Could not find reverse relationship type for type {!r} specified in item-relink directive"
-                           .format(forward_type), self['document'], self['line'])
+            report_warning("Could not find reverse relationship type for type {!r} specified in {!r} item-relink directive"
+                           .format(forward_type, source_id), self['document'], self['line'])
             return
 
         affected_items = set()

--- a/mlx/directives/item_relink_directive.py
+++ b/mlx/directives/item_relink_directive.py
@@ -33,12 +33,13 @@ class ItemRelink(TraceableBaseNode):
         reverse_type = collection.get_reverse_relation(forward_type)
 
         if source is None:
-            report_warning("Could not find item {!r} with type {!r} specified in item-relink directive".format(source_id, forward_type),
-                           self['document'], self['line'])
+            report_warning("Could not find item {!r} with type {!r} specified in item-relink directive"
+                           .format(source_id, forward_type), self['document'], self['line'])
             return
         if not reverse_type:
-            report_warning("Could not find reverse relationship type for type {!r} specified in {!r} item-relink directive"
-                           .format(forward_type, source_id), self['document'], self['line'])
+            report_warning(("Could not find reverse relationship type for type {!r} specified in "
+                            "{!r} item-relink directive").format(forward_type, source_id),
+                            self['document'], self['line'])
             return
 
         affected_items = set()


### PR DESCRIPTION
During debugging of some item-relink directives I discovered that it is hard to find which relink item is to blame for the error, so adding a type to the error message makes that more user friendly.