### PR TITLE
Process attribute-link during consistency check event

### DIFF
--- a/doc/checklist.rst
+++ b/doc/checklist.rst
@@ -53,10 +53,6 @@ Checklist items
     The item ID is present in the queried PR description, but won't get the configured checklist-attribute added since
     it's defined with the regular *item* directive.
 
-.. attribute-link::
-    :filter: CL-
-    :asil: A
-
 ---------------------------
 Matrices of checklist items
 ---------------------------

--- a/doc/integration_test_report.rst
+++ b/doc/integration_test_report.rst
@@ -26,6 +26,11 @@ Other requirements
 .. attribute-sort::
     :sort: aspice nonexistent
 
+.. process attribute-link before rendering matrices
+.. attribute-link::
+    :filter: CL-
+    :asil: A
+
 .. triggers a warning about r003 already having a configuration for attribute-sort
 
 .. item:: r001 First requirement

--- a/mlx/directives/attribute_link_directive.py
+++ b/mlx/directives/attribute_link_directive.py
@@ -7,7 +7,7 @@ from mlx.traceable_base_node import TraceableBaseNode
 
 class AttributeLink(TraceableBaseNode):
     """Node that adds one or more attributes to one or more items."""
-    order = 1
+    order = 3
 
     def perform_replacement(self, app, collection):
         """ The AttributeLink node has no final representation, so it is removed from the tree.

--- a/mlx/directives/attribute_link_directive.py
+++ b/mlx/directives/attribute_link_directive.py
@@ -7,14 +7,21 @@ from mlx.traceable_base_node import TraceableBaseNode
 
 class AttributeLink(TraceableBaseNode):
     """Node that adds one or more attributes to one or more items."""
+    order = 1
 
     def perform_replacement(self, app, collection):
-        """ Processes the attribute-link items.
-
-        The AttributeLink node has no final representation, so it is removed from the tree.
+        """ The AttributeLink node has no final representation, so it is removed from the tree.
 
         Args:
             app: Sphinx application object to use.
+            collection (TraceableCollection): Collection for which to generate the nodes.
+        """
+        self.replace_self([])
+
+    def apply_effect(self, collection):
+        """ Processes the attribute-link items, which shall be done before converting anything to docutils.
+
+        Args:
             collection (TraceableCollection): Collection for which to generate the nodes.
         """
         filtered_items = collection.get_item_objects(self['filter'])
@@ -25,7 +32,6 @@ class AttributeLink(TraceableBaseNode):
                         item.add_attribute(attribute, value)
                     except TraceabilityException as err:
                         report_warning(err, self['document'], self['line'])
-        self.replace_self([])
 
 
 class AttributeLinkDirective(TraceableBaseDirective):
@@ -65,4 +71,5 @@ class AttributeLinkDirective(TraceableBaseDirective):
         self.add_found_attributes(node)
         self.check_option_presence(node, 'nooverwrite')
 
+        env.traceability_collection.add_intermediate_node(node)
         return [node]


### PR DESCRIPTION
This PR fixes #322 by shamelessly copying ab784f9a43e73bce35a827b2986a8a8dc77d8036 and applying it to the `attribute-link` directive.