### PR TITLE
Add option to item-directive to hide specific relation-types

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -54,12 +54,16 @@ Documentation items can be defined using the *item* directive, specifying:
         :validated_by: ITEST-MY_FIRST_INTEGRATION_TEST
         :ext_polarion_reference: project_x:workitem_y
         :nocaptions:
+        :noshow: validated_by
 
         According to the Polarion reference, the software **shall** implement my first requirement.
 
 Attributes can be added to the item, using the configured attribute keys in :ref:`traceability_default_config`
 (e.g. *value* in the above example). The content of the attribute is treated as a single string and should
 match_ the regular expression in configuration.
+
+The *noshow* is a space-seperated list of relation types. The relations to other items will not be shown for the
+mentioned relation types.
 
 The relations to other documentation items can be specified as:
 

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -54,7 +54,7 @@ Documentation items can be defined using the *item* directive, specifying:
         :validated_by: ITEST-MY_FIRST_INTEGRATION_TEST
         :ext_polarion_reference: project_x:workitem_y
         :nocaptions:
-        :noshow: validated_by
+        :hidelinks: validated_by
 
         According to the Polarion reference, the software **shall** implement my first requirement.
 
@@ -62,7 +62,7 @@ Attributes can be added to the item, using the configured attribute keys in :ref
 (e.g. *value* in the above example). The content of the attribute is treated as a single string and should
 match_ the regular expression in configuration.
 
-The *noshow* is a space-seperated list of relation types. The relations to other items will not be shown for the
+The *hidelinks* is a space-seperated list of relation types. The relations to other items will not be shown for the
 mentioned relation types.
 
 The relations to other documentation items can be specified as:

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -63,7 +63,7 @@ Attributes can be added to the item, using the configured attribute keys in :ref
 match_ the regular expression in configuration.
 
 The *hidelinks* is a space-seperated list of relation types. The relations to other items will not be shown for the
-mentioned relation types.
+mentioned relation types below the item. The links will still be used and displayed in traceability matrixes and other directives.
 
 The relations to other documentation items can be specified as:
 

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -53,17 +53,14 @@ Documentation items can be defined using the *item* directive, specifying:
         :status: Approved
         :validated_by: ITEST-MY_FIRST_INTEGRATION_TEST
         :ext_polarion_reference: project_x:workitem_y
+        :hidetype: validated_by
         :nocaptions:
-        :hidelinks: validated_by
 
         According to the Polarion reference, the software **shall** implement my first requirement.
 
 Attributes can be added to the item, using the configured attribute keys in :ref:`traceability_default_config`
 (e.g. *value* in the above example). The content of the attribute is treated as a single string and should
 match_ the regular expression in configuration.
-
-The *hidelinks* is a space-seperated list of relation types. The relations to other items will not be shown for the
-mentioned relation types below the item. The links will still be used and displayed in traceability matrixes and other directives.
 
 The relations to other documentation items can be specified as:
 
@@ -78,7 +75,17 @@ The relations to other documentation items can be specified as:
             ITEST-MY_SECOND_INTEGRATION_TEST
 
 The output will contain hyperlinks to all related items. By default, the caption for the target item is displayed for
-each of these related items. With the option *nocaptions* these captions can be omitted.
+each of these related items.
+
+:hidetype: *optional*, *multiple arguments (space-separated)*
+
+    A space-separated list of relation types. By default, the rendered item definition displays all relations to other items
+    in a list below the item name (id). The relation types given to this option will be omitted from this list.
+    It does not affect how the item is rendered in other directives, e.g. item-matrix.
+
+:nocaptions: *optional*, *flag*
+
+    Omits the caption from the rendered item definition.
 
 .. _adding_relations:
 

