### PR TITLE
Deprecate non-pythonic code

### DIFF
--- a/mlx/traceability_exception.py
+++ b/mlx/traceability_exception.py
@@ -34,12 +34,6 @@ class MultipleTraceabilityExceptions(Exception):
         '''Iterate over multiple exceptions'''
         yield from self.errors
 
-    def iter(self):
-        '''Iterator for multiple exceptions'''
-        report_warning("MultipleTraceabilityExceptions.iter() will be removed in version 10.x: "
-                       "you can now loop over an instance of this class directly")
-        return self.errors
-
 
 class TraceabilityException(Exception):
     '''
@@ -55,14 +49,3 @@ class TraceabilityException(Exception):
         '''
         super().__init__(message)
         self.docname = docname
-
-    def get_document(self):
-        '''
-        Get document in which error occurred
-
-        Returns:
-            str: The name of the document in which the error occurred
-        '''
-        report_warning("TraceabilityException.get_document() will be removed in version 10.x in favor of "
-                       "TraceabilityException.docname", docname=self.docname)
-        return self.docname

--- a/mlx/traceable_base_class.py
+++ b/mlx/traceable_base_class.py
@@ -8,7 +8,7 @@ from docutils import nodes
 from docutils.statemachine import ViewList
 from sphinx.util.nodes import nested_parse_with_titles
 
-from mlx.traceability_exception import report_warning, TraceabilityException
+from mlx.traceability_exception import TraceabilityException
 
 
 class TraceableBaseClass:

--- a/mlx/traceable_base_class.py
+++ b/mlx/traceable_base_class.py
@@ -34,12 +34,6 @@ class TraceableBaseClass:
         self.content_node = nodes.block_quote()
         self._state = state
 
-    @property
-    def id(self):
-        report_warning("TraceableBaseClass.id will be removed in version 10.x in favor of "
-                       "TraceableBaseClass.identifier", docname=self.docname, lineno=self.lineno)
-        return self.identifier
-
     @staticmethod
     def to_id(identifier):
         '''
@@ -73,61 +67,6 @@ class TraceableBaseClass:
         if other.content is not None:
             self.content = other.content
 
-    def get_id(self):
-        '''
-        Getter for identification
-
-        Returns:
-            str: identification
-        '''
-        report_warning("TraceableBaseClass.get_id() will be removed in version 10.x in favor of "
-                       "TraceableBaseClass.identifier", docname=self.docname, lineno=self.lineno)
-        return self.identifier
-
-    def set_name(self, name):
-        '''
-        Set readable name
-
-        Args:
-            name (str): Short name
-        '''
-        report_warning("TraceableBaseClass.set_name() will be removed in version 10.x: "
-                       "set TraceableBaseClass.name directly instead", docname=self.docname, lineno=self.lineno)
-        self.name = name
-
-    def get_name(self):
-        '''
-        Get readable name
-
-        Returns:
-            str: Short name
-        '''
-        report_warning("TraceableBaseClass.get_name() will be removed in version 10.x in favor of "
-                       "TraceableBaseClass.name", docname=self.docname, lineno=self.lineno)
-        return self.name
-
-    def set_caption(self, caption):
-        '''
-        Set caption
-
-        Args:
-            caption (str): Short caption
-        '''
-        report_warning("TraceableBaseClass.set_caption() will be removed in version 10.x: "
-                       "set TraceableBaseClass.caption directly instead", docname=self.docname, lineno=self.lineno)
-        self.caption = caption
-
-    def get_caption(self):
-        '''
-        Get caption
-
-        Returns:
-            str: Short caption
-        '''
-        report_warning("TraceableBaseClass.get_caption() will be removed in version 10.x in favor of "
-                       "TraceableBaseClass.caption", docname=self.docname, lineno=self.lineno)
-        return self.caption
-
     def set_location(self, docname, lineno=0):
         '''
         Set location in document
