### PR TITLE
The JSON export should not export a placeholder item as an empty entry

### DIFF
--- a/mlx/traceability/traceable_collection.py
+++ b/mlx/traceability/traceable_collection.py
@@ -188,8 +188,10 @@ class TraceableCollection:
         with open(fname, 'w') as outfile:
             data = []
             for itemid in self.iter_items():
-                item = self.get_item(itemid)
-                data.append(item.to_dict())
+                item = self.items[itemid]
+                entry = item.to_dict()
+                if entry:
+                    data.append(entry)
             json.dump(data, outfile, indent=4, sort_keys=True)
 
     def self_test(self, notification_item_id, docname=None):


### PR DESCRIPTION
FYI: Items remain "placeholder" when they are not defined with the `item`-directive (or derived directive) and only reference by another item, for example.