### PR TITLE
Fix #403: Hyperlink to item points to wrong location if item was included from different file

### DIFF
--- a/mlx/traceability/directives/item_attribute_directive.py
+++ b/mlx/traceability/directives/item_attribute_directive.py
@@ -1,5 +1,4 @@
 """Module for the item-attribute directive"""
-from pathlib import Path
 from docutils import nodes
 
 from ..traceability_exception import report_warning
@@ -70,11 +69,8 @@ class ItemAttributeDirective(TraceableBaseDirective):
         else:
             attr = TraceableItem.defined_attributes[stored_id]
             attr.caption = self.caption
-            doc_path_str, lineno = self.get_source_info()
-            doc_path = Path(doc_path_str)
-            if doc_path.is_absolute():
-                doc_path = doc_path.relative_to(env.srcdir)
-            attr.set_location(doc_path, lineno)
+            _, lineno = self.get_source_info()
+            attr.set_location(env.docname, lineno)
             attr.directive = self  # the directive is needed to parse any content
             attribute_node['id'] = attr.identifier
 

--- a/mlx/traceability/directives/item_directive.py
+++ b/mlx/traceability/directives/item_directive.py
@@ -1,7 +1,6 @@
 """Module for the item directive"""
 from docutils import nodes
 from docutils.parsers.rst import directives
-from pathlib import Path
 
 from ..traceability_exception import report_warning, TraceabilityException
 from ..traceable_base_directive import TraceableBaseDirective
