### PR TITLE
Remove space before colons

### DIFF
--- a/mlx/traceability/directives/item_attribute_directive.py
+++ b/mlx/traceability/directives/item_attribute_directive.py
@@ -22,7 +22,7 @@ class ItemAttribute(TraceableBaseNode):
             attr = TraceableItem.defined_attributes[self['id']]
             header = attr.name
             if attr.caption:
-                header += ' : ' + attr.caption
+                header += ': ' + attr.caption
         else:
             header = self['id']
         top_node = self.create_top_node(header)

--- a/mlx/traceability/traceable_base_node.py
+++ b/mlx/traceability/traceable_base_node.py
@@ -254,7 +254,7 @@ class TraceableBaseNode(nodes.General, nodes.Element, ABC):
                 hidden_node = nodes.inline('', item_info.identifier)
                 hidden_node['classes'].append('popup_caption')
             elif not self.get('nocaptions'):
-                display_text = '{0.identifier} : {0.caption}'.format(item_info)
+                display_text = '{0.identifier}: {0.caption}'.format(item_info)
             else:
                 hidden_node = nodes.inline('', item_info.caption)
                 hidden_node['classes'].append('popup_caption')

--- a/tests/directives/test_item_directive.py
+++ b/tests/directives/test_item_directive.py
@@ -73,9 +73,9 @@ class TestItemDirective(TestCase):
 
         self.assertEqual(len(em_node.children), 1)
         self.assertEqual(len(em_node.children), 1)
-        self.assertEqual(str(em_node), '<emphasis>some_id : caption text</emphasis>')
+        self.assertEqual(str(em_node), '<emphasis>some_id: caption text</emphasis>')
         self.assertEqual(ref_node.tagname, 'reference')
-        self.assertEqual(em_node.rawsource, 'some_id : caption text')
+        self.assertEqual(em_node.rawsource, 'some_id: caption text')
         cache = self.app.builder.env.traceability_ref_nodes[self.node['id']]
         self.assertEqual(p_node, cache['default'][f'{self.node["document"]}.html'])
 


### PR DESCRIPTION
From [Wikipedia](https://en.wikipedia.org/wiki/Colon_(punctuation)#Spacing_and_parentheses):

> In modern [English-language](https://en.wikipedia.org/wiki/English-language) printing, no space is placed before a colon and a single space is placed after it.