### PR TITLE
Support disabling traceability_checklist

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -834,6 +834,7 @@ GitLab
 - *GIT_PLATFORM* shall be 'gitlab' if API_HOST_NAME does not contain this string
 - *PROJECT_ID* is the ID or `URL-encoded path of the project`_.
 - *MERGE_REQUEST_ID* are one or more internal IDs of merge requests (comma-separated) ordered from low to high priority. The data gets aggregated.
+  Can be an empty string to avoid sending any query.
 
 
 GitHub
@@ -843,6 +844,7 @@ GitHub
 - *GIT_PLATFORM* shall be 'github' if API_HOST_NAME does not contain this string
 - *PROJECT_ID* defines the repository by specifying *owner* and *repo* separated by a forward slash, e.g. *melexis/sphinx-traceability-extension*.
 - *MERGE_REQUEST_ID* are one or more pull request numbers (comma-separated) ordered from low to high priority. The data gets aggregated.
+  Can be an empty string to avoid sending any query.
 
 .. _`URL-encoded path of the project`: https://docs.gitlab.com/ee/api/index.html#namespaced-path-encoding
 .. _`personal access token`: https://github.blog/2013-05-16-personal-api-tokens/

--- a/mlx/traceability.py
+++ b/mlx/traceability.py
@@ -418,7 +418,7 @@ def query_checklist(settings, attr_values):
         return {}
     query_results = {}
     with Session() as session:
-        for merge_request_id in str(settings['merge_request_id']).split(','):
+        for merge_request_id in [id_ for id_ in str(settings['merge_request_id']).split(',') if id_]:
             url = base_url + merge_request_id.strip()
             try:
                 with session.get(url, headers=headers) as response:


### PR DESCRIPTION
Sometimes when building documentation you don't care about the effect that the feature [`traceability_checklist`](https://melexis.github.io/sphinx-traceability-extension/usage.html#defining-items-with-a-custom-checklist-attribute-advanced) has and you don't want mlx.traceability to send a query GitLab/GitHub, e.g. when you don't have internet access.

The changes in this PR allow you to configure `traceability_checklist['merge_request_id'] = ''` so that mlx.traceability does not send a query (instead of an invalid one).