### PR TITLE
Display selected items at the top of the browser viewport

### DIFF
--- a/mlx/traceability/assets/traceability.js
+++ b/mlx/traceability/assets/traceability.js
@@ -58,6 +58,15 @@ $(document).ready(function () {
     $('p.admonition-title').each(function (i) {
         $(this).children('a').first().denyPermalinkStyling($(this));
     });
+
+    // if an item was selected, ensure it's displayed at the top of the viewport
+    if (location.hash) {
+        const anchorId = location.hash.slice(1);
+        const element = document.getElementById(anchorId);
+        if (element) {
+            element.scrollIntoView(true, { block: "start", inline: "nearest" });
+        }
+    }
 });
 
 // item


### PR DESCRIPTION
With the configuration of `traceability_collapse_links = True`, our `traceability.js` hides all attributes and relationships when the HTML document is ready. This can cause the viewport to jump, losing focus of the selected traceable item.

This PR should fix this issue. I tested it with Firefox and Chrome.

Closes #363 