@@ -196,11 +195,8 @@ class ItemDirective(TraceableBaseDirective):
         """
         target_node = nodes.target('', '', ids=[target_id])
         item = TraceableItem(target_id, directive=self)
-        doc_path_str, lineno = self.get_source_info()
-        doc_path = Path(doc_path_str)
-        if doc_path.is_absolute():
-            doc_path = doc_path.relative_to(env.srcdir)
-        item.set_location(doc_path, lineno)
+        _, lineno = self.get_source_info()
+        item.set_location(env.docname, lineno)
         item.node = target_node
         item.caption = self.caption
         item.content = self.content

--- a/tests/directives/test_item_attribute_directive.py
+++ b/tests/directives/test_item_attribute_directive.py
@@ -1,0 +1,319 @@
+"""Tests for the item-attribute directive"""
+from unittest import TestCase
+from unittest.mock import Mock, MagicMock, patch
+import logging
+
+from docutils import nodes
+from docutils.parsers.rst import directives
+from docutils.statemachine import StringList
+
+from mlx.traceability.directives.item_attribute_directive import (
+    ItemAttribute,
+    ItemAttributeDirective
+)
+from mlx.traceability.traceable_attribute import TraceableAttribute
+from mlx.traceability.traceable_item import TraceableItem
+from mlx.traceability.traceable_collection import TraceableCollection
+
+LOGGER = logging.getLogger('sphinx.mlx.traceability.traceability_exception')
+
+
+class TestItemAttribute(TestCase):
+    """Test the ItemAttribute node class"""
+
+    def setUp(self):
+        self.app = MagicMock()
+        self.app.config.traceability_hyperlink_colors = {}
+        self.collection = TraceableCollection()
+        self.node = ItemAttribute('')
+        self.node['document'] = 'test_doc'
+        self.node['line'] = 42
+        self.node['id'] = 'test_attr'
+
+    def test_perform_replacement_with_defined_attribute_with_caption(self):
+        """Test replacement when attribute is defined with caption"""
+        # Setup defined attribute with caption
+        attr = TraceableAttribute('test_attr', '.*')
+        attr.name = 'Test Attribute'
+        attr.caption = 'This is a test caption'
+        TraceableItem.defined_attributes = {'test_attr': attr}
+
+        # Create parent and perform replacement
+        parent = nodes.container()
+        parent.append(self.node)
+        self.node.perform_replacement(self.app, self.collection)
+
+        # Verify the node was replaced
+        self.assertEqual(len(parent.children), 1)
+        replaced_node = parent.children[0]
+        self.assertNotEqual(replaced_node, self.node)
+        # The header should contain both name and caption
+        self.assertIn('Test Attribute: This is a test caption', str(replaced_node))
+
+    def test_perform_replacement_with_defined_attribute_without_caption(self):
+        """Test replacement when attribute is defined without caption"""
+        # Setup defined attribute without caption
+        attr = TraceableAttribute('test_attr', '.*')
+        attr.name = 'Test Attribute'
+        attr.caption = ''
+        TraceableItem.defined_attributes = {'test_attr': attr}
+
+        # Create parent and perform replacement
+        parent = nodes.container()
+        parent.append(self.node)
+        self.node.perform_replacement(self.app, self.collection)
+
+        # Verify the node was replaced
+        self.assertEqual(len(parent.children), 1)
+        replaced_node = parent.children[0]
+        # The header should only contain the name
+        self.assertIn('Test Attribute', str(replaced_node))
+        self.assertNotIn(':', str(replaced_node))
+
+    def test_perform_replacement_with_undefined_attribute(self):
+        """Test replacement when attribute is not defined"""
+        # Clear defined attributes
+        TraceableItem.defined_attributes = {}
+        self.node['id'] = 'undefined_attr'
+
+        # Create parent and perform replacement
+        parent = nodes.container()
+        parent.append(self.node)
+        self.node.perform_replacement(self.app, self.collection)
+
+        # Verify the node was replaced with just the id
+        self.assertEqual(len(parent.children), 1)
+        replaced_node = parent.children[0]
+        self.assertIn('undefined_attr', str(replaced_node))
+
+
+class TestItemAttributeDirective(TestCase):
+    """Test the ItemAttributeDirective class"""
+
+    def setUp(self):
+        """Setup test fixtures"""
+        self.directive = ItemAttributeDirective(
+            name='item-attribute',
+            arguments=['test_attr_id'],
+            options={},
+            content=StringList(['Content line 1', 'Content line 2'], 'test.rst'),
+            lineno=10,
+            content_offset=0,
+            block_text='',
+            state=Mock(),
+            state_machine=Mock()
+        )
+
+        # Mock the state and environment
+        self.directive.state.document = Mock()
+        self.directive.state.document.ids = {}  # Must be a real dict for item assignment
+        self.directive.state.document.settings = Mock()
+        self.directive.state.document.settings.env = Mock()
+        self.directive.state.document.settings.env.docname = 'test_document'
+
+        # Mock get_source_info to return a tuple
+        self.directive.get_source_info = Mock(return_value=('test.rst', 10))
+
+        # Clear defined attributes
+        TraceableItem.defined_attributes = {}
+
+    def test_directive_has_correct_configuration(self):
+        """Test that directive has correct required/optional arguments and content settings"""
+        self.assertEqual(ItemAttributeDirective.required_arguments, 1)
+        self.assertEqual(ItemAttributeDirective.optional_arguments, 1)
+        self.assertTrue(ItemAttributeDirective.has_content)
+
+    def test_run_with_defined_attribute(self):
+        """Test run method with a defined attribute"""
+        # Setup defined attribute - must use lowercase id
+        attr_id = 'test_attr_id'
+        attr = TraceableAttribute(attr_id, '.*')
+        attr.name = 'Test Attribute'
+        TraceableItem.defined_attributes[attr_id] = attr
+
+        # Run the directive
+        result = self.directive.run()
+
+        # Verify return value is a list with 3 nodes
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 3)
+
+        # Check target node
+        self.assertIsInstance(result[0], nodes.target)
+        self.assertIn(attr_id, result[0]['ids'])
+
+        # Check attribute node
+        self.assertIsInstance(result[1], ItemAttribute)
+        self.assertEqual(result[1]['id'], attr_id)
+        self.assertEqual(result[1]['document'], 'test_document')
+        self.assertEqual(result[1]['line'], 10)
+
+        # Check content node
+        self.assertIsNotNone(result[2])
+
+        # Verify attribute was updated with content (content getter converts to string)
+        self.assertEqual(attr.content, 'Content line 1\nContent line 2')
+
+    def test_run_with_defined_attribute_and_caption(self):
+        """Test run method with a defined attribute and caption argument"""
+        # Setup directive with caption
+        self.directive.arguments = ['test_attr_id', 'Test Caption']
+
+        # Setup defined attribute
+        attr_id = 'test_attr_id'
+        attr = TraceableAttribute(attr_id, '.*')
+        attr.name = 'Test Attribute'
+        TraceableItem.defined_attributes[attr_id] = attr
+
+        # Run the directive
+        result = self.directive.run()
+
+        # Verify the attribute's caption was set
+        self.assertEqual(attr.caption, 'Test Caption')
+
+    def test_run_with_undefined_attribute_reports_warning(self):
+        """Test run method reports warning for undefined attribute"""
+        # Ensure attribute is not defined
+        attr_id = 'undefined_attr'
+        TraceableItem.defined_attributes = {}
+
+        # Run the directive and expect a warning
+        with self.assertLogs(LOGGER, logging.DEBUG) as log_context:
+            result = self.directive.run()
+
+        # Verify warning was logged
+        warning_found = any('not defined in configuration' in msg for msg in log_context.output)
+        self.assertTrue(warning_found, "Expected warning about undefined attribute not found in logs")
+
+        # Verify return value still contains 3 nodes
+        self.assertEqual(len(result), 3)
+
+        # Check that a temporary attribute was created
+        self.assertIsInstance(result[1], ItemAttribute)
+
+    def test_run_creates_target_node_with_lowercase_id(self):
+        """Test that target node uses lowercase id"""
+        # Setup with mixed case attribute id
+        attr_id = 'TestAttrId'
+        self.directive.arguments = [attr_id]
+        attr = TraceableAttribute(attr_id.lower(), '.*')
+        TraceableItem.defined_attributes[attr_id.lower()] = attr
+
+        # Run the directive
+        result = self.directive.run()
+
+        # Verify target node has lowercase id
+        target_node = result[0]
+        self.assertIn(attr_id.lower(), target_node['ids'])
+
+    def test_run_sets_location_on_attribute(self):
+        """Test that run method sets location on the attribute"""
+        # Setup defined attribute - must match directive's argument
+        attr_id = 'test_attr_id'
+        attr = TraceableAttribute(attr_id, '.*')
+        TraceableItem.defined_attributes[attr_id] = attr
+
+        # Run the directive
+        with patch.object(self.directive, 'get_source_info', return_value=('test.rst', 15)):
+            result = self.directive.run()
+
+        # Verify location was set on attribute
+        self.assertEqual(attr.docname, 'test_document')
+        self.assertEqual(attr.lineno, 15)
+
+    def test_run_stores_directive_reference(self):
+        """Test that the directive reference is stored on the attribute"""
+        # Setup defined attribute - must match directive's argument
+        attr_id = 'test_attr_id'
+        attr = TraceableAttribute(attr_id, '.*')
+        TraceableItem.defined_attributes[attr_id] = attr
+
+        # Run the directive
+        result = self.directive.run()
+
+        # Verify directive reference was stored
+        self.assertIs(attr.directive, self.directive)
+
+    def test_attribute_node_has_correct_properties(self):
+        """Test that the attribute node has all required properties set"""
+        # Setup defined attribute - must match directive's argument
+        attr_id = 'test_attr_id'
+        attr = TraceableAttribute(attr_id, '.*')
+        TraceableItem.defined_attributes[attr_id] = attr
+
+        # Run the directive
+        result = self.directive.run()
+
+        attribute_node = result[1]
+
+        # Verify node properties
+        self.assertEqual(attribute_node['id'], attr_id)
+        self.assertEqual(attribute_node['document'], 'test_document')
+        self.assertEqual(attribute_node['line'], 10)
+
+    def test_content_is_stored_on_attribute(self):
+        """Test that content from directive is stored on the attribute"""
+        # Setup defined attribute - must match directive's argument
+        attr_id = 'test_attr_id'
+        attr = TraceableAttribute(attr_id, '.*')
+        TraceableItem.defined_attributes[attr_id] = attr
+
+        # Run the directive with content
+        result = self.directive.run()
+
+        # Verify content was stored (content property converts StringList to string)
+        expected_content = 'Content line 1\nContent line 2'
+        self.assertEqual(attr.content, expected_content)
+        self.assertIn('Content line 1', attr.content)
+        self.assertIn('Content line 2', attr.content)
+
+    def test_run_with_empty_content(self):
+        """Test run method with empty content"""
+        # Setup directive with no content
+        self.directive.content = StringList([], 'test.rst')
+
+        # Setup defined attribute - must match directive's argument
+        attr_id = 'test_attr_id'
+        attr = TraceableAttribute(attr_id, '.*')
+        TraceableItem.defined_attributes[attr_id] = attr
+
+        # Run the directive
+        result = self.directive.run()
+
+        # Verify it still returns 3 nodes
+        self.assertEqual(len(result), 3)
+
+        # Verify content is stored (converted to empty string)
+        self.assertEqual(attr.content, '')
+
+    def test_undefined_attribute_creates_wildcard_pattern(self):
+        """Test that undefined attributes get a wildcard regex pattern"""
+        # Ensure attribute is not defined
+        TraceableItem.defined_attributes = {}
+
+        # Run the directive (suppressing expected warning)
+        # The directive was initialized with 'test_attr_id' in setUp
+        with self.assertLogs(LOGGER, logging.DEBUG):
+            result = self.directive.run()
+
+        # The temporary attribute should have been created with .* pattern
+        # We can't directly verify it was created with .*, but we can verify
+        # the node was created successfully
+        self.assertIsInstance(result[1], ItemAttribute)
+        self.assertEqual(result[1]['id'], 'test_attr_id')
+
+    def test_multiline_caption(self):
+        """Test that multiline captions are handled correctly"""
+        # Setup directive with multiline caption
+        self.directive.arguments = ['test_attr', 'Caption\nwith newline']
+
+        # Setup defined attribute
+        attr_id = 'test_attr'
+        attr = TraceableAttribute(attr_id, '.*')
+        TraceableItem.defined_attributes[attr_id] = attr
+
+        # Run the directive
+        result = self.directive.run()
+
+        # Verify caption has newline replaced with space
+        self.assertEqual(attr.caption, 'Caption with newline')

--- a/tests/directives/test_item_attribute_directive.py
+++ b/tests/directives/test_item_attribute_directive.py
@@ -4,7 +4,6 @@ from unittest.mock import Mock, MagicMock, patch
 import logging
 
 from docutils import nodes
-from docutils.parsers.rst import directives
 from docutils.statemachine import StringList
 
 from mlx.traceability.directives.item_attribute_directive import (
@@ -166,7 +165,7 @@ class TestItemAttributeDirective(TestCase):
         TraceableItem.defined_attributes[attr_id] = attr
 
         # Run the directive
-        result = self.directive.run()
+        self.directive.run()
 
         # Verify the attribute's caption was set
         self.assertEqual(attr.caption, 'Test Caption')
@@ -174,8 +173,8 @@ class TestItemAttributeDirective(TestCase):
     def test_run_with_undefined_attribute_reports_warning(self):
         """Test run method reports warning for undefined attribute"""
         # Ensure attribute is not defined
-        attr_id = 'undefined_attr'
         TraceableItem.defined_attributes = {}
+        self.directive.arguments = ['undefined_attr']
 
         # Run the directive and expect a warning
         with self.assertLogs(LOGGER, logging.DEBUG) as log_context:
@@ -215,7 +214,7 @@ class TestItemAttributeDirective(TestCase):
 
         # Run the directive
         with patch.object(self.directive, 'get_source_info', return_value=('test.rst', 15)):
-            result = self.directive.run()
+            self.directive.run()
 
         # Verify location was set on attribute
         self.assertEqual(attr.docname, 'test_document')
@@ -229,7 +228,7 @@ class TestItemAttributeDirective(TestCase):
         TraceableItem.defined_attributes[attr_id] = attr
 
         # Run the directive
-        result = self.directive.run()
+        self.directive.run()
 
         # Verify directive reference was stored
         self.assertIs(attr.directive, self.directive)
@@ -259,7 +258,7 @@ class TestItemAttributeDirective(TestCase):
         TraceableItem.defined_attributes[attr_id] = attr
 
         # Run the directive with content
-        result = self.directive.run()
+        self.directive.run()
 
         # Verify content was stored (content property converts StringList to string)
         expected_content = 'Content line 1\nContent line 2'
@@ -313,7 +312,7 @@ class TestItemAttributeDirective(TestCase):
         TraceableItem.defined_attributes[attr_id] = attr
 
         # Run the directive
-        result = self.directive.run()
+        self.directive.run()
 
         # Verify caption has newline replaced with space
         self.assertEqual(attr.caption, 'Caption with newline')

--- a/tests/directives/test_item_directive.py
+++ b/tests/directives/test_item_directive.py
@@ -170,6 +170,7 @@ class TestItemDirectiveClass(TestCase):
 
     def setUp(self):
         """Setup test fixtures for directive testing"""
+        self._original_defined_attributes = TraceableItem.defined_attributes.copy()
         self.directive = ItemDirective(
             name='item',
             arguments=['TEST_ITEM_ID'],
@@ -204,6 +205,9 @@ class TestItemDirectiveClass(TestCase):
 
         # Clear defined attributes
         TraceableItem.defined_attributes = {}
+
+    def tearDown(self):
+        TraceableItem.defined_attributes = self._original_defined_attributes
 
     def test_directive_configuration(self):
         """Test that directive has correct configuration"""

--- a/tests/directives/test_item_directive.py
+++ b/tests/directives/test_item_directive.py
@@ -220,8 +220,7 @@ class TestItemDirectiveClass(TestCase):
 
     def test_run_creates_three_nodes(self):
         """Test that run method creates three nodes"""
-        with patch.object(self.directive, 'get_source_info', return_value=('test.rst', 10)):
-            result = self.directive.run()
+        result = self.directive.run()
 
         self.assertIsInstance(result, list)
         self.assertEqual(len(result), 3)
@@ -234,8 +233,7 @@ class TestItemDirectiveClass(TestCase):
 
     def test_run_stores_item_in_collection(self):
         """Test that run method stores item in collection"""
-        with patch.object(self.directive, 'get_source_info', return_value=('test.rst', 10)):
-            self.directive.run()
+        self.directive.run()
 
         # Verify item was added to collection
         self.assertTrue(self.collection.has_item('TEST_ITEM_ID'))
@@ -246,8 +244,7 @@ class TestItemDirectiveClass(TestCase):
         """Test run method with caption argument"""
         self.directive.arguments = ['TEST_ITEM_ID', 'Test Caption']
 
-        with patch.object(self.directive, 'get_source_info', return_value=('test.rst', 10)):
-            self.directive.run()
+        self.directive.run()
 
         item = self.collection.get_item('TEST_ITEM_ID')
         self.assertEqual(item.caption, 'Test Caption')
@@ -256,8 +253,7 @@ class TestItemDirectiveClass(TestCase):
         """Test that multiline captions have newlines replaced with spaces"""
         self.directive.arguments = ['TEST_ITEM_ID', 'Caption\nwith newline']
 
-        with patch.object(self.directive, 'get_source_info', return_value=('test.rst', 10)):
-            self.directive.run()
+        self.directive.run()
 
         item = self.collection.get_item('TEST_ITEM_ID')
         self.assertEqual(item.caption, 'Caption with newline')
@@ -279,8 +275,7 @@ class TestItemDirectiveClass(TestCase):
 
         # Try to add duplicate
         with self.assertLogs(LOGGER, logging.DEBUG):
-            with patch.object(self.directive, 'get_source_info', return_value=('test.rst', 10)):
-                result = self.directive.run()
+            result = self.directive.run()
 
         # Should return empty list when duplicate detected
         self.assertEqual(result, [])
@@ -291,8 +286,7 @@ class TestItemDirectiveClass(TestCase):
         self.collection.add_relation_pair('depends_on', 'impacts_on')
         self.directive.options['depends_on'] = 'OTHER_ITEM'
 
-        with patch.object(self.directive, 'get_source_info', return_value=('test.rst', 10)):
-            self.directive.run()
+        self.directive.run()
 
         # Verify relationship was added
         item = self.collection.get_item('TEST_ITEM_ID')
@@ -305,8 +299,7 @@ class TestItemDirectiveClass(TestCase):
         self.collection.add_relation_pair('depends_on', 'impacts_on')
         self.directive.options['depends_on'] = 'ITEM_1 ITEM_2 ITEM_3'
 
-        with patch.object(self.directive, 'get_source_info', return_value=('test.rst', 10)):
-            self.directive.run()
+        self.directive.run()
 
         # Verify all relationships were added
         item = self.collection.get_item('TEST_ITEM_ID')
@@ -322,8 +315,7 @@ class TestItemDirectiveClass(TestCase):
         TraceableItem.defined_attributes = {'status': attr}
         self.directive.options['status'] = 'completed'
 
-        with patch.object(self.directive, 'get_source_info', return_value=('test.rst', 10)):
-            self.directive.run()
+        self.directive.run()
 
         # Verify attribute was added
         item = self.collection.get_item('TEST_ITEM_ID')
@@ -337,8 +329,7 @@ class TestItemDirectiveClass(TestCase):
         self.directive.options['status'] = 'invalid_value'
 
         with self.assertLogs(LOGGER, logging.DEBUG) as log_context:
-            with patch.object(self.directive, 'get_source_info', return_value=('test.rst', 10)):
-                self.directive.run()
+            self.directive.run()
 
         # Should have logged a warning
         warning_found = any('status' in msg.lower() for msg in log_context.output)
@@ -348,8 +339,7 @@ class TestItemDirectiveClass(TestCase):
         """Test run method with class option"""
         self.directive.options['class'] = ['custom-class', 'another-class']
 
-        with patch.object(self.directive, 'get_source_info', return_value=('test.rst', 10)):
-            result = self.directive.run()
+        result = self.directive.run()
 
         item_node = result[1]
         self.assertIn('custom-class', item_node['classes'])
@@ -359,8 +349,7 @@ class TestItemDirectiveClass(TestCase):
         """Test run method with nocaptions flag"""
         self.directive.options['nocaptions'] = None  # Flag options are None when present
 
-        with patch.object(self.directive, 'get_source_info', return_value=('test.rst', 10)):
-            result = self.directive.run()
+        result = self.directive.run()
 
         # The directive should process nocaptions flag
         # We're just verifying it doesn't crash
@@ -370,8 +359,7 @@ class TestItemDirectiveClass(TestCase):
         """Test run method with hidetype option"""
         self.directive.options['hidetype'] = 'depends_on impacts_on'
 
-        with patch.object(self.directive, 'get_source_info', return_value=('test.rst', 10)):
-            result = self.directive.run()
+        result = self.directive.run()
 
         item_node = result[1]
         self.assertIn('depends_on', item_node['hidetype'])
@@ -381,8 +369,7 @@ class TestItemDirectiveClass(TestCase):
         """Test that collapse links config is respected"""
         self.env.app.config.traceability_collapse_links = True
 
-        with patch.object(self.directive, 'get_source_info', return_value=('test.rst', 10)):
-            result = self.directive.run()
+        result = self.directive.run()
 
         item_node = result[1]
         self.assertIn('collapse', item_node['classes'])
@@ -391,24 +378,21 @@ class TestItemDirectiveClass(TestCase):
         """Test that collapse class is not added when config is False"""
         self.env.app.config.traceability_collapse_links = False
 
-        with patch.object(self.directive, 'get_source_info', return_value=('test.rst', 10)):
-            result = self.directive.run()
+        result = self.directive.run()
 
         item_node = result[1]
         self.assertNotIn('collapse', item_node['classes'])
 
     def test_run_always_adds_collapsible_links_class(self):
         """Test that collapsible_links class is always added"""
-        with patch.object(self.directive, 'get_source_info', return_value=('test.rst', 10)):
-            result = self.directive.run()
+        result = self.directive.run()
 
         item_node = result[1]
         self.assertIn('collapsible_links', item_node['classes'])
 
     def test_run_sets_item_node_properties(self):
         """Test that item node has correct properties"""
-        with patch.object(self.directive, 'get_source_info', return_value=('test.rst', 10)):
-            result = self.directive.run()
+        result = self.directive.run()
 
         item_node = result[1]
         self.assertEqual(item_node['document'], 'test_document')
@@ -417,8 +401,7 @@ class TestItemDirectiveClass(TestCase):
 
     def test_run_stores_content_on_item(self):
         """Test that content is stored on the item"""
-        with patch.object(self.directive, 'get_source_info', return_value=('test.rst', 10)):
-            self.directive.run()
+        self.directive.run()
 
         item = self.collection.get_item('TEST_ITEM_ID')
         # Content property converts StringList to string
@@ -429,8 +412,7 @@ class TestItemDirectiveClass(TestCase):
         callback_mock = Mock()
         self.env.app.config.traceability_callback_per_item = callback_mock
 
-        with patch.object(self.directive, 'get_source_info', return_value=('test.rst', 10)):
-            self.directive.run()
+        self.directive.run()
 
         # Verify callback was called
         callback_mock.assert_called_once()
@@ -441,9 +423,7 @@ class TestItemDirectiveClass(TestCase):
         self.directive.options['unknown_relation'] = 'OTHER_ITEM'
 
         with self.assertLogs(LOGGER, logging.DEBUG) as log_context:
-            with patch.object(self.directive, 'get_source_info', return_value=('test.rst', 10)):
-                # This should not crash but should handle gracefully
-                self.directive.run()
+            self.directive.run()
 
         warning_found = any('unknown_relation' in msg.lower() for msg in log_context.output)
         self.assertTrue(warning_found, "Expected warning about invalid relation not found in logs")
@@ -452,16 +432,14 @@ class TestItemDirectiveClass(TestCase):
 
     def test_item_node_has_correct_id(self):
         """Test that the item node contains correct id"""
-        with patch.object(self.directive, 'get_source_info', return_value=('test.rst', 10)):
-            result = self.directive.run()
+        result = self.directive.run()
 
         item_node = result[1]
         self.assertEqual(item_node['id'], 'TEST_ITEM_ID')
 
     def test_target_node_has_item_id(self):
         """Test that target node includes the item ID"""
-        with patch.object(self.directive, 'get_source_info', return_value=('test.rst', 10)):
-            result = self.directive.run()
+        result = self.directive.run()
 
         target_node = result[0]
         self.assertIn('TEST_ITEM_ID', target_node['ids'])
@@ -472,13 +450,11 @@ class TestItemDirectiveClass(TestCase):
         self.collection.add_relation_pair('depends_on', 'impacts_on')
 
         # This should not raise any warnings
-        with patch.object(self.directive, 'get_source_info', return_value=('test.rst', 10)):
-            self.directive.check_relationships(['depends_on'], self.env)
+        self.directive.check_relationships(['depends_on'], self.env)
 
     def test_item_clears_state_after_processing(self):
         """Test that item state is cleared after processing"""
-        with patch.object(self.directive, 'get_source_info', return_value=('test.rst', 10)):
-            self.directive.run()
+        self.directive.run()
 
         item = self.collection.get_item('TEST_ITEM_ID')
         # State should be cleared - verify by checking that directive is None

--- a/tests/directives/test_item_directive.py
+++ b/tests/directives/test_item_directive.py
@@ -418,7 +418,7 @@ class TestItemDirectiveClass(TestCase):
         callback_mock.assert_called_once()
 
     def test_add_relation_with_invalid_relation_still_creates_item(self):
-        """Test that adding invalid relations triggers warnings"""
+        """Test that invalid relations don't crash and the item is still created"""
         # Don't add the relation to the collection
         self.directive.options['unknown_relation'] = 'OTHER_ITEM'
 

