### PR TITLE
Support natural sorting on attributes

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -416,8 +416,8 @@ The plugin itself holds a default config that can be used for any traceability d
         'assignee': 'Assignee',
         'effort': 'Effort estimation',
     }
-    traceability_attributes_natsort = {
-        'effort',
+    traceability_attributes_sort = {
+        'effort': natsort.natsorted,
     }
     traceability_relationships = {
         'fulfills': 'fulfilled_by',

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -416,6 +416,9 @@ The plugin itself holds a default config that can be used for any traceability d
         'assignee': 'Assignee',
         'effort': 'Effort estimation',
     }
+    traceability_attributes_natsort = {
+        'effort',
+    }
     traceability_relationships = {
         'fulfills': 'fulfilled_by',
         'depends_on': 'impacts_on',

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -73,7 +73,7 @@ Example of attribute stringification:
 Valid relationships
 -------------------
 
-Python variable *traceability_relationsips* can be defined in order to override the
+Python variable *traceability_relationships* can be defined in order to override the
 default configuration of the traceability plugin.
 It is a *dictionary* of relationship pairs: the *key* is the name of the forward relationship, while the *value* holds
 the name of the corresponding reverse relationship. Both can only be lowercase.

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -326,7 +326,9 @@ to hide the item IDs, set the *onlycaptions* flag instead.
 
 By default, items are sorted naturally based on their name. With the *sort* argument it is possible to sort on one
 or more attribute values alphabetically. When providing multiple attributes to sort on, the attribute keys are
-space-separated. With the *reverse* argument, the sorting is reversed.
+space-separated. With the *reverse* argument, the sorting is reversed. If you want natural instead of alphabetical
+sorting on attribute values, add one or more attribute keys to the configuration value
+*traceability_attributes_natsort* (see :ref:`traceability_default_config`).
 
 By default, the attribute names are listed the header row and every item takes up a row. Depending on the number of
 items and attributes it could be better to transpose the generated matrix (swap columns for row) by providing the

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -324,8 +324,8 @@ By default, the caption for every item in the table is shown. By providing the *
 caption can be omitted. This gives a smaller table, but also less details. If you only care about the captions and want
 to hide the item IDs, set the *onlycaptions* flag instead.
 
-By default, items are sorted naturally based on their name. With the *sort* argument it is possible to naturally sort
-on one or more attribute values. When providing multiple attributes to sort on, the attribute keys are
+By default, items are sorted naturally based on their name. With the *sort* argument it is possible to sort on one
+or more attribute values alphabetically. When providing multiple attributes to sort on, the attribute keys are
 space-separated. With the *reverse* argument, the sorting is reversed.
 
 By default, the attribute names are listed the header row and every item takes up a row. Depending on the number of

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -326,9 +326,8 @@ to hide the item IDs, set the *onlycaptions* flag instead.
 
 By default, items are sorted naturally based on their name. With the *sort* argument it is possible to sort on one
 or more attribute values alphabetically. When providing multiple attributes to sort on, the attribute keys are
-space-separated. With the *reverse* argument, the sorting is reversed. If you want natural instead of alphabetical
-sorting on attribute values, add one or more attribute keys to the configuration value
-*traceability_attributes_natsort* (see :ref:`traceability_default_config`).
+space-separated. With the *reverse* argument, the sorting is reversed. Instead of the default sort order (alphabetical),
+you can configure a custom sort order per attribute, (see :ref:`traceability_default_config`).
 
 By default, the attribute names are listed the header row and every item takes up a row. Depending on the number of
 items and attributes it could be better to transpose the generated matrix (swap columns for row) by providing the

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -324,8 +324,8 @@ By default, the caption for every item in the table is shown. By providing the *
 caption can be omitted. This gives a smaller table, but also less details. If you only care about the captions and want
 to hide the item IDs, set the *onlycaptions* flag instead.
 
-By default, items are sorted naturally based on their name. With the *sort* argument it is possible to sort on one
-or more attribute values alphabetically. When providing multiple attributes to sort on, the attribute keys are
+By default, items are sorted naturally based on their name. With the *sort* argument it is possible to naturally sort
+on one or more attribute values. When providing multiple attributes to sort on, the attribute keys are
 space-separated. With the *reverse* argument, the sorting is reversed.
 
 By default, the attribute names are listed the header row and every item takes up a row. Depending on the number of

--- a/mlx/traceability.py
+++ b/mlx/traceability.py
@@ -7,16 +7,17 @@ Sphinx extension for reStructuredText that added traceable documentation items.
 See readme for more details.
 """
 from collections import namedtuple
-from re import fullmatch, match
 from os import path
+from re import fullmatch, match
 
-from requests import Session
-from sphinx import version_info as sphinx_version
-from sphinx.roles import XRefRole
-from sphinx.util.nodes import make_refnode
-from sphinx.errors import NoUri
+import natsort
 from docutils import nodes
 from docutils.parsers.rst import directives
+from requests import Session
+from sphinx import version_info as sphinx_version
+from sphinx.errors import NoUri
+from sphinx.roles import XRefRole
+from sphinx.util.nodes import make_refnode
 
 from mlx.__traceability_version__ import version
 from mlx.traceable_attribute import TraceableAttribute
@@ -315,7 +316,7 @@ def initialize_environment(app):
     # generates placeholders when parsing the reverse relationships, the
     # database of items needs to be empty on every re-build.
     env.traceability_collection = TraceableCollection()
-    env.traceability_collection.attributes_natsort = app.config.traceability_attributes_natsort
+    env.traceability_collection.attributes_sort = app.config.traceability_attributes_sort
     env.traceability_ref_nodes = {}
 
     all_relationships = set(app.config.traceability_relationships).union(app.config.traceability_relationships.values())
@@ -534,11 +535,11 @@ def setup(app):
         'env',
     )
 
-    # Set of attributes to sort naturally on instead of alphabetically in item-attributes-matrix
+    # Configuration for custom sort orders for sorting on attribute in item-attributes-matrix (default is alphabetical)
     app.add_config_value(
-        'traceability_attributes_natsort',
+        'traceability_attributes_sort',
         {
-            'effort',
+            'effort': natsort.natsorted,
         },
         'env',
     )

--- a/mlx/traceability.py
+++ b/mlx/traceability.py
@@ -315,6 +315,7 @@ def initialize_environment(app):
     # generates placeholders when parsing the reverse relationships, the
     # database of items needs to be empty on every re-build.
     env.traceability_collection = TraceableCollection()
+    env.traceability_collection.attributes_natsort = app.config.traceability_attributes_natsort
     env.traceability_ref_nodes = {}
 
     all_relationships = set(app.config.traceability_relationships).union(app.config.traceability_relationships.values())
@@ -529,6 +530,15 @@ def setup(app):
             'effort': 'Effort estimation',
             'non_functional': 'Non-functional',
             'functional': 'Functional',
+        },
+        'env',
+    )
+
+    # Configuration for defining which attributes to sort naturally instead of alphabetically in item-attributes-matrix
+    app.add_config_value(
+        'traceability_attributes_natsort',
+        {
+            'effort',
         },
         'env',
     )

--- a/mlx/traceability.py
+++ b/mlx/traceability.py
@@ -534,7 +534,7 @@ def setup(app):
         'env',
     )
 
-    # Configuration for defining which attributes to sort naturally instead of alphabetically in item-attributes-matrix
+    # Set of attributes to sort naturally on instead of alphabetically in item-attributes-matrix
     app.add_config_value(
         'traceability_attributes_natsort',
         {

--- a/mlx/traceable_collection.py
+++ b/mlx/traceable_collection.py
@@ -25,6 +25,7 @@ class TraceableCollection:
         self.items = {}
         self.relations_sorted = {}
         self._intermediate_nodes = []
+        self.attributes_natsort = set()
 
     def add_relation_pair(self, forward, reverse=NO_RELATION_STR):
         '''
@@ -298,7 +299,8 @@ class TraceableCollection:
         Args:
             regex (str/re.Pattern): Regex pattern or object to match the items in this collection against
             attributes (dict): Dictionary with attribute-regex pairs to match the items in this collection against
-            sortattributes (list): List of attributes on which to alphabetically sort the items
+            sortattributes (list): List of attributes on which to sort the items alphabetically, or naturally if
+                at least one attribute is in ``attributes_natsort``
             reverse (bool): True for reverse sorting
             sort (bool): When sortattributes is falsy: True to enable natural sorting, False to disable sorting
 
@@ -313,8 +315,12 @@ class TraceableCollection:
             if item.is_match(regex) and (not attributes or item.attributes_match(attributes)):
                 matches.append(itemid)
         if sortattributes:
-            return sorted(matches, key=lambda itemid: self.get_item(itemid).get_attributes(sortattributes),
-                          reverse=reverse)
+            if set(sortattributes).intersection(self.attributes_natsort):
+                sorted_func = natsorted
+            else:
+                sorted_func = sorted
+            return sorted_func(matches, key=lambda itemid: self.get_item(itemid).get_attributes(sortattributes),
+                               reverse=reverse)
         elif sort:
             return natsorted(matches, reverse=reverse)
         return matches

--- a/mlx/traceable_collection.py
+++ b/mlx/traceable_collection.py
@@ -25,7 +25,7 @@ class TraceableCollection:
         self.items = {}
         self.relations_sorted = {}
         self._intermediate_nodes = []
-        self.attributes_natsort = set()
+        self.attributes_sort = {}
 
     def add_relation_pair(self, forward, reverse=NO_RELATION_STR):
         '''
@@ -299,8 +299,8 @@ class TraceableCollection:
         Args:
             regex (str/re.Pattern): Regex pattern or object to match the items in this collection against
             attributes (dict): Dictionary with attribute-regex pairs to match the items in this collection against
-            sortattributes (list): List of attributes on which to sort the items alphabetically, or naturally if
-                at least one attribute is in ``attributes_natsort``
+            sortattributes (list): List of attributes on which to sort the items alphabetically, or using a custom
+                sort order if at least one attribute is in ``attributes_sort``
             reverse (bool): True for reverse sorting
             sort (bool): When sortattributes is falsy: True to enable natural sorting, False to disable sorting
 
@@ -315,8 +315,10 @@ class TraceableCollection:
             if item.is_match(regex) and (not attributes or item.attributes_match(attributes)):
                 matches.append(itemid)
         if sortattributes:
-            if set(sortattributes).intersection(self.attributes_natsort):
-                sorted_func = natsorted
+            for attr in sortattributes:
+                if attr in self.attributes_sort:
+                    sorted_func = self.attributes_sort[attr]
+                    break
             else:
                 sorted_func = sorted
             return sorted_func(matches, key=lambda itemid: self.get_item(itemid).get_attributes(sortattributes),

--- a/mlx/traceable_collection.py
+++ b/mlx/traceable_collection.py
@@ -298,7 +298,7 @@ class TraceableCollection:
         Args:
             regex (str/re.Pattern): Regex pattern or object to match the items in this collection against
             attributes (dict): Dictionary with attribute-regex pairs to match the items in this collection against
-            sortattributes (list): List of attributes on which to alphabetically sort the items
+            sortattributes (list): List of attributes on which to naturally sort the items
             reverse (bool): True for reverse sorting
             sort (bool): When sortattributes is falsy: True to enable natural sorting, False to disable sorting
 
@@ -313,8 +313,8 @@ class TraceableCollection:
             if item.is_match(regex) and (not attributes or item.attributes_match(attributes)):
                 matches.append(itemid)
         if sortattributes:
-            return sorted(matches, key=lambda itemid: self.get_item(itemid).get_attributes(sortattributes),
-                          reverse=reverse)
+            return natsorted(matches, key=lambda itemid: self.get_item(itemid).get_attributes(sortattributes),
+                             reverse=reverse)
         elif sort:
             return natsorted(matches, reverse=reverse)
         return matches

--- a/mlx/traceable_collection.py
+++ b/mlx/traceable_collection.py
@@ -298,7 +298,7 @@ class TraceableCollection:
         Args:
             regex (str/re.Pattern): Regex pattern or object to match the items in this collection against
             attributes (dict): Dictionary with attribute-regex pairs to match the items in this collection against
-            sortattributes (list): List of attributes on which to naturally sort the items
+            sortattributes (list): List of attributes on which to alphabetically sort the items
             reverse (bool): True for reverse sorting
             sort (bool): When sortattributes is falsy: True to enable natural sorting, False to disable sorting
 
@@ -313,8 +313,8 @@ class TraceableCollection:
             if item.is_match(regex) and (not attributes or item.attributes_match(attributes)):
                 matches.append(itemid)
         if sortattributes:
-            return natsorted(matches, key=lambda itemid: self.get_item(itemid).get_attributes(sortattributes),
-                             reverse=reverse)
+            return sorted(matches, key=lambda itemid: self.get_item(itemid).get_attributes(sortattributes),
+                          reverse=reverse)
         elif sort:
             return natsorted(matches, reverse=reverse)
         return matches

--- a/tests/test_traceable_collection.py
+++ b/tests/test_traceable_collection.py
@@ -1,6 +1,8 @@
 from unittest import TestCase
 from unittest.mock import patch, mock_open
 
+from natsort import natsorted
+
 import mlx.traceable_item as item
 import mlx.traceable_attribute as attribute
 import mlx.traceability_exception as exception
@@ -325,7 +327,7 @@ class TestTraceableCollection(TestCase):
         # Alphabetical sorting on attributes: 0x0029 before 0x003A
         self.assertEqual([name1, name2], coll.get_items('', sortattributes=[self.attribute_key]))
         # Natural sorting: 0x003A before 0x0029
-        coll.attributes_natsort.add(self.attribute_key)
+        coll.attributes_sort.update({self.attribute_key: natsorted})
         self.assertEqual([name2, name1], coll.get_items('', sortattributes=[self.attribute_key]))
         # Natural sorting on items: z2 before z11
         self.assertEqual([name2, name1], coll.get_items(''))

--- a/tests/test_traceable_collection.py
+++ b/tests/test_traceable_collection.py
@@ -323,15 +323,12 @@ class TestTraceableCollection(TestCase):
         item1.add_attribute(self.attribute_key, '0x0029')
         item2.add_attribute(self.attribute_key, '0x003A')
         # Alphabetical sorting on attributes: 0x0029 before 0x003A
-        self.assertEqual(item1.get_id(), coll.get_items('', sortattributes=[self.attribute_key])[0])
-        self.assertEqual(item2.get_id(), coll.get_items('', sortattributes=[self.attribute_key])[1])
+        self.assertEqual([name1, name2], coll.get_items('', sortattributes=[self.attribute_key]))
         # Natural sorting: 0x003A before 0x0029
         coll.attributes_natsort.add(self.attribute_key)
-        self.assertEqual(item1.get_id(), coll.get_items('', sortattributes=[self.attribute_key])[1])
-        self.assertEqual(item2.get_id(), coll.get_items('', sortattributes=[self.attribute_key])[0])
+        self.assertEqual([name2, name1], coll.get_items('', sortattributes=[self.attribute_key]))
         # Natural sorting on items: z2 before z11
-        self.assertEqual(item2.get_id(), coll.get_items('')[0])
-        self.assertEqual(item1.get_id(), coll.get_items('')[1])
+        self.assertEqual([name2, name1], coll.get_items(''))
 
     def test_related(self):
         coll = dut.TraceableCollection()

--- a/tests/test_traceable_collection.py
+++ b/tests/test_traceable_collection.py
@@ -322,10 +322,14 @@ class TestTraceableCollection(TestCase):
         dut.TraceableItem.define_attribute(attr)
         item1.add_attribute(self.attribute_key, '0x0029')
         item2.add_attribute(self.attribute_key, '0x003A')
-        # Alphabetical sorting: 0x0029 before 0x003A
+        # Alphabetical sorting on attributes: 0x0029 before 0x003A
         self.assertEqual(item1.get_id(), coll.get_items('', sortattributes=[self.attribute_key])[0])
         self.assertEqual(item2.get_id(), coll.get_items('', sortattributes=[self.attribute_key])[1])
-        # Natural sorting: z2 before z11
+        # Natural sorting: 0x003A before 0x0029
+        coll.attributes_natsort.add(self.attribute_key)
+        self.assertEqual(item1.get_id(), coll.get_items('', sortattributes=[self.attribute_key])[1])
+        self.assertEqual(item2.get_id(), coll.get_items('', sortattributes=[self.attribute_key])[0])
+        # Natural sorting on items: z2 before z11
         self.assertEqual(item2.get_id(), coll.get_items('')[0])
         self.assertEqual(item1.get_id(), coll.get_items('')[1])
 

--- a/tox.ini
+++ b/tox.ini
@@ -35,10 +35,8 @@ deps=
     pytest
     pytest-cov
     coverage
-    reportlab
     natsort
     matplotlib
-    sphinx-testing >= 0.5.2
     sphinx_selective_exclude>=1.0.3
     sphinx_rtd_theme<2.0.0
     parameterized
@@ -70,7 +68,7 @@ deps=
     markupsafe == 1.1.0
     sphinx == 2.4.5  # rq.filter: ==2.4.5
     sphinxcontrib-plantuml
-    mlx.warnings >= 1.3.0
+    mlx.warnings >= 4.3.2
 whitelist_externals =
     make
     tee
@@ -84,7 +82,7 @@ deps=
     {[testenv]deps}
     sphinx<7.0
     sphinxcontrib-plantuml
-    mlx.warnings >= 1.3.0
+    mlx.warnings >= 4.3.2
 whitelist_externals =
     make
     tee

--- a/tox.ini
+++ b/tox.ini
@@ -58,7 +58,10 @@ commands =
     python setup.py sdist
     twine check dist/*
     check-manifest {toxinidir} -u
-    flake8 mlx tests setup.py --per-file-ignores mlx/directives/item_pie_chart_directive.py:E402
+    flake8 mlx tests setup.py --per-file-ignores '\
+        mlx/directives/item_pie_chart_directive.py:E402 \
+        mlx/__traceability_version__.py:F401 \
+        '
 
 [testenv:sphinx2.4.5]
 deps=


### PR DESCRIPTION
Closes #354

The option `:sort:` of the `item-attributes-matrix` sorts items on attribute values alphabetically. This is good and desired as the default behavior.

A use case for [natural sorting](https://en.wikipedia.org/wiki/Natural_sort_order) on attribute values came up. For example, sorting on values of the attribute `effort` like `11d` and `5d`. 

This PR adds a new configuration value ``traceability_attributes_natsort = {"effort"}``. Any item-attributes-matrix that contains the `effort` attribute will sort on attribute values naturally.
This default value can be overridden in conf.py like all other configuration values.