--- a/mlx/traceability/directives/item_directive.py
+++ b/mlx/traceability/directives/item_directive.py
@@ -63,7 +63,7 @@ class Item(TraceableBaseNode):
         All targets get naturally sorted per relationship.
         """
         for rel, targets in self._item.all_relations:
-            if rel not in self['hidelinks']:
+            if rel not in self['hidetype']:
                 self._list_targets_for_relation(rel, targets, *args)
 
     def _list_targets_for_relation(self, relation, targets, dl_node, app):
@@ -130,7 +130,7 @@ class ItemDirective(TraceableBaseDirective):
     option_spec = {
         'class': directives.class_option,
         'nocaptions': directives.flag,
-        'hidelinks': directives.unchanged,
+        'hidetype': directives.unchanged,
     }
     # Content allowed
     has_content = True
@@ -154,7 +154,7 @@ class ItemDirective(TraceableBaseDirective):
         self.process_options(
             item_node,
             {
-                'hidelinks': {'default': []},
+                'hidetype': {'default': []},
             },
         )
         item = self._store_item_info(target_id, env)

--- a/mlx/traceability/directives/item_directive.py
+++ b/mlx/traceability/directives/item_directive.py
@@ -161,6 +161,8 @@ class ItemDirective(TraceableBaseDirective):
         if item is None:
             return []
 
+        self.check_relationships(item_node['hidetype'], env)
+
         # Custom callback for modifying items
         if app.config.traceability_callback_per_item:
             app.config.traceability_callback_per_item(target_id, env.traceability_collection)

--- a/mlx/traceability/directives/item_directive.py
+++ b/mlx/traceability/directives/item_directive.py
@@ -63,7 +63,8 @@ class Item(TraceableBaseNode):
         All targets get naturally sorted per relationship.
         """
         for rel, targets in self._item.all_relations:
-            self._list_targets_for_relation(rel, targets, *args)
+            if rel not in self['noshow']:
+                self._list_targets_for_relation(rel, targets, *args)
 
     def _list_targets_for_relation(self, relation, targets, dl_node, app):
         """ Add a list with all targets for a specific relation to the given definition list.
@@ -129,6 +130,7 @@ class ItemDirective(TraceableBaseDirective):
     option_spec = {
         'class': directives.class_option,
         'nocaptions': directives.flag,
+        'noshow': directives.unchanged,
     }
     # Content allowed
     has_content = True
@@ -149,6 +151,12 @@ class ItemDirective(TraceableBaseDirective):
             item_node['classes'].append('collapse')
         if 'class' in self.options:
             item_node['classes'].extend(self.options.get('class'))
+        self.process_options(
+            item_node,
+            {
+                'noshow': {'default': []},
+            },
+        )
         item = self._store_item_info(target_id, env)
         if item is None:
             return []

--- a/mlx/traceability/directives/item_directive.py
+++ b/mlx/traceability/directives/item_directive.py
@@ -63,7 +63,7 @@ class Item(TraceableBaseNode):
         All targets get naturally sorted per relationship.
         """
         for rel, targets in self._item.all_relations:
-            if rel not in self['noshow']:
+            if rel not in self['hidelinks']:
                 self._list_targets_for_relation(rel, targets, *args)
 
     def _list_targets_for_relation(self, relation, targets, dl_node, app):
@@ -130,7 +130,7 @@ class ItemDirective(TraceableBaseDirective):
     option_spec = {
         'class': directives.class_option,
         'nocaptions': directives.flag,
-        'noshow': directives.unchanged,
+        'hidelinks': directives.unchanged,
     }
     # Content allowed
     has_content = True
@@ -154,7 +154,7 @@ class ItemDirective(TraceableBaseDirective):
         self.process_options(
             item_node,
             {
-                'noshow': {'default': []},
+                'hidelinks': {'default': []},
             },
         )
         item = self._store_item_info(target_id, env)

--- a/tests/directives/test_item_directive.py
+++ b/tests/directives/test_item_directive.py
@@ -30,7 +30,7 @@ class TestItemDirective(TestCase):
         self.node['document'] = 'some_doc'
         self.node['id'] = 'some_id'
         self.node['line'] = 1
-        self.node['hidelinks'] = []
+        self.node['hidetype'] = []
         self.item = TraceableItem(self.node['id'])
         self.item.set_location(self.node['document'], self.node['line'])
         self.item.node = self.node

--- a/tests/directives/test_item_directive.py
+++ b/tests/directives/test_item_directive.py
@@ -30,6 +30,7 @@ class TestItemDirective(TestCase):
         self.node['document'] = 'some_doc'
         self.node['id'] = 'some_id'
         self.node['line'] = 1
+        self.node['noshow'] = []
         self.item = TraceableItem(self.node['id'])
         self.item.set_location(self.node['document'], self.node['line'])
         self.item.node = self.node

--- a/tests/directives/test_item_directive.py
+++ b/tests/directives/test_item_directive.py
@@ -30,7 +30,7 @@ class TestItemDirective(TestCase):
         self.node['document'] = 'some_doc'
         self.node['id'] = 'some_id'
         self.node['line'] = 1