--- a/tests/directives/test_item_directive.py
+++ b/tests/directives/test_item_directive.py
@@ -417,16 +417,14 @@ class TestItemDirectiveClass(TestCase):
         # Verify callback was called
         callback_mock.assert_called_once()
 
-    def test_add_relation_with_invalid_relation_reports_warning(self):
+    def test_add_relation_with_invalid_relation_still_creates_item(self):
         """Test that adding invalid relations triggers warnings"""
         # Don't add the relation to the collection
         self.directive.options['unknown_relation'] = 'OTHER_ITEM'
 
-        with self.assertLogs(LOGGER, logging.DEBUG) as log_context:
-            self.directive.run()
+        # This should not crash but should handle gracefully
+        self.directive.run()
 
-        warning_found = any('unknown_relation' in msg.lower() for msg in log_context.output)
-        self.assertTrue(warning_found, "Expected warning about invalid relation not found in logs")
         # Item should still be created
         self.assertTrue(self.collection.has_item('TEST_ITEM_ID'))
 

--- a/tests/directives/test_item_directive.py
+++ b/tests/directives/test_item_directive.py
@@ -235,7 +235,7 @@ class TestItemDirectiveClass(TestCase):
     def test_run_stores_item_in_collection(self):
         """Test that run method stores item in collection"""
         with patch.object(self.directive, 'get_source_info', return_value=('test.rst', 10)):
