### PR TITLE
item-matrix: Fix bug in error handling of invalid options

### DIFF
--- a/mlx/traceability/directives/item_matrix_directive.py
+++ b/mlx/traceability/directives/item_matrix_directive.py
@@ -682,7 +682,7 @@ class ItemMatrixDirective(TraceableBaseDirective):
             raise TraceabilityException(
                 "Item-matrix directive should have the same number of values for the options 'target' and "
                 "'targettitle'. Got target: {targets!r} and targettitle: {titles!r}"
-                .format(targets=self.options['target'], titles=self.options['targettitle']),
+                .format(targets=self.options.get('target', ''), titles=self.options.get('targettitle', '')),
                 docname=env.docname)
 
         if node['type']:


### PR DESCRIPTION
When an `item-matrix` does not have the same number of values for the options 'target' and 'targettitle', and either one of these options is unused, a `KeyError` would be raised instead of handling this configuration error correctly.