### PR TITLE
Clarify error about incomplete traceability_relationship_to_string

### DIFF
--- a/mlx/directives/item_directive.py
+++ b/mlx/directives/item_directive.py
@@ -78,7 +78,8 @@ class Item(TraceableBaseNode):
         if relation in app.config.traceability_relationship_to_string:
             relstr = app.config.traceability_relationship_to_string[relation]
         else:
-            report_warning(f'Traceability: relation {relation} cannot be translated to string')
+            report_warning(f'Traceability: relation {relation} cannot be translated to string',
+                           docname=self['document'], lineno=self['line'])
             relstr = relation
         dt_node.append(nodes.Text(relstr))
         li_node.append(dt_node)

--- a/mlx/directives/item_directive.py
+++ b/mlx/directives/item_directive.py
@@ -79,9 +79,7 @@ class Item(TraceableBaseNode):
         if relation in app.config.traceability_relationship_to_string:
             relstr = app.config.traceability_relationship_to_string[relation]
         else:
-            report_warning('Traceability: relation {rel} cannot be translated to string'
-                           .format(rel=relation),
-                           env.docname, self.line)
+            report_warning(f'Traceability: relation {relation} cannot be translated to string')
             relstr = relation
         dt_node.append(nodes.Text(relstr))
         li_node.append(dt_node)

--- a/mlx/directives/item_directive.py
+++ b/mlx/directives/item_directive.py
@@ -73,7 +73,6 @@ class Item(TraceableBaseNode):
             dl_node (nodes.definition_list): Definition list of the item.
             app: Sphinx's application object to use.
         """
-        env = app.builder.env
         li_node = nodes.definition_list_item()
         dt_node = nodes.term()
         if relation in app.config.traceability_relationship_to_string:

--- a/mlx/traceability.py
+++ b/mlx/traceability.py
@@ -324,7 +324,7 @@ def initialize_environment(app):
     undefined_stringifications = all_relationships.difference(app.config.traceability_relationship_to_string)
     if undefined_stringifications:
         raise TraceabilityException(f"Relationships {undefined_stringifications!r} are missing from configuration "
-                                    "variable `traceability_relationship_to_string`")
+                                    "variable 'traceability_relationship_to_string'")
 
     app.config.traceability_checklist['has_checklist_items'] = False
     add_checklist_attribute(app.config.traceability_checklist,

--- a/mlx/traceability.py
+++ b/mlx/traceability.py
@@ -324,7 +324,7 @@ def initialize_environment(app):
     undefined_stringifications = all_relationships.difference(app.config.traceability_relationship_to_string)
     if undefined_stringifications:
         raise TraceabilityException(f"Relationships {undefined_stringifications!r} are missing from configuration "
-                                    "variable `traceability_relationships`")
+                                    "variable `traceability_relationship_to_string`")
 
     app.config.traceability_checklist['has_checklist_items'] = False
     add_checklist_attribute(app.config.traceability_checklist,

--- a/tests/directives/test_item_directive.py
+++ b/tests/directives/test_item_directive.py
@@ -17,6 +17,7 @@ from parameterized import parameterized
 
 LOGGER = logging.getLogger()
 
+
 def raise_no_uri(*args, **kwargs):
     raise NoUri
 
@@ -34,7 +35,7 @@ class TestItemDirective(TestCase):
         self.item.node = self.node
         self.app.config = Mock()
         self.app.config.traceability_hyperlink_colors = {}
-        self.collection =  TraceableCollection()
+        self.collection = TraceableCollection()
         self.collection.add_item(self.item)
 
     def init_builder(self, spec=StandaloneHTMLBuilder):

--- a/tests/directives/test_item_directive.py
+++ b/tests/directives/test_item_directive.py
@@ -148,7 +148,6 @@ class TestItemDirective(TestCase):
 
         target_item = TraceableItem('target_id')
         self.collection.add_item(target_item)
-
         self.collection.add_relation(self.item.identifier, 'depends_on', target_item.identifier)
 
         with self.assertLogs(LOGGER, logging.DEBUG) as c_m:


### PR DESCRIPTION
When configuration variable `traceability_relationship_to_string` is incomplete, the doc build is exited with `exception: Relationships {'<<relationship_name>>'} are missing from configuration variable 'traceability_relationship_to_string'`.

If this is check for completeness were to be removed, a warning would be reported when this relationship is used: `Traceability: relation <<relationship_name>> cannot be translated to string`. However, this warning is bugged and would crash the doc build with the following error:

```
Traceback (most recent call last):
  File "/opt/venv/lib/python3.11/site-packages/sphinx/events.py", line 96, in emit
    results.append(listener.handler(self.app, *args))
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.11/site-packages/mlx/traceability.py", line 249, in process_item_nodes
    node.perform_replacement(app, env.traceability_collection)
  File "/opt/venv/lib/python3.11/site-packages/mlx/directives/item_directive.py", line 28, in perform_replacement
    self._process_relationships(dl_node, app)
  File "/opt/venv/lib/python3.11/site-packages/mlx/directives/item_directive.py", line 65, in _process_relationships
    self._list_targets_for_relation(rel, targets, *args)
  File "/opt/venv/lib/python3.11/site-packages/mlx/directives/item_directive.py", line 84, in _list_targets_for_relation
    env.docname, self.line)
    ^^^^^^^^^^^
  File "/opt/venv/lib/python3.11/site-packages/sphinx/environment/__init__.py", line 534, in docname
    return self.temp_data['docname']
           ~~~~~~~~~~~~~~^^^^^^^^^^^
KeyError: 'docname'
```