-            result = self.directive.run()
+            self.directive.run()
 
         # Verify item was added to collection
         self.assertTrue(self.collection.has_item('TEST_ITEM_ID'))
@@ -247,7 +247,7 @@ class TestItemDirectiveClass(TestCase):
         self.directive.arguments = ['TEST_ITEM_ID', 'Test Caption']
 
         with patch.object(self.directive, 'get_source_info', return_value=('test.rst', 10)):
-            result = self.directive.run()
+            self.directive.run()
 
         item = self.collection.get_item('TEST_ITEM_ID')
         self.assertEqual(item.caption, 'Test Caption')
@@ -257,7 +257,7 @@ class TestItemDirectiveClass(TestCase):
         self.directive.arguments = ['TEST_ITEM_ID', 'Caption\nwith newline']
 
         with patch.object(self.directive, 'get_source_info', return_value=('test.rst', 10)):
-            result = self.directive.run()
+            self.directive.run()
 
         item = self.collection.get_item('TEST_ITEM_ID')
         self.assertEqual(item.caption, 'Caption with newline')
@@ -265,7 +265,7 @@ class TestItemDirectiveClass(TestCase):
     def test_run_sets_item_location(self):
         """Test that item location is properly set"""
         with patch.object(self.directive, 'get_source_info', return_value=('test.rst', 25)):