@@ -138,40 +77,6 @@ class TraceableBaseClass:
         '''
         self.docname = docname
         self.lineno = lineno
-
-    def set_document(self, docname, lineno=0):
-        '''
-        Set location in document
-
-        Args:
-            docname (str): Path to docname
-            lineno (int): Line number in given document
-        '''
-        self.set_location(docname, lineno=lineno)
-        report_warning("TraceableBaseClass.set_document() will be removed in version 10.x: "
-                       "use TraceableBaseClass.set_location() instead", docname=self.docname, lineno=self.lineno)
-
-    def get_document(self):
-        '''
-        Get location in document
-
-        Returns:
-            str: Path to docname
-        '''
-        report_warning("TraceableBaseClass.get_document() will be removed in version 10.x in favor of "
-                       "TraceableBaseClass.docname", docname=self.docname, lineno=self.lineno)
-        return self.docname
-
-    def get_line_number(self):
-        '''
-        Get line number in document
-
-        Returns:
-            int: Line number in given document
-        '''
-        report_warning("TraceableBaseClass.get_line_number() will be removed in version 10.x in favor of "
-                       "TraceableBaseClass.lineno", docname=self.docname, lineno=self.lineno)
-        return self.lineno
 
     @property
     def content(self):
@@ -186,50 +91,6 @@ class TraceableBaseClass:
                 template.append(line, self.docname, idx)
             self.content_node = nodes.block_quote()  # reset
             nested_parse_with_titles(self._state, template, self.content_node)
-
-    def set_content(self, content):
-        '''
-        Set content of the item
-
-        Args:
-            content (str): Content of the item
-        '''
-        self.content = content
-        report_warning("TraceableBaseClass.set_content() will be removed in version 10.x: "
-                       "set TraceableBaseClass.content directly instead", docname=self.docname, lineno=self.lineno)
-
-    def get_content(self):
-        '''
-        Get content of the item
-
-        Returns:
-            str: Content of the item
-        '''
-        report_warning("TraceableBaseClass.get_content() will be removed in version 10.x in favor of "
-                       "TraceableBaseClass.content", docname=self.docname, lineno=self.lineno)
-        return self.content
-
-    def bind_node(self, node):
-        '''
-        Bind to node
-
-        Args:
-            node (node): Docutils node object
-        '''
-        report_warning("TraceableBaseClass.bind_node() will be removed in version 10.x: "
-                       "set TraceableBaseClass.node directly instead", docname=self.docname, lineno=self.lineno)
-        self.node = node
-
-    def get_node(self):
-        '''
-        Get the node to which the object is bound
-
-        Returns:
-            node: Docutils node object
-        '''
-        report_warning("TraceableBaseClass.get_node() will be removed in version 10.x in favor of "
-                       "TraceableBaseClass.node", docname=self.docname, lineno=self.lineno)
-        return self.node
 
     def clear_state(self):
         '''

--- a/mlx/traceable_base_directive.py
+++ b/mlx/traceable_base_directive.py
@@ -43,19 +43,6 @@ class TraceableBaseDirective(Directive, ABC):
             return self.arguments[1].replace('\n', ' ')
         return ''
 
