### PR TITLE
Add nooverwrite flag for item-relink and item-link to reduce amount of warnings

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -123,7 +123,7 @@ involved. In that case, you can use the ``item-link`` directive as follows:
 
 :nooverwrite: *optional*, *flag*
 
-    Do not report an error when existing value already matches.
+    Do not report a warning when the relationship to add between the target and new source already exists.
 
 .. note::
 
@@ -167,7 +167,7 @@ Example usage of the ``item-relink`` directive:
 
 :nooverwrite: *optional*, *flag*
 
-    Do not report an error when existing value already matches.
+    Do not report a warning when the relationship to add between the target and new source already exists.
 
 This directive has no representation in the documentation build output.
 

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -123,7 +123,7 @@ involved. In that case, you can use the ``item-link`` directive as follows:
 
 :nooverwrite: *optional*, *flag*
 
-    Do not report a warning when the relationship to add between the target and new source already exists.
+    Do not report a warning when the relationship to add between the source and target already exists.
 
 .. note::
 

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -143,6 +143,7 @@ Example usage of the ``item-relink`` directive:
         :remap: RQT-OLD_PROJECT
         :target: RQT-NEW_PROJECT
         :type: validates
+        :nooverwrite:
 
 :remap: *required*, *single argument*
 
@@ -158,6 +159,10 @@ Example usage of the ``item-relink`` directive:
 
     Relationship type, for which the values for the ``remap`` and ``target`` options are the target.
     The value must not be empty.
+
+:nooverwrite: *optional*, *flag*
+
+    Do not report an error when existing value already matches.
 
 This directive has no representation in the documentation build output.
 

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -96,6 +96,7 @@ involved. In that case, you can use the ``item-link`` directive as follows:
         :source: RQT\d
         :target: TST[345]
         :type: validates
+        :nooverwrite:
 
 :sources: *multiple arguments*, *mutually exclusive with* ``source``
 
@@ -119,6 +120,10 @@ involved. In that case, you can use the ``item-link`` directive as follows:
 
     Relationship type, used to link all source items to all target items.
     The value must not be empty.
+
+:nooverwrite: *optional*, *flag*
+
+    Do not report an error when existing value already matches.
 
 .. note::
 

--- a/mlx/directives/item_link_directive.py
+++ b/mlx/directives/item_link_directive.py
@@ -40,7 +40,8 @@ class ItemLink(TraceableBaseNode):
                 try:
                     collection.add_relation(source, self['type'], target)
                 except TraceabilityException as err:
-                    report_warning(err, self['document'], self['line'])
+                    if not self['nooverwrite']:
+                        report_warning(err, self['document'], self['line'])
 
 
 class ItemLinkDirective(TraceableBaseDirective):
@@ -55,6 +56,7 @@ class ItemLinkDirective(TraceableBaseDirective):
          :target: regexp
          :targets: list_of_items
          :type: relationship_type
+         :nooverwrite: flag
     """
     # Options
     option_spec = {
@@ -63,6 +65,7 @@ class ItemLinkDirective(TraceableBaseDirective):
         'target': directives.unchanged,
         'targets': directives.unchanged,
         'type': directives.unchanged,
+        'nooverwrite': directives.flag,
     }
     # Content disallowed
     has_content = False
@@ -97,6 +100,8 @@ class ItemLinkDirective(TraceableBaseDirective):
                 report_warning(f"item-link: expected exactly one of the following options but got {option_amount}: "
                                f"{mutually_exclusive_options}", env.docname, self.lineno)
                 process_options_success = False
+
+        self.check_option_presence(node, 'nooverwrite')
         if not process_options_success:
             return []
         env.traceability_collection.add_intermediate_node(node)


### PR DESCRIPTION
Same as for the attribute, we want to avoid a warning when existing relationship would be overwritten. This enables a bit more general usage of item-relink where items already containing correct links do not report warnings when they would be duplicated in project specific setting.