-        self.node['noshow'] = []
+        self.node['hidelinks'] = []
         self.item = TraceableItem(self.node['id'])
         self.item.set_location(self.node['document'], self.node['line'])
         self.item.node = self.node

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -58,66 +58,57 @@ class TestSphinx(unittest.TestCase):
         ])
         self.assertEqual(retcode, 0)
 
-    def test_item_relation(self):
+    def make_doc_with_rst(self, rst_content, **build_options):
         with open(self.index_rst_path, "w") as f:
-            f.write(textwrap.dedent(r"""
-            .. item:: ITEM-A Description of item-a
-
-            .. item:: ITEM-B Description of item-b
-                :my_relation: ITEM-A
-            """))
-
-        self.build(builder="html")
+            f.write(textwrap.dedent(rst_content))
+        self.build(**build_options)
         with open(self.html_file, "r") as f:
-            content = f.read()
-            assert 'My relation' in content
-            assert 'My reverse relation' in content
+            return f.read()
+
+    def test_item_relation(self):
+        rst_content = r"""
+        .. item:: ITEM-A Description of item-a
+
+        .. item:: ITEM-B Description of item-b
+            :my_relation: ITEM-A
+        """
+        content = self.make_doc_with_rst(rst_content)
+        assert 'My relation' in content
+        assert 'My reverse relation' in content
 
     def test_item_relation_hide_forward(self):
