### PR TITLE
Define a fallback font for pie charts

### DIFF
--- a/mlx/directives/item_pie_chart_directive.py
+++ b/mlx/directives/item_pie_chart_directive.py
@@ -310,7 +310,7 @@ class ItemPieChart(TraceableBaseNode):
         Returns:
             (nodes.image) Image node containing the pie chart image.
         """
-        mpl.rcParams['font.sans-serif'] = 'Lato'
+        mpl.rcParams['font.sans-serif'] = ['Lato', 'DejaVu Sans']
         explode = self._get_explode_values(labels, self['label_set'])
         if not colors:
             colors = None


### PR DESCRIPTION
Lato is not always installed by default, so let's define `DejaVu Sans`, which ships with matplotlib, as the fallback font. Some versions of matplotlib generate the following warning many times when Lato is not found, which is annoying: `findfont: Generic family 'sans-serif' not found because none of the following families were found: Lato`

Closes #326 