-            result = self.directive.run()
+            self.directive.run()
 
         item = self.collection.get_item('TEST_ITEM_ID')
         self.assertEqual(item.docname, 'test_document')
@@ -292,7 +292,7 @@ class TestItemDirectiveClass(TestCase):
         self.directive.options['depends_on'] = 'OTHER_ITEM'
 
         with patch.object(self.directive, 'get_source_info', return_value=('test.rst', 10)):
-            result = self.directive.run()
+            self.directive.run()
 
         # Verify relationship was added
         item = self.collection.get_item('TEST_ITEM_ID')
@@ -306,7 +306,7 @@ class TestItemDirectiveClass(TestCase):
         self.directive.options['depends_on'] = 'ITEM_1 ITEM_2 ITEM_3'
 
         with patch.object(self.directive, 'get_source_info', return_value=('test.rst', 10)):
-            result = self.directive.run()
+            self.directive.run()
 
         # Verify all relationships were added
         item = self.collection.get_item('TEST_ITEM_ID')
@@ -323,7 +323,7 @@ class TestItemDirectiveClass(TestCase):
         self.directive.options['status'] = 'completed'
 
         with patch.object(self.directive, 'get_source_info', return_value=('test.rst', 10)):
-            result = self.directive.run()
+            self.directive.run()
 
         # Verify attribute was added
         item = self.collection.get_item('TEST_ITEM_ID')
