### PR TITLE
Check traceability_relationship_to_string for completeness

### DIFF
--- a/mlx/traceability.py
+++ b/mlx/traceability.py
@@ -317,6 +317,12 @@ def initialize_environment(app):
     env.traceability_collection = TraceableCollection()
     env.traceability_ref_nodes = {}
 
+    for rel1, rel2 in app.config.traceability_relationships.items():
+        for rel in (rel1, rel2):
+            if rel and rel not in app.config.traceability_relationship_to_string:
+                raise TraceabilityException(f"Relationship {rel!r} is missing from configuration variable "
+                                            "`traceability_relationships`")
+
     app.config.traceability_checklist['has_checklist_items'] = False
     add_checklist_attribute(app.config.traceability_checklist,
                             app.config.traceability_attributes,

--- a/mlx/traceability.py
+++ b/mlx/traceability.py
@@ -317,11 +317,12 @@ def initialize_environment(app):
     env.traceability_collection = TraceableCollection()
     env.traceability_ref_nodes = {}
 
-    for rel1, rel2 in app.config.traceability_relationships.items():
-        for rel in (rel1, rel2):
-            if rel and rel not in app.config.traceability_relationship_to_string:
-                raise TraceabilityException(f"Relationship {rel!r} is missing from configuration variable "
-                                            "`traceability_relationships`")
+    all_relationships = set(app.config.traceability_relationships).union(app.config.traceability_relationships.values())
+    all_relationships.discard('')
+    undefined_stringifications = all_relationships.difference(app.config.traceability_relationship_to_string)
+    if undefined_stringifications:
+        raise TraceabilityException(f"Relationships {undefined_stringifications!r} are missing from configuration "
+                                    "variable `traceability_relationships`")
 
     app.config.traceability_checklist['has_checklist_items'] = False
     add_checklist_attribute(app.config.traceability_checklist,


### PR DESCRIPTION
Check config variable `traceability_relationship_to_string` for completeness, aborting the doc build during initialization if a relationship defined in `traceability_relationships` is missing from it.

Closes #344