-        with open(self.index_rst_path, "w") as f:
-            f.write(textwrap.dedent(r"""
-            .. item:: ITEM-A Description of item-a
+        rst_content = r"""
+        .. item:: ITEM-A Description of item-a
 
-            .. item:: ITEM-B Description of item-b
-                :my_relation: ITEM-A
-                :hidetype: my_relation
-            """))
-
-        self.build(builder="html")
-        with open(self.html_file, "r") as f:
-            content = f.read()
-            assert 'My relation' not in content
-            assert 'My reverse relation' in content
+        .. item:: ITEM-B Description of item-b
+            :my_relation: ITEM-A
+            :hidetype: my_relation
+        """
+        content = self.make_doc_with_rst(rst_content)
+        assert 'My relation' not in content
+        assert 'My reverse relation' in content
 
     def test_item_relation_hide_reverse(self):
-        with open(self.index_rst_path, "w") as f:
-            f.write(textwrap.dedent(r"""
-            .. item:: ITEM-A Description of item-a
-                :hidetype: my_reverse_relation
+        rst_content = r"""
+        .. item:: ITEM-A Description of item-a
+            :hidetype: my_reverse_relation
 
-            .. item:: ITEM-B Description of item-b
-                :my_relation: ITEM-A
-            """))
-
-        self.build(builder="html")
-        with open(self.html_file, "r") as f:
-            content = f.read()
-            assert 'My relation' in content
-            assert 'My reverse relation' not in content
+        .. item:: ITEM-B Description of item-b
+            :my_relation: ITEM-A
+        """
+        content = self.make_doc_with_rst(rst_content)
+        assert 'My relation' in content
+        assert 'My reverse relation' not in content
 
     def test_item_relation_hide_both(self):
-        with open(self.index_rst_path, "w") as f:
-            f.write(textwrap.dedent(r"""
-            .. item:: ITEM-A Description of item-a
-                :hidetype: my_reverse_relation
+        rst_content = r"""
+        .. item:: ITEM-A Description of item-a
+            :hidetype: my_reverse_relation
 
-            .. item:: ITEM-B Description of item-b
-                :my_relation: ITEM-A
-                :hidetype: my_relation
-            """))
-
-        self.build(builder="html")
-        with open(self.html_file, "r") as f:
-            content = f.read()
-            assert 'My relation' not in content
-            assert 'My reverse relation' not in content
+        .. item:: ITEM-B Description of item-b
+            :my_relation: ITEM-A
+            :hidetype: my_relation
+        """
+        content = self.make_doc_with_rst(rst_content)
+        assert 'My relation' not in content
+        assert 'My reverse relation' not in content

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -1,4 +1,3 @@
-import os
 import shutil
 import tempfile
 import textwrap

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -5,17 +5,19 @@ import textwrap
 import unittest
 import sphinx.cmd.build
 import sphinx.cmd.quickstart
+from pathlib import Path
 
 
 class TestSphinx(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.docs_folder = tempfile.mkdtemp()
-        cls.rst_file = os.path.join(cls.docs_folder, "index.rst")
-        cls.html_file = os.path.join(cls.docs_folder, "_build", "index.html")
+        cls.doc_dir = Path(tempfile.mkdtemp())
+        cls.build_dir = cls.doc_dir / "_build"
+        cls.index_rst_path = cls.doc_dir / "index.rst"
+        cls.html_file = cls.build_dir / "index.html"
         sphinx.cmd.quickstart.generate({
-            "path": cls.docs_folder,
+            "path": cls.doc_dir,
             "sep": False,
             "project": "testdoc",
             "author": "mlx.traceability contributors",
@@ -39,25 +41,25 @@ class TestSphinx(unittest.TestCase):
             traceability_attributes_sort = {}
             """
 
-        with open(f'{cls.docs_folder}/conf.py', 'a') as f:
+        with open(cls.doc_dir / 'conf.py', 'a') as f:
             f.write(textwrap.dedent(cfg))
 
     @classmethod
     def tearDownClass(cls):
-        shutil.rmtree(cls.docs_folder)
+        shutil.rmtree(cls.doc_dir)
 
     def build(self, builder="html"):
         retcode = sphinx.cmd.build.main([
             "-q",
             "-b",
             builder,
-            self.docs_folder,
-            os.path.join(self.docs_folder, "_build"),
+            str(self.doc_dir),
+            str(self.build_dir),
         ])
         self.assertEqual(retcode, 0)
 
     def test_item_relation(self):
-        with open(os.path.join(self.docs_folder, self.rst_file), "w") as f:
+        with open(self.index_rst_path, "w") as f:
             f.write(textwrap.dedent(r"""
             .. item:: ITEM-A Description of item-a
 
@@ -72,7 +74,7 @@ class TestSphinx(unittest.TestCase):
             assert 'My reverse relation' in content
 
     def test_item_relation_hide_forward(self):
-        with open(os.path.join(self.docs_folder, self.rst_file), "w") as f:
+        with open(self.index_rst_path, "w") as f:
             f.write(textwrap.dedent(r"""
             .. item:: ITEM-A Description of item-a
 
@@ -88,7 +90,7 @@ class TestSphinx(unittest.TestCase):
             assert 'My reverse relation' in content
 
     def test_item_relation_hide_reverse(self):
-        with open(os.path.join(self.docs_folder, self.rst_file), "w") as f:
+        with open(self.index_rst_path, "w") as f:
             f.write(textwrap.dedent(r"""
             .. item:: ITEM-A Description of item-a
                 :hidetype: my_reverse_relation
@@ -104,7 +106,7 @@ class TestSphinx(unittest.TestCase):
             assert 'My reverse relation' not in content
 
     def test_item_relation_hide_both(self):
-        with open(os.path.join(self.docs_folder, self.rst_file), "w") as f:
+        with open(self.index_rst_path, "w") as f:
             f.write(textwrap.dedent(r"""
             .. item:: ITEM-A Description of item-a
                 :hidetype: my_reverse_relation

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -6,6 +6,7 @@ import unittest
 import sphinx.cmd.build
 import sphinx.cmd.quickstart
 
+
 class TestSphinx(unittest.TestCase):
 
     @classmethod
@@ -29,12 +30,17 @@ class TestSphinx(unittest.TestCase):
             "extensions": ["mlx.traceability"],
         }, silent=True)
 
-        with open(f'{cls.docs_folder}/conf.py', 'a') as cfg:
-            cfg.write("traceability_render_relationship_per_item = True\n")
-            cfg.write("traceability_relationships = {'my_relation': 'my_reverse_relation'}\n")
-            cfg.write("traceability_relationship_to_string = {'my_relation': 'My relation', 'my_reverse_relation': 'My reverse relation'}\n")
-            cfg.write("traceability_attributes = {}\n")
-            cfg.write("traceability_attributes_sort = {}\n")
+        cfg = r"""
+            traceability_render_relationship_per_item = True
+            traceability_relationships = {'my_relation': 'my_reverse_relation'}
+            traceability_relationship_to_string = {'my_relation': 'My relation',
+                                                   'my_reverse_relation': 'My reverse relation'}
+            traceability_attributes = {}
+            traceability_attributes_sort = {}
+            """
+
+        with open(f'{cls.docs_folder}/conf.py', 'a') as f:
+            f.write(textwrap.dedent(cfg))
 
     @classmethod
     def tearDownClass(cls):
@@ -113,4 +119,3 @@ class TestSphinx(unittest.TestCase):
             content = f.read()
             assert 'My relation' not in content
             assert 'My reverse relation' not in content
-

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -1,0 +1,116 @@
+import os
+import shutil
+import tempfile
+import textwrap
+import unittest
+import sphinx.cmd.build
+import sphinx.cmd.quickstart
+
+class TestSphinx(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.docs_folder = tempfile.mkdtemp()
+        cls.rst_file = os.path.join(cls.docs_folder, "index.rst")
+        cls.html_file = os.path.join(cls.docs_folder, "_build", "index.html")
+        sphinx.cmd.quickstart.generate({
+            "path": cls.docs_folder,
+            "sep": False,
+            "project": "testdoc",
+            "author": "mlx.traceability contributors",
+            "version": "a",
+            "release": "a",
+            "language": "en",
+            "dot": "_",
+            "suffix": ".rst",
+            "master": "index",
+            "makefile": True,
+            "batchfile": False,
+            "extensions": ["mlx.traceability"],
+        }, silent=True)
+
+        with open(f'{cls.docs_folder}/conf.py', 'a') as cfg:
+            cfg.write("traceability_render_relationship_per_item = True\n")
+            cfg.write("traceability_relationships = {'my_relation': 'my_reverse_relation'}\n")
+            cfg.write("traceability_relationship_to_string = {'my_relation': 'My relation', 'my_reverse_relation': 'My reverse relation'}\n")
+            cfg.write("traceability_attributes = {}\n")
+            cfg.write("traceability_attributes_sort = {}\n")
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.docs_folder)
+
+    def build(self, builder="html"):
+        retcode = sphinx.cmd.build.main([
+            "-q",
+            "-b",
+            builder,
+            self.docs_folder,
+            os.path.join(self.docs_folder, "_build"),
+        ])
+        self.assertEqual(retcode, 0)
+
+    def test_item_relation(self):
+        with open(os.path.join(self.docs_folder, self.rst_file), "w") as f:
+            f.write(textwrap.dedent(r"""
+            .. item:: ITEM-A Description of item-a
+
+            .. item:: ITEM-B Description of item-b
+                :my_relation: ITEM-A
+            """))
+
+        self.build(builder="html")
+        with open(self.html_file, "r") as f:
+            content = f.read()
+            assert 'My relation' in content
+            assert 'My reverse relation' in content
+
+    def test_item_relation_hide_forward(self):
+        with open(os.path.join(self.docs_folder, self.rst_file), "w") as f:
+            f.write(textwrap.dedent(r"""
+            .. item:: ITEM-A Description of item-a
+
+            .. item:: ITEM-B Description of item-b
+                :my_relation: ITEM-A
+                :hidetype: my_relation
+            """))
+
+        self.build(builder="html")
+        with open(self.html_file, "r") as f:
+            content = f.read()
+            assert 'My relation' not in content
+            assert 'My reverse relation' in content
+
+    def test_item_relation_hide_reverse(self):
+        with open(os.path.join(self.docs_folder, self.rst_file), "w") as f:
+            f.write(textwrap.dedent(r"""
+            .. item:: ITEM-A Description of item-a
+                :hidetype: my_reverse_relation
+
+            .. item:: ITEM-B Description of item-b
+                :my_relation: ITEM-A
+            """))
+
+        self.build(builder="html")
+        with open(self.html_file, "r") as f:
+            content = f.read()
+            assert 'My relation' in content
+            assert 'My reverse relation' not in content
+
+    def test_item_relation_hide_both(self):
+        with open(os.path.join(self.docs_folder, self.rst_file), "w") as f:
+            f.write(textwrap.dedent(r"""
+            .. item:: ITEM-A Description of item-a
+                :hidetype: my_reverse_relation
+
+            .. item:: ITEM-B Description of item-b
+                :my_relation: ITEM-A
+                :hidetype: my_relation
+            """))
+
+        self.build(builder="html")
+        with open(self.html_file, "r") as f:
+            content = f.read()
+            assert 'My relation' not in content
+            assert 'My reverse relation' not in content
+


### PR DESCRIPTION
Add option to item-directive to hide specific relation-types in the rendered item definition.