@@ -338,7 +338,7 @@ class TestItemDirectiveClass(TestCase):
 
         with self.assertLogs(LOGGER, logging.DEBUG) as log_context:
             with patch.object(self.directive, 'get_source_info', return_value=('test.rst', 10)):
-                result = self.directive.run()
+                self.directive.run()
 
         # Should have logged a warning
         warning_found = any('status' in msg.lower() for msg in log_context.output)
@@ -418,7 +418,7 @@ class TestItemDirectiveClass(TestCase):
     def test_run_stores_content_on_item(self):
         """Test that content is stored on the item"""
         with patch.object(self.directive, 'get_source_info', return_value=('test.rst', 10)):
-            result = self.directive.run()
+            self.directive.run()
 
         item = self.collection.get_item('TEST_ITEM_ID')
         # Content property converts StringList to string
@@ -430,7 +430,7 @@ class TestItemDirectiveClass(TestCase):
         self.env.app.config.traceability_callback_per_item = callback_mock
 
         with patch.object(self.directive, 'get_source_info', return_value=('test.rst', 10)):
-            result = self.directive.run()
+            self.directive.run()
 
         # Verify callback was called
         callback_mock.assert_called_once()
@@ -478,7 +478,7 @@ class TestItemDirectiveClass(TestCase):
     def test_item_clears_state_after_processing(self):
         """Test that item state is cleared after processing"""
         with patch.object(self.directive, 'get_source_info', return_value=('test.rst', 10)):
-            result = self.directive.run()
+            self.directive.run()
 
         item = self.collection.get_item('TEST_ITEM_ID')
         # State should be cleared - verify by checking that directive is None

--- a/tests/directives/test_item_directive.py
+++ b/tests/directives/test_item_directive.py
@@ -1,17 +1,20 @@
 from unittest import TestCase
-from unittest.mock import Mock, MagicMock
+from unittest.mock import Mock, MagicMock, patch
 import logging
 
 from docutils import nodes
+from docutils.statemachine import StringList
 from sphinx.application import Sphinx
 from sphinx.builders.latex import LaTeXBuilder
 from sphinx.builders.html import StandaloneHTMLBuilder
 from sphinx.environment import BuildEnvironment
 from sphinx.errors import NoUri
 
-from mlx.traceability.directives.item_directive import Item as dut
+from mlx.traceability.directives.item_directive import Item as dut, ItemDirective
 from mlx.traceability.traceable_collection import TraceableCollection
 from mlx.traceability.traceable_item import TraceableItem
+from mlx.traceability.traceable_attribute import TraceableAttribute
+from mlx.traceability.traceability_exception import TraceabilityException
 
 from parameterized import parameterized
 
@@ -161,3 +164,316 @@ class TestItemDirective(TestCase):
         warning = "WARNING:sphinx.mlx.traceability.traceability_exception:Traceability: relation depends_on cannot be "\
             "translated to string"
         self.assertEqual(c_m.output, [warning])
