### PR TITLE
Avoid sphinxcontrib.jquery==3.0.0 and enable plugin

### DIFF
--- a/mlx/traceability.py
+++ b/mlx/traceability.py
@@ -11,6 +11,7 @@ from re import fullmatch, match
 from os import path
 
 from requests import Session
+from sphinx import version_info as sphinx_version
 from sphinx.roles import XRefRole
 from sphinx.util.nodes import make_refnode
 from sphinx.errors import NoUri
@@ -471,6 +472,14 @@ def setup(app):
     app.add_js_file('https://cdn.rawgit.com/aexmachina/jquery-bonsai/master/jquery.bonsai.js')
     app.add_css_file('https://cdn.rawgit.com/aexmachina/jquery-bonsai/master/jquery.bonsai.css')
     app.add_js_file('traceability.js')
+
+    # Since Sphinx 6, jquery isn't bundled anymore and we need to ensure that
+    # the sphinxcontrib-jquery extension is enabled.
+    # See: https://dev.readthedocs.io/en/latest/design/sphinx-jquery.html
+    if sphinx_version >= (6, 0, 0):
+        # Documentation of Sphinx guarantees that an extension is added and enabled at most once.
+        # See: https://www.sphinx-doc.org/en/master/extdev/appapi.html#sphinx.application.Sphinx.setup_extension
+        app.setup_extension("sphinxcontrib.jquery")
 
     # Configuration for exporting collection to json
     app.add_config_value('traceability_json_export_path', None, 'env')

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ project_url = 'https://github.com/melexis/sphinx-traceability-extension'
 
 requires = [
     'Sphinx>=2.4.5,<7.0',
-    'sphinxcontrib.jquery>=2.0,<3.0',
+    'sphinxcontrib-jquery>=2.0.0,!=3.0.0',
     'docutils',
     'matplotlib<4.0',
     'natsort',

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ project_url = 'https://github.com/melexis/sphinx-traceability-extension'
 
 requires = [
     'Sphinx>=2.4.5,<7.0',
-    'sphinxcontrib-jquery>=3.0.0',
+    'sphinxcontrib.jquery>=2.0,<3.0',
     'docutils',
     'matplotlib<4.0',
     'natsort',


### PR DESCRIPTION
Fixes local doc builds after unreleased #333 

Explanation in https://github.com/readthedocs/sphinx_rtd_theme/pull/1421

We cannot rely on `sphinx-rtd-theme` to add the jQuery for us as other HTML themes may also be used, even though they aren't recommended.