### PR TITLE
Hide pie chart statistics unless stats flag is provided

### DIFF
--- a/doc/requirements.rst
+++ b/doc/requirements.rst
@@ -155,18 +155,21 @@ Test coverage
     :id_set: RQT [IU]TEST [IU]TEST_REP
     :label_set: not covered, covered
     :colors: orange c b
+    :stats:
 
 .. item-piechart:: Test coverage chart targeting UTEST and ITEST
     :id_set: RQT [IU]TEST [IU]TEST_REP
     :label_set: not covered, covered
     :colors: orange c b darkred green yellow
     :targettype: failed_by passed_by skipped_by
+    :stats:
 
 .. item-piechart:: Test coverage chart targeting ITEST only
     :id_set: RQT ITEST ITEST_REP
     :label_set: not covered, covered
     :colors: orange c b darkred green yellow
     :targettype: failed_by passed_by skipped_by
+    :stats:
 
 .. item-piechart:: Test coverage chart with test results, based on the :result: attribute
     :id_set: RQT [IU]TEST [IU]TEST_REP
@@ -175,11 +178,12 @@ Test coverage
     :label_set: uncovered, covered, has report
     :result: ERROR, fail, pass
     :colors: orange c b darkred #FF0000 g pink
+    :stats:
 
 ..
     uncovered: orange (orange)
     covered: c (cyan)
-    ran test: b (blue)
+    has report: b (blue)
     ERROR: darkred (dark red)
     fail: #FF0000 (red)
     pass: g (green)
@@ -190,6 +194,7 @@ Test coverage
     :sourcetype: validated_by
     :targettype: failed_by passed_by skipped_by
     :colors: orange c b r g y
+    :stats:
 
 .. item-piechart:: Test coverage chart with test results, based on the :targettype: option (in bad order)
     :id_set: RQT [IU]TEST [IU]TEST_REP
@@ -197,6 +202,7 @@ Test coverage
     :sourcetype: validated_by
     :targettype: skipped_by passed_by failed_by
     :colors: orange c b y g r
+    :stats:
 
 .. item-piechart:: Test cases as source using sourcetype to label with the :splitsourcetype: flag
     :id_set: [IU]TEST [IU]TEST_REP WAIVER
@@ -205,6 +211,7 @@ Test coverage
     :status: not implemented,
     :colors: orange black cyan r g y slategrey
     :splitsourcetype:
+    :stats:
 
 .. item-piechart:: All uncovered as the bad sourcetype results in 0 links
     :id_set: RQT [IU]TEST
@@ -222,3 +229,4 @@ Test coverage
 
 .. item-piechart:: Chart without any items: no image or warning shall be generated
     :id_set: NONEXISTENT [IU]TEST
+    :stats:

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -643,10 +643,6 @@ Pie chart of documentation items
 
 A pie chart of documentation items can be generated using:
 
-.. warning::
-
-    Starting from version 10.0.0, pie chart statistics will be hidden unless the *stats* flag is provided.
-
 .. code-block:: rest
 
     .. item-piechart:: Test coverage of requirements with report results

--- a/mlx/directives/item_pie_chart_directive.py
+++ b/mlx/directives/item_pie_chart_directive.py
@@ -1,5 +1,4 @@
 import re
-import warnings
 from hashlib import sha256
 from os import environ, mkdir, path
 
@@ -77,11 +76,15 @@ class ItemPieChart(TraceableBaseNode):
             report_warning("item-piechart contains {} slices: {} color(s) will be reused"
                            .format(len(data['labels']), len(data['labels']) - len(data['colors'])),
                            self['document'], self['line'])
-        p_node = nodes.paragraph()
-        p_node += nodes.Text(statistics)
+
         if data['labels']:
             top_node += self.build_pie_chart(data['sizes'], data['labels'], data['colors'], env)
-        top_node += p_node
+
+        if self['stats']:
+            p_node = nodes.paragraph()
+            p_node += nodes.Text(statistics)
+            top_node += p_node
+
         self.replace_self(top_node)
 
     def _relationships_to_labels(self, relationships):
@@ -422,10 +425,6 @@ class ItemPieChartDirective(TraceableBaseDirective):
             report_warning('item-piechart: The splitsourcetype flag must not be used when the sourcetype option is '
                            'unused; disabling splitsourcetype.', node['document'], node['line'])
             node['splitsourcetype'] = False
-
-        if not node['stats']:
-            warnings.warn('Pie chart statistics will not be displayed in mlx.traceability>=10 unless the stats flag '
-                          'is provided.', FutureWarning)
 
         return [node]
 


### PR DESCRIPTION
The `:stats:` flag was added in https://github.com/melexis/sphinx-traceability-extension/pull/323 (released in [v9.5.0](https://github.com/melexis/sphinx-traceability-extension/releases/tag/v9.5.0)) but did not yet have an effect because it was backwards incompatible. A warning was added to give users time to add this flag to any `item-piechart` directives they want to still display the statistics of.