+
+
+class TestItemDirectiveClass(TestCase):
+    """Test the ItemDirective class"""
+
+    def setUp(self):
+        """Setup test fixtures for directive testing"""
+        self.directive = ItemDirective(
+            name='item',
+            arguments=['TEST_ITEM_ID'],
+            options={},
+            content=StringList(['Item content line'], 'test.rst'),
+            lineno=10,
+            content_offset=0,
+            block_text='',
+            state=Mock(),
+            state_machine=Mock()
+        )
+
+        # Mock the state and environment
+        self.directive.state.document = Mock()
+        self.directive.state.document.ids = {}  # Must be a real dict for item assignment
+        self.directive.state.document.settings = Mock()
+        self.directive.state.document.settings.env = Mock()
+        self.env = self.directive.state.document.settings.env
+        self.env.docname = 'test_document'
+        self.env.app = MagicMock(autospec=Sphinx)
+        self.env.app.config = Mock()
+        self.env.app.config.traceability_collapse_links = False
+        self.env.app.config.traceability_item_no_captions = []
+        self.env.app.config.traceability_callback_per_item = None
+
+        # Mock get_source_info to return a tuple
+        self.directive.get_source_info = Mock(return_value=('test.rst', 10))
+
+        # Initialize collection
+        self.collection = TraceableCollection()
+        self.env.traceability_collection = self.collection
+
+        # Clear defined attributes
+        TraceableItem.defined_attributes = {}
+
+    def test_directive_configuration(self):
+        """Test that directive has correct configuration"""
+        self.assertEqual(ItemDirective.required_arguments, 1)
+        self.assertEqual(ItemDirective.optional_arguments, 1)
+        self.assertTrue(ItemDirective.has_content)
+        self.assertIn('class', ItemDirective.option_spec)
+        self.assertIn('nocaptions', ItemDirective.option_spec)
+        self.assertIn('hidetype', ItemDirective.option_spec)
+
+    def test_run_creates_three_nodes(self):
+        """Test that run method creates three nodes"""
+        with patch.object(self.directive, 'get_source_info', return_value=('test.rst', 10)):
+            result = self.directive.run()
+
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 3)
+        # First node is target node
+        self.assertIsInstance(result[0], nodes.target)
+        # Second node is Item node
+        self.assertIsInstance(result[1], dut)
+        # Third node is content node
+        self.assertIsNotNone(result[2])
+
+    def test_run_stores_item_in_collection(self):
+        """Test that run method stores item in collection"""
+        with patch.object(self.directive, 'get_source_info', return_value=('test.rst', 10)):
+            result = self.directive.run()
+
+        # Verify item was added to collection
+        self.assertTrue(self.collection.has_item('TEST_ITEM_ID'))
+        item = self.collection.get_item('TEST_ITEM_ID')
+        self.assertEqual(item.identifier, 'TEST_ITEM_ID')
+
+    def test_run_with_caption(self):
+        """Test run method with caption argument"""
+        self.directive.arguments = ['TEST_ITEM_ID', 'Test Caption']
+
+        with patch.object(self.directive, 'get_source_info', return_value=('test.rst', 10)):
+            result = self.directive.run()
+
+        item = self.collection.get_item('TEST_ITEM_ID')
+        self.assertEqual(item.caption, 'Test Caption')
+
+    def test_run_with_multiline_caption(self):
+        """Test that multiline captions have newlines replaced with spaces"""
+        self.directive.arguments = ['TEST_ITEM_ID', 'Caption\nwith newline']
+
+        with patch.object(self.directive, 'get_source_info', return_value=('test.rst', 10)):
+            result = self.directive.run()
+
+        item = self.collection.get_item('TEST_ITEM_ID')
+        self.assertEqual(item.caption, 'Caption with newline')
+
+    def test_run_sets_item_location(self):
+        """Test that item location is properly set"""
+        with patch.object(self.directive, 'get_source_info', return_value=('test.rst', 25)):
+            result = self.directive.run()
+
+        item = self.collection.get_item('TEST_ITEM_ID')
+        self.assertEqual(item.docname, 'test_document')
+        self.assertEqual(item.lineno, 25)
+
+    def test_run_with_duplicate_item_id_reports_warning(self):
+        """Test that duplicate item IDs trigger a warning"""
+        # Add item to collection first
+        existing_item = TraceableItem('TEST_ITEM_ID')
+        self.collection.add_item(existing_item)
+
+        # Try to add duplicate
+        with self.assertLogs(LOGGER, logging.DEBUG) as log_context:
+            with patch.object(self.directive, 'get_source_info', return_value=('test.rst', 10)):
+                result = self.directive.run()
+
+        # Should return empty list when duplicate detected
+        self.assertEqual(result, [])
+
+    def test_run_with_relationship_option(self):
+        """Test run method with relationship options"""
+        # Setup relationship
+        self.collection.add_relation_pair('depends_on', 'impacts_on')
+        self.directive.options['depends_on'] = 'OTHER_ITEM'
+
+        with patch.object(self.directive, 'get_source_info', return_value=('test.rst', 10)):
+            result = self.directive.run()
+
+        # Verify relationship was added
+        item = self.collection.get_item('TEST_ITEM_ID')
+        relations = list(item.iter_targets('depends_on'))
+        self.assertIn('OTHER_ITEM', relations)
+
+    def test_run_with_multiple_relationships(self):
+        """Test run method with multiple related items"""
+        # Setup relationship
+        self.collection.add_relation_pair('depends_on', 'impacts_on')
+        self.directive.options['depends_on'] = 'ITEM_1 ITEM_2 ITEM_3'
+
+        with patch.object(self.directive, 'get_source_info', return_value=('test.rst', 10)):
+            result = self.directive.run()
+
+        # Verify all relationships were added
+        item = self.collection.get_item('TEST_ITEM_ID')
+        relations = list(item.iter_targets('depends_on'))
+        self.assertIn('ITEM_1', relations)
+        self.assertIn('ITEM_2', relations)
+        self.assertIn('ITEM_3', relations)
+
+    def test_run_with_attributes(self):
+        """Test run method with attribute options"""
+        # Setup attribute
+        attr = TraceableAttribute('status', '.*')
+        TraceableItem.defined_attributes = {'status': attr}
+        self.directive.options['status'] = 'completed'
+
+        with patch.object(self.directive, 'get_source_info', return_value=('test.rst', 10)):
+            result = self.directive.run()
+
+        # Verify attribute was added
+        item = self.collection.get_item('TEST_ITEM_ID')
+        self.assertEqual(item.get_attribute('status'), 'completed')
+
+    def test_run_with_invalid_attribute_value(self):
+        """Test that invalid attribute values trigger a warning"""
+        # Setup attribute with strict pattern
+        attr = TraceableAttribute('status', '^(open|closed)$')
+        TraceableItem.defined_attributes = {'status': attr}
+        self.directive.options['status'] = 'invalid_value'
+
+        with self.assertLogs(LOGGER, logging.DEBUG) as log_context:
+            with patch.object(self.directive, 'get_source_info', return_value=('test.rst', 10)):
+                result = self.directive.run()
+
+        # Should have logged a warning
+        warning_found = any('status' in msg.lower() for msg in log_context.output)
+        self.assertTrue(warning_found)
+
+    def test_run_with_class_option(self):
+        """Test run method with class option"""
+        self.directive.options['class'] = ['custom-class', 'another-class']
+
+        with patch.object(self.directive, 'get_source_info', return_value=('test.rst', 10)):
+            result = self.directive.run()
+
+        item_node = result[1]
+        self.assertIn('custom-class', item_node['classes'])
+        self.assertIn('another-class', item_node['classes'])
+
+    def test_run_with_nocaptions_option(self):
+        """Test run method with nocaptions flag"""
+        self.directive.options['nocaptions'] = None  # Flag options are None when present
+
+        with patch.object(self.directive, 'get_source_info', return_value=('test.rst', 10)):
+            result = self.directive.run()
+
+        # The directive should process nocaptions flag
+        # We're just verifying it doesn't crash
+        self.assertEqual(len(result), 3)
+
+    def test_run_with_hidetype_option(self):
+        """Test run method with hidetype option"""
+        self.directive.options['hidetype'] = 'depends_on impacts_on'
+
+        with patch.object(self.directive, 'get_source_info', return_value=('test.rst', 10)):
+            result = self.directive.run()
+
+        item_node = result[1]
+        self.assertIn('depends_on', item_node['hidetype'])
+        self.assertIn('impacts_on', item_node['hidetype'])
+
+    def test_run_with_collapse_links_config(self):
+        """Test that collapse links config is respected"""
+        self.env.app.config.traceability_collapse_links = True
+
+        with patch.object(self.directive, 'get_source_info', return_value=('test.rst', 10)):
+            result = self.directive.run()
+
+        item_node = result[1]
+        self.assertIn('collapse', item_node['classes'])
+
+    def test_run_without_collapse_links_config(self):
+        """Test that collapse class is not added when config is False"""
+        self.env.app.config.traceability_collapse_links = False
+
+        with patch.object(self.directive, 'get_source_info', return_value=('test.rst', 10)):
+            result = self.directive.run()
+
+        item_node = result[1]
+        self.assertNotIn('collapse', item_node['classes'])
+
+    def test_run_always_adds_collapsible_links_class(self):
+        """Test that collapsible_links class is always added"""
+        with patch.object(self.directive, 'get_source_info', return_value=('test.rst', 10)):
+            result = self.directive.run()
+
+        item_node = result[1]
+        self.assertIn('collapsible_links', item_node['classes'])
+
+    def test_run_sets_item_node_properties(self):
+        """Test that item node has correct properties"""
+        with patch.object(self.directive, 'get_source_info', return_value=('test.rst', 10)):
+            result = self.directive.run()
+
+        item_node = result[1]
+        self.assertEqual(item_node['document'], 'test_document')
+        self.assertEqual(item_node['line'], 10)
+        self.assertEqual(item_node['id'], 'TEST_ITEM_ID')
+
+    def test_run_stores_content_on_item(self):
+        """Test that content is stored on the item"""
+        with patch.object(self.directive, 'get_source_info', return_value=('test.rst', 10)):
+            result = self.directive.run()
+
+        item = self.collection.get_item('TEST_ITEM_ID')
+        # Content property converts StringList to string
+        self.assertEqual(item.content, 'Item content line')
+
+    def test_run_with_callback(self):
+        """Test that callback is called when configured"""
+        callback_mock = Mock()
+        self.env.app.config.traceability_callback_per_item = callback_mock
+
+        with patch.object(self.directive, 'get_source_info', return_value=('test.rst', 10)):
+            result = self.directive.run()
+
+        # Verify callback was called
+        callback_mock.assert_called_once()
+
+    def test_add_relation_with_invalid_relation_reports_warning(self):
+        """Test that adding invalid relations triggers warnings"""
+        # Don't add the relation to the collection
+        self.directive.options['unknown_relation'] = 'OTHER_ITEM'
+
+        with patch.object(self.directive, 'get_source_info', return_value=('test.rst', 10)):
+            # This should not crash but should handle gracefully
+            result = self.directive.run()
+
+        # Item should still be created
+        self.assertTrue(self.collection.has_item('TEST_ITEM_ID'))
+
+    def test_item_node_has_correct_id(self):
+        """Test that the item node contains correct id"""
+        with patch.object(self.directive, 'get_source_info', return_value=('test.rst', 10)):
+            result = self.directive.run()
+
+        item_node = result[1]
+        self.assertEqual(item_node['id'], 'TEST_ITEM_ID')
+
+    def test_target_node_has_item_id(self):
+        """Test that target node includes the item ID"""
+        with patch.object(self.directive, 'get_source_info', return_value=('test.rst', 10)):
+            result = self.directive.run()
+
+        target_node = result[0]
+        self.assertIn('TEST_ITEM_ID', target_node['ids'])
+
+    def test_check_relationships_with_valid_relationships(self):
+        """Test check_relationships with valid relationship names"""
+        # Setup valid relationships
+        self.collection.add_relation_pair('depends_on', 'impacts_on')
+
+        # This should not raise any warnings
+        with patch.object(self.directive, 'get_source_info', return_value=('test.rst', 10)):
+            self.directive.check_relationships(['depends_on'], self.env)
+
+    def test_item_clears_state_after_processing(self):
+        """Test that item state is cleared after processing"""
+        with patch.object(self.directive, 'get_source_info', return_value=('test.rst', 10)):
+            result = self.directive.run()
+
+        item = self.collection.get_item('TEST_ITEM_ID')
+        # State should be cleared - verify by checking that directive is None
+        self.assertIsNone(item.directive)


### PR DESCRIPTION
Closes #403

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified location recording for item and attribute directives to rely on document identifiers and line numbers; no changes to public interfaces.

* **Tests**
  * Added extensive unit tests covering directive creation, caption and content handling (including multiline), id normalization, location tracking, warnings for missing attributes, relationships, and numerous edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->