### PR TITLE
Fix occasional failures of the workflow job test

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   test:
-
+    environment: doc-build
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
Reference environment 'doc-build' in workflow job 'test' so that the runner has access to its environment  secret `PRIVATE_TOKEN`, used by the feature `traceability_checklist` to read pull request descriptions via the GitLab API. The token has read-only access to public repositories. It should prevent the following warning to occur in CI: https://github.com/melexis/sphinx-traceability-extension/actions/runs/4242099484/jobs/7373166172#step:6:496