### PR TITLE
Don't ignore regexp in traceability_attributes for traceability_checklist feature

### DIFF
--- a/mlx/directives/item_relink_directive.py
+++ b/mlx/directives/item_relink_directive.py
@@ -71,7 +71,6 @@ class ItemRelink(TraceableBaseNode):
         for source_id in ItemRelink.source_ids:
             source = collection.get_item(source_id)
             if source.is_placeholder and not [targets for _, targets in source.all_relations if targets]:
-                print(f'poppingg {source_id}')
                 collection.items.pop(source_id)
 
 

--- a/mlx/traceability.py
+++ b/mlx/traceability.py
@@ -355,8 +355,7 @@ def add_checklist_attribute(checklist_config, attributes_config, attribute_to_st
         checklist_config['configured'] = False
     else:
         checklist_config['configured'] = True
-        if not checklist_config.get('checklist_item_regex'):
-            checklist_config['checklist_item_regex'] = r"\S+"
+        checklist_config['checklist_item_regex'] = checklist_config.get('checklist_item_regex', r"\S+")
 
         attr_values = checklist_config['attribute_values'].split(',')
         if len(attr_values) != 2:

--- a/mlx/traceability.py
+++ b/mlx/traceability.py
@@ -363,9 +363,12 @@ def add_checklist_attribute(checklist_config, attributes_config, attribute_to_st
             raise TraceabilityException("Checklist attribute values must be two comma-separated strings; got '{}'."
                                         .format(checklist_config['attribute_values']))
         else:
-            regexp = "({}|{})".format(attr_values[0], attr_values[1])
-            attributes_config[checklist_config['attribute_name']] = regexp
-            attribute_to_string_config[checklist_config['attribute_name']] = checklist_config['attribute_to_str']
+            attribute_name = checklist_config['attribute_name']
+            regexes = list(attr_values)
+            if attributes_config.get(attribute_name):
+                regexes.append(attributes_config[attribute_name])
+            attributes_config[attribute_name] = "({})".format("|".join(regexes))
+            attribute_to_string_config[attribute_name] = checklist_config['attribute_to_str']
             if checklist_config.get('api_host_name') and checklist_config.get('project_id') and \
                     checklist_config.get('merge_request_id'):
                 ChecklistItemDirective.query_results = query_checklist(checklist_config, attr_values)


### PR DESCRIPTION
For example, when `traceability_checklist['attribute_values'] = 'Yes,No'`, the only allowed values for that attribute were `Yes` and `No` even when `traceability_attributes` contains a regular expression. Let's not ignore that regular expression as there is a use case for this.