-    def get_caption(self):
-        """ Gets the item's caption.
-
-        Item caption is the text following the mandatory id argument. Caption should be considered a to be line of text.
-        Remove line breaks.
-
-        Returns:
-            (str) Formatted caption.
-        """
-        report_warning("TraceableBaseDirective.get_caption() will be removed in version 10.x in favor of "
-                       "TraceableBaseDirective.caption")
-        return self.caption
-
     def add_found_attributes(self, node, is_pattern=False):
         """ Adds found attributes to node. Attribute data is a single string.
 

--- a/tests/test_traceable_base_class.py
+++ b/tests/test_traceable_base_class.py
@@ -2,7 +2,6 @@ from unittest import TestCase
 
 from docutils import nodes
 
-import mlx.traceability_exception as exception
 import mlx.traceable_base_class as dut
 
 

--- a/tests/test_traceable_base_class.py
+++ b/tests/test_traceable_base_class.py
@@ -1,5 +1,7 @@
 from unittest import TestCase
 
+from docutils import nodes
+
 import mlx.traceability_exception as exception
 import mlx.traceable_base_class as dut
 
@@ -11,59 +13,21 @@ class TestTraceableBaseClass(TestCase):
 
     def test_init(self):
         item = dut.TraceableBaseClass(self.identification)
-        item.set_document(self.docname)
+        item.set_location(self.docname)
         item.self_test()
-        self.assertEqual(self.identification, item.get_id())
-        self.assertIsNotNone(item.get_document())
-        self.assertEqual(0, item.get_line_number())
-        self.assertEqual(self.identification, item.get_name())
-        self.assertIsNone(item.get_node())
-        self.assertIsNone(item.get_caption())
-        self.assertIsNone(item.get_content())
+        self.assertEqual(self.identification, item.identifier)
+        self.assertEqual(0, item.lineno)
+        self.assertEqual(self.identification, item.name)
+        self.assertIsNone(item.node)
+        self.assertIsNone(item.caption)
+        self.assertIsNone(item.content)
+        self.assertEqual(str(nodes.block_quote()), str(item.content_node))
 
-    def test_set_name(self):
-        item = dut.TraceableBaseClass(self.identification)
-        item.set_name(self.name)
-        self.assertEqual(self.name, item.get_name())
-
-    def test_set_document(self):
-        item = dut.TraceableBaseClass(self.identification)
-        with self.assertRaises(exception.TraceabilityException):
-            item.self_test()
-        item.set_document('some-file.rst', 888)
-        self.assertEqual('some-file.rst', item.get_document())
-        self.assertEqual(888, item.get_line_number())
-        item.self_test()
-
-    def test_bind_node(self):
-        item = dut.TraceableBaseClass(self.identification)
-        item.set_document(self.docname)
-        node = object()
-        item.bind_node(node)
-        self.assertEqual(node, item.get_node())
-        item.self_test()
-
-    def test_set_caption(self):
-        txt = 'some short description'
-        item = dut.TraceableBaseClass(self.identification)
-        item.set_document(self.docname)
-        item.set_caption(txt)
-        self.assertEqual(txt, item.get_caption())
-        # Verify dict
-        data = item.to_dict()
-        self.assertEqual(self.identification, data['id'])
-        self.assertEqual(txt, data['caption'])
-        self.assertEqual(self.docname, data['document'])
-        self.assertEqual(0, data['line'])
-        self.assertEqual("0", data['content-hash'])
-        item.self_test()
-
-    def test_set_content(self):
+    def test_to_dict(self):
         txt = 'some description, with\n newlines and other stuff'
         item = dut.TraceableBaseClass(self.identification)
-        item.set_document(self.docname)
-        item.set_content(txt)
-        self.assertEqual(txt, item.get_content())
+        item.set_location(self.docname)
+        item.content = txt
         data = item.to_dict()
         self.assertEqual("b787a17fc91c9cf37b5bf0665f13c8b1", data['content-hash'])
         item.self_test()

--- a/tests/test_traceable_collection.py
+++ b/tests/test_traceable_collection.py
@@ -72,7 +72,7 @@ class TestTraceableCollection(TestCase):
         self.assertNotIn(self.identification_tgt, item_iterator)
         # Add an item
         item1 = item.TraceableItem(self.identification_src)
-        item1.set_document(self.docname)
+        item1.set_location(self.docname)
         coll.add_item(item1)
         self.assertTrue(coll.has_item(self.identification_src))
         self.assertEqual(item1, coll.get_item(self.identification_src))
@@ -85,7 +85,7 @@ class TestTraceableCollection(TestCase):
         # Add a second item, make sure first one is still there
         self.assertFalse(coll.has_item(self.identification_tgt))
         item2 = item.TraceableItem(self.identification_tgt)
-        item2.set_document(self.docname)
+        item2.set_location(self.docname)
         coll.add_item(item2)
         self.assertTrue(coll.has_item(self.identification_tgt))
         self.assertEqual(item2, coll.get_item(self.identification_tgt))
@@ -101,7 +101,7 @@ class TestTraceableCollection(TestCase):
     def test_add_item_overwrite(self):
         coll = dut.TraceableCollection()
         item1 = item.TraceableItem(self.identification_src)
-        item1.set_document(self.docname)
+        item1.set_location(self.docname)
         coll.add_item(item1)
         coll.add_relation_pair(self.fwd_relation, self.rev_relation)
         coll.add_relation(self.identification_src,
@@ -109,7 +109,7 @@ class TestTraceableCollection(TestCase):
                           self.identification_tgt)
         # Add target item: should update existing one (keeping relations)
         item2 = item.TraceableItem(self.identification_tgt)
-        item2.set_document(self.docname)
+        item2.set_location(self.docname)
         coll.add_item(item2)
         # Assert old relations are still there
         item1_out = coll.get_item(self.identification_src)
@@ -128,7 +128,7 @@ class TestTraceableCollection(TestCase):
         # with unknown source item, the generation of a placeholder is expected
         coll = dut.TraceableCollection()
         item2 = item.TraceableItem(self.identification_tgt)
-        item2.set_document(self.docname)
+        item2.set_location(self.docname)
         coll.add_item(item2)
         coll.add_relation_pair(self.fwd_relation, self.rev_relation)
         coll.add_relation(self.identification_src,
@@ -137,7 +137,7 @@ class TestTraceableCollection(TestCase):
         # Assert placeholder item is created
         item1 = coll.get_item(self.identification_src)
         self.assertIsNotNone(item1)
-        self.assertEqual(self.identification_src, item1.get_id())
+        self.assertEqual(self.identification_src, item1.identifier)
         self.assertTrue(item1.is_placeholder)
         # Assert explicit forward relation is created
         relations = item1.iter_targets(self.fwd_relation, explicit=True, implicit=False)
@@ -158,9 +158,9 @@ class TestTraceableCollection(TestCase):
         # with unknown relation, warning is expected
         coll = dut.TraceableCollection()
         item1 = item.TraceableItem(self.identification_src)
-        item1.set_document(self.docname)
+        item1.set_location(self.docname)
         item2 = item.TraceableItem(self.identification_tgt)
-        item2.set_document(self.docname)
+        item2.set_location(self.docname)
         coll.add_item(item1)
         coll.add_item(item2)
         with self.assertRaises(exception.TraceabilityException):
@@ -179,7 +179,7 @@ class TestTraceableCollection(TestCase):
         # With unknown target item, the generation of a placeholder is expected
         coll = dut.TraceableCollection()
         item1 = item.TraceableItem(self.identification_src)
-        item1.set_document(self.docname)
+        item1.set_location(self.docname)
         coll.add_item(item1)
         coll.add_relation_pair(self.fwd_relation, self.rev_relation)
         coll.add_relation(self.identification_src,
@@ -194,7 +194,7 @@ class TestTraceableCollection(TestCase):
         # Assert placeholder item is created
         item2 = coll.get_item(self.identification_tgt)
         self.assertIsNotNone(item2)
-        self.assertEqual(self.identification_tgt, item2.get_id())
+        self.assertEqual(self.identification_tgt, item2.identifier)
         self.assertTrue(item2.is_placeholder)
         # Assert implicit reverse relation is created
         relations = item2.iter_targets(self.rev_relation, explicit=False, implicit=True)
@@ -210,9 +210,9 @@ class TestTraceableCollection(TestCase):
         # Normal addition of relation, everything is there
         coll = dut.TraceableCollection()
         item1 = item.TraceableItem(self.identification_src)
-        item1.set_document(self.docname)
+        item1.set_location(self.docname)
         item2 = item.TraceableItem(self.identification_tgt)
-        item2.set_document(self.docname)
+        item2.set_location(self.docname)
         coll.add_item(item1)
         coll.add_item(item2)
         coll.add_relation_pair(self.fwd_relation, self.rev_relation)
@@ -242,7 +242,7 @@ class TestTraceableCollection(TestCase):
         # Normal addition of uni-directional relation
         coll = dut.TraceableCollection()
         item1 = item.TraceableItem(self.identification_src)
-        item1.set_document(self.docname)
+        item1.set_location(self.docname)
         coll.add_item(item1)
         coll.add_relation_pair(self.unidir_relation)
         coll.add_relation(self.identification_src,
@@ -268,7 +268,7 @@ class TestTraceableCollection(TestCase):
         self.assertIn(self.rev_relation, collstr)
         # Add some items and relations, assert they are in the string
         item1 = item.TraceableItem(self.identification_src)
-        item1.set_document(self.docname)
+        item1.set_location(self.docname)
         coll.add_item(item1)
         coll.add_relation(self.identification_src,
                           self.fwd_relation,
@@ -360,7 +360,7 @@ class TestTraceableCollection(TestCase):
         coll.self_test(None)
         # Create first item
         item1 = item.TraceableItem(self.identification_src)
-        item1.set_document(self.docname)
+        item1.set_location(self.docname)
         # Improper use: add target on item level (no sanity check and no automatic reverse link)
         item1.add_target(self.fwd_relation, self.identification_tgt)
         # Improper use is not detected at level of item-level
@@ -374,7 +374,7 @@ class TestTraceableCollection(TestCase):
         coll.self_test(None, docname='document-does-not-exist.rst')
         # Creating and adding second item, self test should still fail as no automatic reverse relation
         item2 = item.TraceableItem(self.identification_tgt)
-        item2.set_document(self.docname)
+        item2.set_location(self.docname)
         coll.add_item(item2)
         with self.assertRaises(dut.MultipleTraceabilityExceptions):
             coll.self_test(None)

--- a/tests/test_traceable_item.py
+++ b/tests/test_traceable_item.py
@@ -47,7 +47,6 @@ class TestTraceableItem(TestCase):
         # Verify dict
         self.assertEqual({}, item.to_dict())
 
-
     def test_to_dict(self):
         txt = 'some short description'
         item = dut.TraceableItem(self.identification)

--- a/tests/test_traceable_item.py
+++ b/tests/test_traceable_item.py
@@ -26,50 +26,33 @@ class TestTraceableItem(TestCase):
 
     def test_init(self):
         item = dut.TraceableItem(self.identification)
-        item.set_document(self.docname)
+        item.set_location(self.docname)
         item.self_test()
-        self.assertEqual(self.identification, item.get_id())
+        self.assertEqual(self.identification, item.identifier)
         self.assertFalse(item.is_placeholder)
-        self.assertIsNotNone(item.get_document())
-        self.assertEqual(0, item.get_line_number())
-        self.assertIsNone(item.get_node())
-        self.assertIsNone(item.get_caption())
-        self.assertIsNone(item.get_content())
+        self.assertIsNotNone(item.docname)
+        self.assertEqual(0, item.lineno)
+        self.assertIsNone(item.node)
+        self.assertIsNone(item.caption)
+        self.assertIsNone(item.content)
 
     def test_init_placeholder(self):
         item = dut.TraceableItem(self.identification, placeholder=True)
-        item.set_document(self.docname)
+        item.set_location(self.docname)
         with self.assertRaises(exception.TraceabilityException) as err:
             item.self_test()
-        self.assertEqual(err.exception.get_document(), self.docname)
-        self.assertEqual(self.identification, item.get_id())
+        self.assertEqual(err.exception.docname, self.docname)
+        self.assertEqual(self.identification, item.identifier)
         self.assertTrue(item.is_placeholder)
         # Verify dict
         self.assertEqual({}, item.to_dict())
 
-    def test_set_document(self):
-        item = dut.TraceableItem(self.identification)
-        with self.assertRaises(exception.TraceabilityException):
-            item.self_test()
-        item.set_document('some-file.rst', 888)
-        self.assertEqual('some-file.rst', item.get_document())
-        self.assertEqual(888, item.get_line_number())
-        item.self_test()
 
-    def test_bind_node(self):
-        item = dut.TraceableItem(self.identification)
-        item.set_document(self.docname)
-        node = object()
-        item.bind_node(node)
-        self.assertEqual(node, item.get_node())
-        item.self_test()
-
-    def test_set_caption(self):
+    def test_to_dict(self):
         txt = 'some short description'
         item = dut.TraceableItem(self.identification)
-        item.set_document(self.docname)
-        item.set_caption(txt)
-        self.assertEqual(txt, item.get_caption())
+        item.set_location(self.docname)
+        item.caption = txt
         # Verify dict
         data = item.to_dict()
         self.assertEqual(self.identification, data['id'])
@@ -80,19 +63,9 @@ class TestTraceableItem(TestCase):
         self.assertEqual("0", data['content-hash'])
         item.self_test()
 
-    def test_set_content(self):
-        txt = 'some description, with\n newlines and other stuff'
-        item = dut.TraceableItem(self.identification)
-        item.set_document(self.docname)
-        item.set_content(txt)
-        self.assertEqual(txt, item.get_content())
-        data = item.to_dict()
-        self.assertEqual("b787a17fc91c9cf37b5bf0665f13c8b1", data['content-hash'])
-        item.self_test()
-
     def test_add_invalid_attribute(self):
         item = dut.TraceableItem(self.identification)
-        item.set_document(self.docname)
+        item.set_location(self.docname)
         self.assertFalse(item.get_attribute(self.attribute_key1))
         with self.assertRaises(exception.TraceabilityException):
             item.add_attribute(None, self.attribute_value1)
@@ -108,7 +81,7 @@ class TestTraceableItem(TestCase):
 
     def test_add_attribute_overwrite(self):
         item = dut.TraceableItem(self.identification)
-        item.set_document(self.docname)
+        item.set_location(self.docname)
         self.assertFalse(item.get_attribute(self.attribute_key1))
         item.add_attribute(self.attribute_key1, self.attribute_value1)
         self.assertEqual(self.attribute_value1, item.get_attribute(self.attribute_key1))
@@ -118,7 +91,7 @@ class TestTraceableItem(TestCase):
 
     def test_add_attribute_no_overwrite(self):
         item = dut.TraceableItem(self.identification)
-        item.set_document(self.docname)
+        item.set_location(self.docname)
         self.assertFalse(item.get_attribute(self.attribute_key1))
         item.add_attribute(self.attribute_key1, self.attribute_value1)
         self.assertEqual(self.attribute_value1, item.get_attribute(self.attribute_key1))
@@ -128,7 +101,7 @@ class TestTraceableItem(TestCase):
 
     def test_remove_invalid_attribute(self):
         item = dut.TraceableItem(self.identification)
-        item.set_document(self.docname)
+        item.set_location(self.docname)
         self.assertFalse(item.get_attribute(self.attribute_key1))
         with self.assertRaises(exception.TraceabilityException):
             item.remove_attribute(None)
@@ -138,7 +111,7 @@ class TestTraceableItem(TestCase):
 
     def test_remove_attribute(self):
         item = dut.TraceableItem(self.identification)
-        item.set_document(self.docname)
+        item.set_location(self.docname)
         item.add_attribute(self.attribute_key1, self.attribute_value1)
         self.assertEqual(self.attribute_value1, item.get_attribute(self.attribute_key1))
         item.remove_attribute(self.attribute_key1)
@@ -147,7 +120,7 @@ class TestTraceableItem(TestCase):
 
     def test_get_attributes(self):
         item = dut.TraceableItem(self.identification)
-        item.set_document(self.docname)
+        item.set_location(self.docname)
         self.assertEqual([''], item.get_attributes([self.attribute_key1]))
         item.add_attribute(self.attribute_key1, self.attribute_value1)
         self.assertEqual([self.attribute_value1], item.get_attributes([self.attribute_key1]))
@@ -162,19 +135,19 @@ class TestTraceableItem(TestCase):
 
     def test_add_target_explicit_self(self):
         item = dut.TraceableItem(self.identification)
-        item.set_document(self.docname)
+        item.set_location(self.docname)
         with self.assertRaises(exception.TraceabilityException):
             item.add_target(self.fwd_relation, self.identification, implicit=False)
 
     def test_add_target_implicit_self(self):
         item = dut.TraceableItem(self.identification)
-        item.set_document(self.docname)
+        item.set_location(self.docname)
         with self.assertRaises(exception.TraceabilityException):
             item.add_target(self.fwd_relation, self.identification, implicit=True)
 
     def test_add_get_target_explicit(self):
         item = dut.TraceableItem(self.identification)
-        item.set_document(self.docname)
+        item.set_location(self.docname)
         # Initially no targets (explicit+implicit)
         targets = item.iter_targets(self.fwd_relation)
         self.assertEqual(0, len(targets))
@@ -231,7 +204,7 @@ class TestTraceableItem(TestCase):
 
     def test_add_get_target_implicit(self):
         item = dut.TraceableItem(self.identification)
-        item.set_document(self.docname)
+        item.set_location(self.docname)
         # Initially no targets (explicit+implicit)
         targets = item.iter_targets(self.fwd_relation)
         self.assertEqual(0, len(targets))
@@ -286,7 +259,7 @@ class TestTraceableItem(TestCase):
 
     def test_remove_target_explicit(self):
         item = dut.TraceableItem(self.identification)
-        item.set_document(self.docname)
+        item.set_location(self.docname)
         # Add an explicit target
         item.add_target(self.fwd_relation, self.identification_tgt)
         targets = item.iter_targets(self.fwd_relation)
@@ -307,7 +280,7 @@ class TestTraceableItem(TestCase):
 
     def test_remove_target_implicit(self):
         item = dut.TraceableItem(self.identification)
-        item.set_document(self.docname)
+        item.set_location(self.docname)
         # Add an implicit target
         item.add_target(self.fwd_relation, self.identification_tgt, implicit=True)
         targets = item.iter_targets(self.fwd_relation)
@@ -328,7 +301,7 @@ class TestTraceableItem(TestCase):
 
     def test_stringify(self):
         item = dut.TraceableItem(self.identification)
-        item.set_document(self.docname)
+        item.set_location(self.docname)
         item.add_attribute(self.attribute_key1, self.attribute_value1)
         item.add_target(self.fwd_relation, self.identification_tgt, implicit=False)
         item.add_target(self.rev_relation, 'one more item', implicit=True)
@@ -343,7 +316,7 @@ class TestTraceableItem(TestCase):
 
     def test_match(self):
         item = dut.TraceableItem(self.identification)
-        self.assertEqual(self.identification, item.get_id())
+        self.assertEqual(self.identification, item.identifier)
         self.assertFalse(item.is_match('some-name-that(will-definitely)not-match'))
         self.assertTrue(item.is_match('some'))
         self.assertTrue(item.is_match('some-random'))
@@ -358,7 +331,7 @@ class TestTraceableItem(TestCase):
 
     def test_related(self):
         item = dut.TraceableItem(self.identification)
-        self.assertEqual(self.identification, item.get_id())
+        self.assertEqual(self.identification, item.identifier)
         self.assertFalse(item.is_related([self.fwd_relation], self.identification_tgt))
         item.add_target(self.fwd_relation, self.identification_tgt)
         self.assertTrue(item.is_related([self.fwd_relation], self.identification_tgt))
@@ -366,7 +339,7 @@ class TestTraceableItem(TestCase):
 
     def test_self_test_duplicate_relation(self):
         item = dut.TraceableItem(self.identification)
-        item.set_document(self.docname)
+        item.set_location(self.docname)
         # Add a target
         item.add_target(self.fwd_relation, self.identification_tgt)
         # Self test should pass
@@ -382,7 +355,7 @@ class TestTraceableItem(TestCase):
 
     def test_self_test_invalid_attribute(self):
         item = dut.TraceableItem(self.identification)
-        item.set_document(self.docname)
+        item.set_location(self.docname)
         # Add a valid attribute
         item.add_attribute(self.attribute_key1, self.attribute_value1)
         # Self test should pass
@@ -398,7 +371,7 @@ class TestTraceableItem(TestCase):
 
     def test_has_relations(self):
         item = dut.TraceableItem(self.identification)
-        item.set_document(self.docname)
+        item.set_location(self.docname)
         item.add_target(self.fwd_relation, self.identification_tgt)
         self.assertEqual(item.has_relations([]), True)
         self.assertEqual(item.has_relations([self.fwd_relation]), True)


### PR DESCRIPTION
The deprecation warnings were added in PR #295 and released on Aug 1, 2022 in v9.0.0.