### PR TITLE
item-matrix: Show item content

### DIFF
--- a/doc/_static/css/extra.css
+++ b/doc/_static/css/extra.css
@@ -92,3 +92,8 @@
 .rst-content ul.bonsai li>ul {
     margin-bottom: 0 !important;
 }
+
+/* Don't add exclamation point icon in admonition bar of items */
+.rst-content div.item p.admonition-title:before {
+    content: None !important;
+}

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -497,6 +497,9 @@ limitations in doing so:
     Normally the *longtable* class is used when the number of rows is greater than 30 which allows long tables to
     span multiple pages. By setting *class* to *longtable* manually, you can force the use of this environment.
 
+In HTML, when you right-click a row, the content of all internal items in the row are fetched and displayed.
+Successive right-clicks toggle the visibility of the items' content.
+
 Link targets via intermediate items (advanced)
 ==============================================
 

--- a/mlx/traceability/assets/traceability.js
+++ b/mlx/traceability/assets/traceability.js
@@ -59,6 +59,7 @@ $(document).ready(function () {
     $('table > tbody > tr[class^=item-group-]').each(function (i) {
         $(this).on("contextmenu",
             function (event) {
+                event.preventDefault()
                 var groupName = /item-group-\d+/.exec($(this).attr('class'))[0];
                 $(this).parent().find(`tr.${groupName} > td > p.item-link`).each(function (j) {
                     const content = $(this).children('div.content').first();

--- a/mlx/traceability/assets/traceability.js
+++ b/mlx/traceability/assets/traceability.js
@@ -34,7 +34,7 @@ $(document).ready(function () {
             'white-space': 'pre'  // prevents adding newlines
         });
         $(this).hover(
-            function() {
+            function () {
                 // entering hover state
                 caption.show();
                 var captionRight = caption.offset().left + caption.outerWidth();
@@ -48,7 +48,7 @@ $(document).ready(function () {
                     // lines up the caption behind the item ID
                     caption.css('transform', 'translate(0.3rem, -3px)');
                 }
-            }, function() {
+            }, function () {
                 // leaving hover state
                 caption.css('transform', 'none');  // resets the transformations
                 caption.hide();
@@ -66,11 +66,10 @@ $(document).ready(function () {
                         content.toggle();
                     } else {
                         var link = $(this).children('a').first();
-                        var container = $('<div>', {class: 'content'});
+                        var container = $('<div>', { class: 'content' });
                         container.load(link.attr('href').replace('#', ' #content-'));
                         $(this).append(container)
                     }
-
                 });
             }
         );

--- a/mlx/traceability/assets/traceability.js
+++ b/mlx/traceability/assets/traceability.js
@@ -62,14 +62,20 @@ $(document).ready(function () {
                 event.preventDefault()
                 var groupName = /item-group-\d+/.exec($(this).attr('class'))[0];
                 $(this).parent().find(`tr.${groupName} > td > p.item-link`).each(function (j) {
+                    const cell = $(this).parent();
+                    const maxWidth = Math.max(cell.width(), ($("div.rst-content").width() / 2));
+                    cell.css("maxWidth", maxWidth);
                     const content = $(this).children('div.content').first();
                     if (content.length) {
                         content.toggle();
                     } else {
                         var link = $(this).children('a').first();
                         var container = $('<div>', { class: 'content' });
-                        container.load(link.attr('href').replace('#', ' #content-'));
-                        $(this).append(container)
+                        var paragraph = $(this)
+                        container.load(link.attr('href').replace('#', ' #content-'), function () {
+                            container.find('*').css("width", "inherit");
+                            paragraph.append(container);
+                        });
                     }
                 });
             }

--- a/mlx/traceability/assets/traceability.js
+++ b/mlx/traceability/assets/traceability.js
@@ -56,6 +56,26 @@ $(document).ready(function () {
         );
     });
 
+    $('table > tbody > tr[class^=item-group-]').each(function (i) {
+        $(this).on("contextmenu",
+            function (event) {
+                var groupName = /item-group-\d+/.exec($(this).attr('class'))[0];
+                $(this).parent().find(`tr.${groupName} > td > p.item-link`).each(function (j) {
+                    const content = $(this).children('div.content').first();
+                    if (content.length) {
+                        content.toggle();
+                    } else {
+                        var link = $(this).children('a').first();
+                        var container = $('<div>', {class: 'content'});
+                        container.load(link.attr('href').replace('#', ' #content-'));
+                        $(this).append(container)
+                    }
+
+                });
+            }
+        );
+    });
+
     $('p.admonition-title').each(function (i) {
         $(this).children('a').first().denyPermalinkStyling($(this));
     });

--- a/mlx/traceability/directives/item_matrix_directive.py
+++ b/mlx/traceability/directives/item_matrix_directive.py
@@ -231,6 +231,8 @@ class ItemMatrix(TraceableBaseNode):
     def _set_rowspan(tbody, indexes):
         """ Sets the 'rowspan' attribute of cells that should span multiple rows to avoid duplication
 
+        Also groups all rows that belong to a single source item by assigning them to the same CSS class.
+
         Args:
             tbody (nodes.tbody): Table body
             indexes (iterable): Range object with indexes of columns to take into account
@@ -241,10 +243,12 @@ class ItemMatrix(TraceableBaseNode):
         prev_row = None
         cells_to_remove = {}
         original_cells = {idx: None for idx in indexes}
+        group_class_nr = 0
         for row_idx, row in enumerate(tbody):
             cells_to_remove[row_idx] = []
             if prev_row is None:
                 prev_row = row
+                row['classes'].append(f'item-group-{group_class_nr}')
                 continue
 
             for col_idx, cell in original_cells.items():
@@ -255,11 +259,13 @@ class ItemMatrix(TraceableBaseNode):
                     cells_to_remove[row_idx].append(col_idx)
                 elif col_idx == 0:  # new source so reset and move on to next row
                     original_cells = {idx: None for idx in indexes}
+                    group_class_nr += 1
                     break
                 else:
                     original_cells[col_idx] = None
 
             prev_row = row
+            row['classes'].append(f'item-group-{group_class_nr}')
         return cells_to_remove
 
     @staticmethod

--- a/mlx/traceability/traceable_base_class.py
+++ b/mlx/traceability/traceable_base_class.py
@@ -31,8 +31,11 @@ class TraceableBaseClass:
         self.lineno = None
         self.node = None
         self._content = None
-        self.content_node = nodes.block_quote()
+        self.content_node = nodes.container()
+        self.content_node['ids'].append(f'content-{self.identifier}')
         self._state = state
+        if state is not None:
+            state.document.ids[f'content-{self.identifier}'] = self.content_node
 
     @staticmethod
     def to_id(identifier):
@@ -89,7 +92,7 @@ class TraceableBaseClass:
             template = ViewList(source=self.docname, parent_offset=self.lineno)
             for idx, line in enumerate(content.split('\n')):
                 template.append(line, self.docname, idx)
-            self.content_node = nodes.block_quote()  # reset
+            self.content_node.children = []  # reset
             nested_parse_with_titles(self._state, template, self.content_node)
 
     def clear_state(self):

--- a/mlx/traceability/traceable_base_node.py
+++ b/mlx/traceability/traceable_base_node.py
@@ -66,6 +66,7 @@ class TraceableBaseNode(nodes.General, nodes.Element, ABC):
         link_item = item_info
         notification_item = None
         p_node = nodes.paragraph()
+        p_node['classes'].append('item-link')
 
         # Only create link when target item (or notification item) exists, warn otherwise (in html and terminal)
         if item_info.is_placeholder:

--- a/tests/test_traceable_base_class.py
+++ b/tests/test_traceable_base_class.py
@@ -1,7 +1,5 @@
 from unittest import TestCase
 
-from docutils import nodes
-
 from mlx.traceability import traceable_base_class as dut
 
 
@@ -20,7 +18,8 @@ class TestTraceableBaseClass(TestCase):
         self.assertIsNone(item.node)
         self.assertIsNone(item.caption)
         self.assertIsNone(item.content)
-        self.assertEqual(str(nodes.block_quote()), str(item.content_node))
+        self.assertEqual("<container ids=\"['content-some-random$name\\'with<\"weird@symbols']\"/>",
+                         str(item.content_node))
 
     def test_to_dict(self):
         txt = 'some description, with\n newlines and other stuff'


### PR DESCRIPTION
In HTML, when you right-click a row, the content of all internal items in the row are fetched and displayed.
Successive right-clicks toggle the visibility of the items' content.

The item content is now displayed in a `<div>` element instead of a `<blockquote>` to get rid of the unwanted indentation reported in #377.

- [ ] tested in internal project

FYI @gcrabbe